### PR TITLE
Reverts #12, javac compile with source 11 target 11

### DIFF
--- a/make/common/SetupJavaCompilers.gmk
+++ b/make/common/SetupJavaCompilers.gmk
@@ -72,7 +72,7 @@ $(eval $(call SetupJavaCompiler,GENERATE_OLDBYTECODE, \
 $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE, \
     JVM := $(JAVA_JAVAC), \
     JAVAC := $(NEW_JAVAC), \
-    FLAGS := -source 10 -target 10 --doclint-format html5 \
+    FLAGS := -source 11 -target 11 --doclint-format html5 \
         -encoding ascii -XDignore.symbol.file=true $(JAVAC_WARNINGS), \
     SERVER_DIR := $(SJAVAC_SERVER_DIR), \
     SERVER_JVM := $(SJAVAC_SERVER_JAVA)))
@@ -82,7 +82,7 @@ $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE, \
 $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE_NOWARNINGS, \
     JVM := $(JAVA_JAVAC), \
     JAVAC := $(NEW_JAVAC), \
-    FLAGS := -source 10 -target 10 \
+    FLAGS := -source 11 -target 11 \
         -encoding ascii -XDignore.symbol.file=true $(DISABLE_WARNINGS), \
     SERVER_DIR := $(SJAVAC_SERVER_DIR), \
     SERVER_JVM := $(SJAVAC_SERVER_JAVA)))


### PR DESCRIPTION
Reverts #12. Similarly to https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/21

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>