### PR TITLE
Revert "Remove unused targets openj9-{jdk,jre}-image"

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -180,6 +180,33 @@ $(foreach file,$(OPENJ9_MANAGEMENT_LIBRARIES), \
 
 endef
 
+# generated_target_rules
+# ----------------------
+# param 1 = The make goal
+# param 2 = The jdk/jre directory to add openj9 content
+define generated_target_rules
+
+.PHONY : $1
+
+$(foreach file,$(OPENJ9_SHARED_LIBRARIES), \
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUTDIR)/vm/$(file))))
+
+$(foreach file,$(OPENJ9_MISC_FILES) $(OPENJ9_PROPERTY_FILES), \
+	$(eval $(call openj9_copy_prereq,$1,$2/lib/$(file),$(OUTPUTDIR)/vm/$(file))))
+
+$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_NOTICE_FILE_RENAME),$(TOPDIR)/$(OPENJ9_NOTICE_FILE)))
+
+$(foreach file,$(OPENJ9_REDIRECTOR), \
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX),$(OUTPUTDIR)/vm/$(file))))
+
+$(foreach file,$(OPENJ9_JAVA_BASE_LIBRARIES), \
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file)),$(OUTPUTDIR)/vm/$(file))))
+
+$(foreach file,$(OPENJ9_SHARED_CLASSES_LIBRARIES), \
+	$(eval $(call openj9_copy_prereq,$1,$2/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(file),$(OUTPUTDIR)/vm/$(file))))
+
+endef
+
 # openj9_copy_prereq
 # ------------------
 # param 1 = The make goal.
@@ -210,9 +237,17 @@ define openj9_copy_tree_impl
 endef
 
 openj9_build_jdk : build-j9
+ifeq ($(BUILD_JDK),$(JDK_OUTPUTDIR))
 	+$(MAKE) -f $(TOPDIR)/closed/OpenJ9.gmk create_build_jdk
+endif
 
-$(eval $(call generated_target_rules_build,create_build_jdk,$(JDK_OUTPUTDIR)))
+# If we weren't given a BUILD_JDK, we must create one.
+ifeq ($(BUILD_JDK),$(JDK_OUTPUTDIR))
+  $(eval $(call generated_target_rules_build,create_build_jdk,$(JDK_OUTPUTDIR)))
+endif
+
+$(eval $(call generated_target_rules,openj9_jdk_image,$(JDK_IMAGE_DIR)))
+$(eval $(call generated_target_rules,openj9_jre_image,$(JRE_IMAGE_DIR)))
 
 # Comments for stage-j9
 # Currently there is a staged location where j9 is built.  This is due to a number of reasons:

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -19,6 +19,8 @@ CLEAN_DIRS += vm
 
 .PHONY : \
 	j9vm-build \
+	openj9-jdk-image \
+	openj9-jre-image \
 	java.base-libs \
 	#
 
@@ -37,6 +39,14 @@ java.base-libs : java.base-copy j9vm-build
 j9vm-build : buildtools-langtools
 	+$(OPENJ9_MAKE) openj9_build_jdk
 
+product-images : openj9-jdk-image openj9-jre-image
+
+openj9-jdk-image : jdk-image j9vm-build
+	+$(OPENJ9_MAKE) openj9_jdk_image
+
+openj9-jre-image : jre-image j9vm-build
+	+$(OPENJ9_MAKE) openj9_jre_image
+
 ifeq (true,$(OPENJ9_ENABLE_DDR))
 
 .PHONY : openj9.dtfj-ddr-gensrc openj9.dtfj-ddr-jar
@@ -50,3 +60,5 @@ openj9.dtfj-ddr-jar : openj9.dtfj-ddr-gensrc
 openj9.dtfj-jmod : openj9.dtfj-ddr-jar
 
 endif # OPENJ9_ENABLE_DDR
+
+ALL_TARGETS += openj9-jdk-image openj9-jre-image


### PR DESCRIPTION
This reverts commit 6d29baf3d7557c280f0fcfc1aaedab46fdbb680f.

Signed-off-by: Steve Groeger GROEGES@uk.ibm.com