### PR TITLE
javac compile with source 12 target 12

### DIFF
--- a/make/common/SetupJavaCompilers.gmk
+++ b/make/common/SetupJavaCompilers.gmk
@@ -72,7 +72,7 @@ $(eval $(call SetupJavaCompiler,GENERATE_OLDBYTECODE, \
 $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE, \
     JVM := $(JAVA_JAVAC), \
     JAVAC := $(NEW_JAVAC), \
-    FLAGS := -source 11 -target 11 --doclint-format html5 \
+    FLAGS := -source 12 -target 12 --doclint-format html5 \
         -encoding ascii -XDignore.symbol.file=true $(JAVAC_WARNINGS), \
     SERVER_DIR := $(SJAVAC_SERVER_DIR), \
     SERVER_JVM := $(SJAVAC_SERVER_JAVA)))
@@ -82,7 +82,7 @@ $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE, \
 $(eval $(call SetupJavaCompiler,GENERATE_JDKBYTECODE_NOWARNINGS, \
     JVM := $(JAVA_JAVAC), \
     JAVAC := $(NEW_JAVAC), \
-    FLAGS := -source 11 -target 11 \
+    FLAGS := -source 12 -target 12 \
         -encoding ascii -XDignore.symbol.file=true $(DISABLE_WARNINGS), \
     SERVER_DIR := $(SJAVAC_SERVER_DIR), \
     SERVER_JVM := $(SJAVAC_SERVER_JAVA)))


### PR DESCRIPTION
Subsequent to #12, openjdk changed to use source 12 target 12. Thanks
@keithc-ca for noticing. Corrects #33

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>