### PR TITLE
Add OSX Support

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -269,7 +269,11 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
       fi
     elif test "x$OPENJDK_BUILD_OS" = xmacosx ; then
       OPENJ9_PLATFORM_CODE=oa64
-      OPENJ9_BUILDSPEC=osx_x86-64
+      if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
+        OPENJ9_BUILDSPEC="osx_x86-64"
+      else
+        OPENJ9_BUILDSPEC="osx_x86-64_cmprssptrs"
+      fi
     else
       AC_MSG_ERROR([Unsupported OpenJ9 platform ${OPENJDK_BUILD_OS}!])
     fi

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -90,3 +90,17 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
   export LIB := "@VS_LIB@"
   export MSVC_VERSION := @TOOLCHAIN_VERSION@
 endif
+
+ifeq ($(OPENJDK_BUILD_OS), macosx)
+  # MACOSX_DEPLOYMENT_TARGET acts similar to -mmacosx-version-min=version
+  # compiler option. If both the compiler option is specified and the
+  # environment variable is set, then the compiler option will take
+  # precedence. Here, MACOSX_DEPLOYMENT_TARGET environment variable and
+  # the compiler option will point to the same version. The environment
+  # variable is defined to support dependencies where the compiler option
+  # is not applied.
+  export MACOSX_DEPLOYMENT_TARGET := @MACOSX_VERSION_MIN@
+
+  # Set page zero size to 4KB for mapping memory below 4GB.
+  LDFLAGS_JDKEXE += -pagezero_size 0x1000
+endif


### PR DESCRIPTION
1. Set `OPENJ9_BUILDSPEC` to `osx_x86-64_cmprssptrs` for compressedrefs
build.

2. Setting `MACOSX_DEPLOYMENT_TARGET` environment variable will let OpenJ9
executables to run on OSX versions older than the OSX version on which
OpenJ9 was built. `MACOSX_DEPLOYMENT_TARGET` acts similar to
`-mmacosx-version-min=version` compiler option. If both the compiler option is
specified and the environment variable is set, then the compiler option will take
precedence. Here, `MACOSX_DEPLOYMENT_TARGET` environment variable and
the compiler option will point to the same version. The environment
variable is defined to support dependencies where the compiler option
is not applied. Issue: eclipse/openj9#3244.

3. Append `-pagezero_size 0x1000` to `LDFLAGS_JDKEXE` on OSX 64-bit build.
This allows memory to be mapped below 4GB. `-pagezero_size 0x1000` is used
with both compressedrefs and non-compressedrefs variants. This allows
executables to work with both compressedrefs and non-compressedrefs OpenJ9
libraries.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>