### PR TITLE
Avoid using `--exclude-vcs` which isn't universally supported

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -103,10 +103,11 @@ openj9_copy_tree = $(call openj9_copy_tree_impl,$(strip $1),$(strip $2))
 
 OPENJ9_MARKER_FILE := .up-to-date
 
-# Use '-m' to update file modification times ('-m' is equivalent to '--touch' in some implementations of tar)
+# Use '-m' to update file modification times ('-m' is equivalent to '--touch' in some implementations of tar).
 define openj9_copy_tree_impl
 	@$(MKDIR) -p $1
-	@$(TAR) --create --directory=$2 $(if $(wildcard $1/$(OPENJ9_MARKER_FILE)),--newer=$1/$(OPENJ9_MARKER_FILE)) --exclude-vcs . | $(TAR) --extract --directory=$1 -m
+	@$(TAR) --create --directory=$2 $(if $(wildcard $1/$(OPENJ9_MARKER_FILE)),--newer=$1/$(OPENJ9_MARKER_FILE)) --exclude=.git . \
+		| $(TAR) --extract --directory=$1 -m
 	@$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
 


### PR DESCRIPTION
This eliminates the need to install a special version of tar on macosx.