### PR TITLE
Bringup JDK12

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -51,7 +51,7 @@ endif
 
 OPENJ9_ALT_SHARED_LIBRARIES := \
 	$(LIBRARY_PREFIX)jclse11_29$(SHARED_LIBRARY_SUFFIX) \
-	j9vm_jdk11/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX) \
+	j9vm_jdk12/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX) \
 	#
 
 OPENJ9_SHARED_CLASSES_LIBRARIES := \
@@ -108,7 +108,7 @@ OPENJ9_MISC_FILES := \
 
 OPENJ9_NOTICE_FILE := openj9/longabout.html
 OPENJ9_NOTICE_FILE_RENAME := openj9-notices.html
-OPENJ9_REDIRECTOR := redirector/$(LIBRARY_PREFIX)jvm_jdk11$(SHARED_LIBRARY_SUFFIX)
+OPENJ9_REDIRECTOR := redirector/$(LIBRARY_PREFIX)jvm_jdk12$(SHARED_LIBRARY_SUFFIX)
 
 MODULES_LIBS_DIR := $(OUTPUTDIR)/support/modules_libs
 
@@ -374,9 +374,9 @@ endif
 	# jvm is required for compiling other java.base support natives
 	@$(ECHO) "Creating support/modules_libs/java.base/*/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX) from J9 sources"
 	@$(MKDIR) -p $(MODULES_LIBS_DIR)/java.base/j9vm
-	@$(CP) -p $(OUTPUTDIR)/vm/redirector/$(LIBRARY_PREFIX)jvm_jdk11$(SHARED_LIBRARY_SUFFIX) $(MODULES_LIBS_DIR)/java.base/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
+	@$(CP) -p $(OUTPUTDIR)/vm/redirector/$(LIBRARY_PREFIX)jvm_jdk12$(SHARED_LIBRARY_SUFFIX) $(MODULES_LIBS_DIR)/java.base/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
 	@$(MKDIR) -p $(MODULES_LIBS_DIR)/java.base/server
-	@$(CP) -p $(OUTPUTDIR)/vm/redirector/$(LIBRARY_PREFIX)jvm_jdk11$(SHARED_LIBRARY_SUFFIX) $(MODULES_LIBS_DIR)/java.base/server/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
+	@$(CP) -p $(OUTPUTDIR)/vm/redirector/$(LIBRARY_PREFIX)jvm_jdk12$(SHARED_LIBRARY_SUFFIX) $(MODULES_LIBS_DIR)/java.base/server/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
 
 ifeq (true,$(OPENJ9_ENABLE_DDR))
 	@$(ECHO) Copying j9ddr.dat

--- a/make/common/SetupJavaCompilers.gmk
+++ b/make/common/SetupJavaCompilers.gmk
@@ -72,7 +72,7 @@ $(eval $(call SetupJavaCompiler,GENERATE_OLDBYTECODE, \
 $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE, \
     JVM := $(JAVA_JAVAC), \
     JAVAC := $(NEW_JAVAC), \
-    FLAGS := -source 12 -target 12 --doclint-format html5 \
+    FLAGS := -source 10 -target 10 --doclint-format html5 \
         -encoding ascii -XDignore.symbol.file=true $(JAVAC_WARNINGS), \
     SERVER_DIR := $(SJAVAC_SERVER_DIR), \
     SERVER_JVM := $(SJAVAC_SERVER_JAVA)))
@@ -82,7 +82,7 @@ $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE, \
 $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE_NOWARNINGS, \
     JVM := $(JAVA_JAVAC), \
     JAVAC := $(NEW_JAVAC), \
-    FLAGS := -source 12 -target 12 \
+    FLAGS := -source 10 -target 10 \
         -encoding ascii -XDignore.symbol.file=true $(DISABLE_WARNINGS), \
     SERVER_DIR := $(SJAVAC_SERVER_DIR), \
     SERVER_JVM := $(SJAVAC_SERVER_JAVA)))


### PR DESCRIPTION
Bringup `JDK12`

Backport release `10` compilation to workaround `nestmates` issue;
Adopt `JDK12 redirector` library.

Along with https://github.com/eclipse/openj9/pull/2458, this PR produces following `-version` output:
```
openjdk version "12-internal" 2019-03-19
OpenJDK Runtime Environment (build 12-internal+0-adhoc.jason.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build jvminitarch-64099b4, JRE 12 Linux amd64-64-Bit Compressed References 20180723_000000 (JIT enabled, AOT enabled)
OpenJ9   - 64099b4
OMR      - 9bf4244
JCL      - b16ce2c based on jdk-11+19)
```

Reviewer: @pshipton 
FYI: @andrew-m-leonard @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>