### PR TITLE
Fix build errors with latest openjdk11

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -180,33 +180,6 @@ $(foreach file,$(OPENJ9_MANAGEMENT_LIBRARIES), \
 
 endef
 
-# generated_target_rules
-# ----------------------
-# param 1 = The make goal
-# param 2 = The jdk/jre directory to add openj9 content
-define generated_target_rules
-
-.PHONY : $1
-
-$(foreach file,$(OPENJ9_SHARED_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUTDIR)/vm/$(file))))
-
-$(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES), \
-	$(eval $(call openj9_copy_prereq,$1,$2/lib/$(file),$(OUTPUTDIR)/vm/$(file))))
-
-$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_NOTICE_FILE_RENAME),$(TOPDIR)/$(OPENJ9_NOTICE_FILE)))
-
-$(foreach file,$(OPENJ9_REDIRECTOR), \
-	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUTDIR)/vm/$(file))))
-
-$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUTDIR)/vm/$(file))))
-
-$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES), \
-	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUTDIR)/vm/$(file))))
-
-endef
-
 # openj9_copy_prereq
 # ------------------
 # param 1 = The make goal.
@@ -237,17 +210,9 @@ define openj9_copy_tree_impl
 endef
 
 openj9_build_jdk : build-j9
-ifeq ($(BUILD_JDK),$(JDK_OUTPUTDIR))
 	+$(MAKE) -f $(TOPDIR)/closed/OpenJ9.gmk create_build_jdk
-endif
 
-# If we weren't given a BUILD_JDK, we must create one.
-ifeq ($(BUILD_JDK),$(JDK_OUTPUTDIR))
-  $(eval $(call generated_target_rules_build,create_build_jdk,$(JDK_OUTPUTDIR)))
-endif
-
-$(eval $(call generated_target_rules,openj9_jdk_image,$(JDK_IMAGE_DIR)))
-$(eval $(call generated_target_rules,openj9_jre_image,$(JRE_IMAGE_DIR)))
+$(eval $(call generated_target_rules_build,create_build_jdk,$(JDK_OUTPUTDIR)))
 
 # Comments for stage-j9
 # Currently there is a staged location where j9 is built.  This is due to a number of reasons:

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -19,8 +19,6 @@ CLEAN_DIRS += vm
 
 .PHONY : \
 	j9vm-build \
-	openj9-jdk-image \
-	openj9-jre-image \
 	java.base-libs \
 	#
 
@@ -39,14 +37,6 @@ java.base-libs : java.base-copy j9vm-build
 j9vm-build : buildtools-langtools
 	+$(OPENJ9_MAKE) openj9_build_jdk
 
-product-images : openj9-jdk-image openj9-jre-image
-
-openj9-jdk-image : jdk-image j9vm-build
-	+$(OPENJ9_MAKE) openj9_jdk_image
-
-openj9-jre-image : jre-image j9vm-build
-	+$(OPENJ9_MAKE) openj9_jre_image
-
 ifeq (true,$(OPENJ9_ENABLE_DDR))
 
 .PHONY : openj9.dtfj-ddr-gensrc openj9.dtfj-ddr-jar
@@ -60,5 +50,3 @@ openj9.dtfj-ddr-jar : openj9.dtfj-ddr-gensrc
 openj9.dtfj-jmod : openj9.dtfj-ddr-jar
 
 endif # OPENJ9_ENABLE_DDR
-
-ALL_TARGETS += openj9-jdk-image openj9-jre-image

--- a/closed/make/common/JdkNativeCompilation.gmk
+++ b/closed/make/common/JdkNativeCompilation.gmk
@@ -1,0 +1,24 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+FindSrcDirsForLib += \
+	$(call uniq, $(wildcard \
+		$(TOPDIR)/closed/src/$(strip $1)/share/native/lib$(strip $2)))
+
+FindSrcDirsForComponent += \
+	$(call uniq, $(wildcard \
+		$(TOPDIR)/closed/src/$(strip $1)/share/native/$(strip $2)))


### PR DESCRIPTION
The way 'closed' source overrides are selected has changed recently in openjdk. To adapt, we need to hook into JdkNativeCompilation.gmk.

The 'jre-image' target has been removed in favour of 'legacy-jre-image'. The targets that depended upon jre-image were not normally used nor needed: they have been removed.

Populating $(JDK_OUTPUTDIR) is required even if given a 'build jdk'.