### PR TITLE
Enable AIX build with xlc 13.1

### DIFF
--- a/src/java.base/share/native/libjimage/NativeImageBuffer.cpp
+++ b/src/java.base/share/native/libjimage/NativeImageBuffer.cpp
@@ -1,4 +1,8 @@
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * ===========================================================================
+ *
  * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +44,16 @@
 #include "inttypes.hpp"
 #include "jimage.hpp"
 #include "osSupport.hpp"
+
+#if defined(__xlC__) && (__xlC__ >= 0x0d01)
+/*
+ * Version 13.1.3 of xlc seems to have trouble parsing the `__attribute__`
+ * annotation in the generated header file we're about to include. Repeating
+ * the forward declaration (without the braces) here avoids the diagnostic:
+ *   1540-0040 (S) The text "void" is unexpected.  "visibility" may be undeclared or ambiguous.
+ */
+extern "C" JNIEXPORT jobject JNICALL Java_jdk_internal_jimage_NativeImageBuffer_getNativeMap(JNIEnv *, jclass, jstring);
+#endif
 
 #include "jdk_internal_jimage_NativeImageBuffer.h"
 

--- a/src/java.base/unix/native/include/jni_md.h
+++ b/src/java.base/unix/native/include/jni_md.h
@@ -1,4 +1,8 @@
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * ===========================================================================
+ *
  * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,6 +41,9 @@
     #define JNIEXPORT     __attribute__((visibility("default")))
     #define JNIIMPORT     __attribute__((visibility("default")))
   #endif
+#elif defined(__xlC__) && (__xlC__ >= 0x0d01) /* xlc version 13.1 or better required */
+  #define JNIEXPORT       __attribute__((visibility("default")))
+  #define JNIIMPORT       __attribute__((visibility("default")))
 #else
   #define JNIEXPORT
   #define JNIIMPORT


### PR DESCRIPTION
Define `JNIEXPORT` and `JNIIMPORT` for xlc version 13.1 or newer. Without this, almost no symbols are exported from shared libraries due to use of `-qvisibility=hidden` as specified in `make/lib/LibCommon.gmk`. The symptoms are reported in eclipse/openj9#2468.

Unfortunately, this encounters a bug in xlc: it fails to parse what seems to be reasonable code. A workaround is required in just one place: `src/java.base/share/native/libjimage/NativeImageBuffer.cpp`.

This is a replay of https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/15.