### PR TITLE
Build JDK11 with JDK 10 target

### DIFF
--- a/make/common/SetupJavaCompilers.gmk
+++ b/make/common/SetupJavaCompilers.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ $(eval $(call SetupJavaCompiler,GENERATE_OLDBYTECODE, \
 $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE, \
     JVM := $(JAVA_JAVAC), \
     JAVAC := $(NEW_JAVAC), \
-    FLAGS := -source 11 -target 11 --doclint-format html5 \
+    FLAGS := -source 10 -target 10 --doclint-format html5 \
         -encoding ascii -XDignore.symbol.file=true $(JAVAC_WARNINGS), \
     SERVER_DIR := $(SJAVAC_SERVER_DIR), \
     SERVER_JVM := $(SJAVAC_SERVER_JAVA)))
@@ -82,7 +82,7 @@ $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE, \
 $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE_NOWARNINGS, \
     JVM := $(JAVA_JAVAC), \
     JAVAC := $(NEW_JAVAC), \
-    FLAGS := -source 11 -target 11 \
+    FLAGS := -source 10 -target 10 \
         -encoding ascii -XDignore.symbol.file=true $(DISABLE_WARNINGS), \
     SERVER_DIR := $(SJAVAC_SERVER_DIR), \
     SERVER_JVM := $(SJAVAC_SERVER_JAVA)))


### PR DESCRIPTION
Build `JDK11` with `JDK 10` target

Compile `JDK11 Java` code with level of `JDK 10` such that the bytecode generated can be recognized by `OpenJ9 JVM` before it fully supports `JDK 11` features such as `nestmates`.
This is a temporary solution to allow `J9 JDK11` workaround the issue like https://github.com/eclipse/openj9/issues/2269#issuecomment-400425378 and continue the development.

With this PR, `CCM` build can produce `JDK` with `-version` output:
```
openjdk version "11-internal" 2018-09-25
OpenJDK Runtime Environment (build 11-internal+0-adhoc.jason.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build master-a934baf, JRE 11 Linux amd64-64-Bit Compressed References 20180628_000000 (JIT enabled, AOT enabled)
OpenJ9   - a934baf
OMR      - 6b22dda
JCL      - 40bef5e based on jdk-11+19)
``` 
No frequent merging conflict is expected due to this change.

Reviewer: @DanHeidinga 
FYI: @tajila @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>