### PR TITLE
AIX xlC qvisibility extension removal

### DIFF
--- a/src/java.base/share/native/libjimage/NativeImageBuffer.cpp
+++ b/src/java.base/share/native/libjimage/NativeImageBuffer.cpp
@@ -28,11 +28,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
- * ===========================================================================
- */
+
 #include <string.h>
 
 #include "jni.h"
@@ -44,16 +40,6 @@
 #include "inttypes.hpp"
 #include "jimage.hpp"
 #include "osSupport.hpp"
-
-#if defined(__xlC__) && (__xlC__ >= 0x0d01)
-/*
- * Version 13.1.3 of xlc seems to have trouble parsing the `__attribute__`
- * annotation in the generated header file we're about to include. Repeating
- * the forward declaration (without the braces) here avoids the diagnostic:
- *   1540-0040 (S) The text "void" is unexpected.  "visibility" may be undeclared or ambiguous.
- */
-extern "C" JNIEXPORT jobject JNICALL Java_jdk_internal_jimage_NativeImageBuffer_getNativeMap(JNIEnv *, jclass, jstring);
-#endif
 
 #include "jdk_internal_jimage_NativeImageBuffer.h"
 

--- a/src/java.base/unix/native/include/jni_md.h
+++ b/src/java.base/unix/native/include/jni_md.h
@@ -22,13 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
- 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
- * ===========================================================================
- */
- 
+
 #ifndef _JAVASOFT_JNI_MD_H_
 #define _JAVASOFT_JNI_MD_H_
 
@@ -43,9 +37,6 @@
     #define JNIEXPORT     __attribute__((visibility("default")))
     #define JNIIMPORT     __attribute__((visibility("default")))
   #endif
-#elif defined(__xlC__) && (__xlC__ >= 0x0d01) /* xlc version 13.1 or better required */
-  #define JNIEXPORT       __attribute__((visibility("default")))
-  #define JNIIMPORT       __attribute__((visibility("default")))
 #else
   #define JNIEXPORT
   #define JNIIMPORT


### PR DESCRIPTION
When you are building OpenJDK on AIX with a version of the xlC
compiler that is not 12.1, OpenJDK adds the qvisibility option
to the xlC_r command line.

This breaks things, and prevents the build from completing.

To compensate, we added some changes into extensions.

The community has been contacted about the bug, and elected to break
the problem into 2 stages.

1. Remove the qvisibility option to enable the builds to pass in the
short term.

2. Add the qvisibility option back in, and add whatever code is
needed to allow builds and testing to complete successfully.

Since step 1 is complete, we don't need our work-around code anymore.

This commit removes that workaround code.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>