### PR TITLE
Put jsig libraries in the correct places

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -213,10 +213,10 @@ $(call openj9_add_jdk_shlibs, java.base, \
 	)
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
-$(foreach subdir, j9vm server, \
-	$(eval $(call openj9_add_jdk_rules, \
-		$(JDK_OUTPUTDIR)/bin/$(subdir)/$(call STATIC_LIBRARY,jvm), \
-		$(OUTPUTDIR)/vm/j9vm_jdk12/$(call STATIC_LIBRARY,jdk12_jvm))))
+  $(call openj9_add_jdk_lib, java.base, lib/$(call STATIC_LIBRARY,jsig))
+  $(eval $(call openj9_add_jdk_rules, \
+	$(call FindLibDirForModule, java.base)/$(call STATIC_LIBRARY,jvm), \
+	$(OUTPUTDIR)/vm/redirector/$(call STATIC_LIBRARY,redirector_jvm)))
 endif
 
 $(call openj9_add_jdk_lib, java.base, \


### PR DESCRIPTION
* on Windows the shared library should be in `bin`, `bin/j9vm` and `bin/server` (in an SDK, the static library should be in `lib`)
* on other platforms, the shared library should be in `lib`, `lib/j9vm` and `lib/server`
* also put the redirector static library where openjdk expects it

This is a replay of ibmruntimes/openj9-openjdk-jdk11#97 for Java 13.