### PR TITLE
Use OpenJ9 implementation of libjsig.so

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -5,6 +5,9 @@
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
 #
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
@@ -176,6 +179,17 @@ $(foreach subdir, j9vm server, \
 		$(subdir)/$(call SHARED_LIBRARY,jvm), \
 		redirector/$(call SHARED_LIBRARY,jvm_jdk12)))
 
+# jsig
+
+$(foreach subdir, j9vm server, \
+	$(call openj9_add_jdk_special, \
+		$(subdir)/$(call SHARED_LIBRARY,jsig), \
+		$(call SHARED_LIBRARY,jsig)))
+
+$(call openj9_add_jdk_special, \
+	$(call SHARED_LIBRARY,jsig), \
+	$(call SHARED_LIBRARY,jsig))
+
 # java.base
 
 $(call openj9_add_jdk_shlibs, java.base, \
@@ -195,7 +209,6 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	j9vrb29 \
 	j9zlib29 \
 	jclse11_29 \
-	jsig \
 	omrsig \
 	)
 

--- a/make/lib/Lib-java.base.gmk
+++ b/make/lib/Lib-java.base.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+
 include LibCommon.gmk
 
 # Hook to include the corresponding custom file, if present.
@@ -130,6 +134,8 @@ endif
 ################################################################################
 # Create the jsig library
 
+# use libjsig from OpenJ9
+ifeq ($(OPENJ9_TOPDIR),)
 ifeq ($(OPENJDK_TARGET_OS_TYPE), unix)
   ifeq ($(STATIC_BUILD), false)
     $(eval $(call SetupJdkLibrary, BUILD_LIBJSIG, \
@@ -172,6 +178,7 @@ ifeq ($(OPENJDK_TARGET_OS_TYPE), unix)
 
   endif
 endif
+endif # use libjsig from OpenJ9
 
 ################################################################################
 # Create the symbols file for static builds.


### PR DESCRIPTION
Use the OpenJ9 implementation of libjsig.so and don't include a copy in the compressedrefs/default directory.

This is a replay of https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/52 and https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/58 for Java 12.

