### PR TITLE
Replace IBM-shared_classes_misc with OpenJ9-shared_classes_misc

### DIFF
--- a/src/java.base/share/classes/java/net/URLClassLoader.java
+++ b/src/java.base/share/classes/java/net/URLClassLoader.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 package java.net;
@@ -49,17 +49,17 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.Vector;                                                         //IBM-shared_classes_misc
+import java.util.Vector;                                                         //OpenJ9-shared_classes_misc
 import java.util.WeakHashMap;
 import java.util.function.IntConsumer;
 import java.util.jar.Attributes;
 import java.util.jar.Attributes.Name;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
-import java.util.regex.Pattern;                                                  //IBM-shared_classes_misc
-import java.util.regex.Matcher;                                                  //IBM-shared_classes_misc
-import java.util.regex.PatternSyntaxException;                                   //IBM-shared_classes_misc
-import java.util.StringTokenizer;                                                //IBM-shared_classes_misc
+import java.util.regex.Pattern;                                                  //OpenJ9-shared_classes_misc
+import java.util.regex.Matcher;                                                  //OpenJ9-shared_classes_misc
+import java.util.regex.PatternSyntaxException;                                   //OpenJ9-shared_classes_misc
+import java.util.StringTokenizer;                                                //OpenJ9-shared_classes_misc
 
 import jdk.internal.loader.Resource;
 import jdk.internal.loader.URLClassPath;
@@ -99,95 +99,95 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
 
     /* The context to be used when loading classes and resources */
     private final AccessControlContext acc;
-    /* Private member fields used for Shared classes*/                           //IBM-shared_classes_misc
+    /* Private member fields used for Shared classes*/                           //OpenJ9-shared_classes_misc
     private SharedClassProvider sharedClassServiceProvider;
-	private SharedClassMetaDataCache sharedClassMetaDataCache;                   //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-    /*                                                                           //IBM-shared_classes_misc
-     * Wrapper class for maintaining the index of where the metadata (codesource and manifest)  //IBM-shared_classes_misc
-     * is found - used only in Shared classes context.                           //IBM-shared_classes_misc
-     */                                                                          //IBM-shared_classes_misc
-    private static class SharedClassIndexHolder {  								 //IBM-shared_classes_misc
-        int index;                                                               //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-        public void setIndex(int index) {                                        //IBM-shared_classes_misc
-            this.index = index;                                                  //IBM-shared_classes_misc
-        }                                                                        //IBM-shared_classes_misc
-    }                                                                            //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-    /*                                                                           //IBM-shared_classes_misc
-     * Wrapper class for internal storage of metadata (codesource and manifest) associated with   //IBM-shared_classes_misc
-     * shared class - used only in Shared classes context.                       //IBM-shared_classes_misc
-     */                                                                          //IBM-shared_classes_misc
-    private class SharedClassMetaData {                                          //IBM-shared_classes_misc
-        private CodeSource codeSource;                                           //IBM-shared_classes_misc
-        private Manifest manifest;                                               //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-        SharedClassMetaData(CodeSource codeSource, Manifest manifest) {          //IBM-shared_classes_misc
-            this.codeSource = codeSource;                                        //IBM-shared_classes_misc
-            this.manifest = manifest;                                            //IBM-shared_classes_misc
-        }                                                                        //IBM-shared_classes_misc
-        public CodeSource getCodeSource() { return codeSource; }                 //IBM-shared_classes_misc
-        public Manifest getManifest() { return manifest; }                       //IBM-shared_classes_misc
-    }                                                                            //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-    /*                                                                           //IBM-shared_classes_misc
-     * Represents a collection of SharedClassMetaData objects retrievable by     //IBM-shared_classes_misc
-     * index.                                                                    //IBM-shared_classes_misc
-     */                                                                          //IBM-shared_classes_misc
-    private class SharedClassMetaDataCache {                                     //IBM-shared_classes_misc
-        private final static int BLOCKSIZE = 10;                                 //IBM-shared_classes_misc
-        private SharedClassMetaData[] store;                                     //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-        public SharedClassMetaDataCache(int initialSize) {                       //IBM-shared_classes_misc
-            /* Allocate space for an initial amount of metadata entries */       //IBM-shared_classes_misc
-            store = new SharedClassMetaData[initialSize];                        //IBM-shared_classes_misc
-        }                                                                        //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-        /**                                                                      //IBM-shared_classes_misc
-         * Retrieves the SharedClassMetaData stored at the given index, or null  //IBM-shared_classes_misc
-         * if no SharedClassMetaData was previously stored at the given index    //IBM-shared_classes_misc
-         * or the index is out of range.                                         //IBM-shared_classes_misc
-         */                                                                      //IBM-shared_classes_misc
-        public synchronized SharedClassMetaData getSharedClassMetaData(int index) {  //IBM-shared_classes_misc
-            if (index < 0 || store.length < (index+1)) {                         //IBM-shared_classes_misc
-                return null;                                                     //IBM-shared_classes_misc
-            }                                                                    //IBM-shared_classes_misc
-            return store[index];                                                 //IBM-shared_classes_misc
-        }                                                                        //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-        /**                                                                      //IBM-shared_classes_misc
-         * Stores the supplied SharedClassMetaData at the given index in the     //IBM-shared_classes_misc
-         * store. The store will be grown to contain the index if necessary.     //IBM-shared_classes_misc
-         */                                                                      //IBM-shared_classes_misc
-        public synchronized void setSharedClassMetaData(int index,               //IBM-shared_classes_misc
-                                                     SharedClassMetaData data) {  //IBM-shared_classes_misc
-            ensureSize(index);                                                   //IBM-shared_classes_misc
-            store[index] = data;                                                 //IBM-shared_classes_misc
-        }                                                                        //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-        /* Ensure that the store can hold at least index number of entries */    //IBM-shared_classes_misc
-        private synchronized void ensureSize(int index) {                        //IBM-shared_classes_misc
-            if (store.length < (index+1)) {                                      //IBM-shared_classes_misc
-                int newSize = (index+BLOCKSIZE);                                 //IBM-shared_classes_misc
-                SharedClassMetaData[] newSCMDS = new SharedClassMetaData[newSize];  //IBM-shared_classes_misc
-                System.arraycopy(store, 0, newSCMDS, 0, store.length);           //IBM-shared_classes_misc
-                store = newSCMDS;                                                //IBM-shared_classes_misc
-            }                                                                    //IBM-shared_classes_misc
-        }                                                                        //IBM-shared_classes_misc
-    }                                                                            //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-    /*                                                                           //IBM-shared_classes_misc
-     * Return true if shared classes support is active, otherwise false.         //IBM-shared_classes_misc
-     */                                                                          //IBM-shared_classes_misc
-    private boolean usingSharedClasses() {                                       //IBM-shared_classes_misc
-        return (sharedClassServiceProvider != null);                          //IBM-shared_classes_misc
-    }                                                                            //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-	/*                                                                           //IBM-shared_classes_misc
-     * Initialize support for shared classes.                                    //IBM-shared_classes_misc
-     */                                                                          //IBM-shared_classes_misc
-	private synchronized void initializeSharedClassesSupport(URL[] initialClassPath) {        //IBM-shared_classes_misc
+	private SharedClassMetaDataCache sharedClassMetaDataCache;                   //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+    /*                                                                           //OpenJ9-shared_classes_misc
+     * Wrapper class for maintaining the index of where the metadata (codesource and manifest)  //OpenJ9-shared_classes_misc
+     * is found - used only in Shared classes context.                           //OpenJ9-shared_classes_misc
+     */                                                                          //OpenJ9-shared_classes_misc
+    private static class SharedClassIndexHolder {  								 //OpenJ9-shared_classes_misc
+        int index;                                                               //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+        public void setIndex(int index) {                                        //OpenJ9-shared_classes_misc
+            this.index = index;                                                  //OpenJ9-shared_classes_misc
+        }                                                                        //OpenJ9-shared_classes_misc
+    }                                                                            //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+    /*                                                                           //OpenJ9-shared_classes_misc
+     * Wrapper class for internal storage of metadata (codesource and manifest) associated with   //OpenJ9-shared_classes_misc
+     * shared class - used only in Shared classes context.                       //OpenJ9-shared_classes_misc
+     */                                                                          //OpenJ9-shared_classes_misc
+    private class SharedClassMetaData {                                          //OpenJ9-shared_classes_misc
+        private CodeSource codeSource;                                           //OpenJ9-shared_classes_misc
+        private Manifest manifest;                                               //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+        SharedClassMetaData(CodeSource codeSource, Manifest manifest) {          //OpenJ9-shared_classes_misc
+            this.codeSource = codeSource;                                        //OpenJ9-shared_classes_misc
+            this.manifest = manifest;                                            //OpenJ9-shared_classes_misc
+        }                                                                        //OpenJ9-shared_classes_misc
+        public CodeSource getCodeSource() { return codeSource; }                 //OpenJ9-shared_classes_misc
+        public Manifest getManifest() { return manifest; }                       //OpenJ9-shared_classes_misc
+    }                                                                            //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+    /*                                                                           //OpenJ9-shared_classes_misc
+     * Represents a collection of SharedClassMetaData objects retrievable by     //OpenJ9-shared_classes_misc
+     * index.                                                                    //OpenJ9-shared_classes_misc
+     */                                                                          //OpenJ9-shared_classes_misc
+    private class SharedClassMetaDataCache {                                     //OpenJ9-shared_classes_misc
+        private final static int BLOCKSIZE = 10;                                 //OpenJ9-shared_classes_misc
+        private SharedClassMetaData[] store;                                     //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+        public SharedClassMetaDataCache(int initialSize) {                       //OpenJ9-shared_classes_misc
+            /* Allocate space for an initial amount of metadata entries */       //OpenJ9-shared_classes_misc
+            store = new SharedClassMetaData[initialSize];                        //OpenJ9-shared_classes_misc
+        }                                                                        //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+        /**                                                                      //OpenJ9-shared_classes_misc
+         * Retrieves the SharedClassMetaData stored at the given index, or null  //OpenJ9-shared_classes_misc
+         * if no SharedClassMetaData was previously stored at the given index    //OpenJ9-shared_classes_misc
+         * or the index is out of range.                                         //OpenJ9-shared_classes_misc
+         */                                                                      //OpenJ9-shared_classes_misc
+        public synchronized SharedClassMetaData getSharedClassMetaData(int index) {  //OpenJ9-shared_classes_misc
+            if (index < 0 || store.length < (index+1)) {                         //OpenJ9-shared_classes_misc
+                return null;                                                     //OpenJ9-shared_classes_misc
+            }                                                                    //OpenJ9-shared_classes_misc
+            return store[index];                                                 //OpenJ9-shared_classes_misc
+        }                                                                        //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+        /**                                                                      //OpenJ9-shared_classes_misc
+         * Stores the supplied SharedClassMetaData at the given index in the     //OpenJ9-shared_classes_misc
+         * store. The store will be grown to contain the index if necessary.     //OpenJ9-shared_classes_misc
+         */                                                                      //OpenJ9-shared_classes_misc
+        public synchronized void setSharedClassMetaData(int index,               //OpenJ9-shared_classes_misc
+                                                     SharedClassMetaData data) {  //OpenJ9-shared_classes_misc
+            ensureSize(index);                                                   //OpenJ9-shared_classes_misc
+            store[index] = data;                                                 //OpenJ9-shared_classes_misc
+        }                                                                        //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+        /* Ensure that the store can hold at least index number of entries */    //OpenJ9-shared_classes_misc
+        private synchronized void ensureSize(int index) {                        //OpenJ9-shared_classes_misc
+            if (store.length < (index+1)) {                                      //OpenJ9-shared_classes_misc
+                int newSize = (index+BLOCKSIZE);                                 //OpenJ9-shared_classes_misc
+                SharedClassMetaData[] newSCMDS = new SharedClassMetaData[newSize];  //OpenJ9-shared_classes_misc
+                System.arraycopy(store, 0, newSCMDS, 0, store.length);           //OpenJ9-shared_classes_misc
+                store = newSCMDS;                                                //OpenJ9-shared_classes_misc
+            }                                                                    //OpenJ9-shared_classes_misc
+        }                                                                        //OpenJ9-shared_classes_misc
+    }                                                                            //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+    /*                                                                           //OpenJ9-shared_classes_misc
+     * Return true if shared classes support is active, otherwise false.         //OpenJ9-shared_classes_misc
+     */                                                                          //OpenJ9-shared_classes_misc
+    private boolean usingSharedClasses() {                                       //OpenJ9-shared_classes_misc
+        return (sharedClassServiceProvider != null);                          //OpenJ9-shared_classes_misc
+    }                                                                            //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+	/*                                                                           //OpenJ9-shared_classes_misc
+     * Initialize support for shared classes.                                    //OpenJ9-shared_classes_misc
+     */                                                                          //OpenJ9-shared_classes_misc
+	private synchronized void initializeSharedClassesSupport(URL[] initialClassPath) {        //OpenJ9-shared_classes_misc
 	   if (null == sharedClassServiceProvider) {
 			ServiceLoader<SharedClassProvider> sl = ServiceLoader.load(SharedClassProvider.class); 
 			for (SharedClassProvider p : sl) {												
@@ -199,12 +199,12 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
 				}
 			}
 		}
-		if (usingSharedClasses()) {                                          //IBM-shared_classes_misc
-            /* Create a metadata cache */                                    //IBM-shared_classes_misc
-            this.sharedClassMetaDataCache = new SharedClassMetaDataCache(initialClassPath.length);  //IBM-shared_classes_misc
-        }                                                                    //IBM-shared_classes_misc
-    }                                                                            //IBM-shared_classes_misc
-                                                                          //IBM-shared_classes_misc
+		if (usingSharedClasses()) {                                          //OpenJ9-shared_classes_misc
+            /* Create a metadata cache */                                    //OpenJ9-shared_classes_misc
+            this.sharedClassMetaDataCache = new SharedClassMetaDataCache(initialClassPath.length);  //OpenJ9-shared_classes_misc
+        }                                                                    //OpenJ9-shared_classes_misc
+    }                                                                            //OpenJ9-shared_classes_misc
+                                                                          //OpenJ9-shared_classes_misc
 
     /**
      * Constructs a new URLClassLoader for the given URLs. The URLs will be
@@ -230,17 +230,17 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      */
     public URLClassLoader(URL[] urls, ClassLoader parent) {
         super(parent);
-        initializeSharedClassesSupport(urls);                                    //IBM-shared_classes_misc
+        initializeSharedClassesSupport(urls);                                    //OpenJ9-shared_classes_misc
         this.acc = AccessController.getContext();
-        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //IBM-shared_classes_misc        
+        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //OpenJ9-shared_classes_misc        
     }
 
     URLClassLoader(String name, URL[] urls, ClassLoader parent,
                    AccessControlContext acc) {
         super(name, parent);
-        initializeSharedClassesSupport(urls);                                    //IBM-shared_classes_misc
+        initializeSharedClassesSupport(urls);                                    //OpenJ9-shared_classes_misc
         this.acc = acc;
-        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //IBM-shared_classes_misc        
+        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //OpenJ9-shared_classes_misc        
     }
 
     /**
@@ -267,16 +267,16 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      */
     public URLClassLoader(URL[] urls) {
         super();
-        initializeSharedClassesSupport(urls);                                    //IBM-shared_classes_misc
+        initializeSharedClassesSupport(urls);                                    //OpenJ9-shared_classes_misc
         this.acc = AccessController.getContext();
-        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //IBM-shared_classes_misc
+        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //OpenJ9-shared_classes_misc
     }
 
     URLClassLoader(URL[] urls, AccessControlContext acc) {
         super();
-        initializeSharedClassesSupport(urls);                                    //IBM-shared_classes_misc
+        initializeSharedClassesSupport(urls);                                    //OpenJ9-shared_classes_misc
         this.acc = acc;
-        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //IBM-shared_classes_misc
+        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //OpenJ9-shared_classes_misc
     }
 
     /**
@@ -304,9 +304,9 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
     public URLClassLoader(URL[] urls, ClassLoader parent,
                           URLStreamHandlerFactory factory) {
         super(parent);
-        initializeSharedClassesSupport(urls);                                    //IBM-shared_classes_misc
+        initializeSharedClassesSupport(urls);                                    //OpenJ9-shared_classes_misc
         this.acc = AccessController.getContext();
-        ucp = new URLClassPath(urls, factory, this.acc, sharedClassServiceProvider);    //IBM-shared_classes_misc
+        ucp = new URLClassPath(urls, factory, this.acc, sharedClassServiceProvider);    //OpenJ9-shared_classes_misc
     }
 
 
@@ -337,9 +337,9 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
                           URL[] urls,
                           ClassLoader parent) {
         super(name, parent);
-        initializeSharedClassesSupport(urls);                                    //IBM-shared_classes_misc
+        initializeSharedClassesSupport(urls);                                    //OpenJ9-shared_classes_misc
         this.acc = AccessController.getContext();
-        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //IBM-shared_classes_misc
+        ucp = new URLClassPath(urls, null, this.acc, sharedClassServiceProvider);       //OpenJ9-shared_classes_misc
     }
 
     /**
@@ -368,9 +368,9 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
     public URLClassLoader(String name, URL[] urls, ClassLoader parent,
                           URLStreamHandlerFactory factory) {
         super(name, parent);
-        initializeSharedClassesSupport(urls);                                    //IBM-shared_classes_misc
+        initializeSharedClassesSupport(urls);                                    //OpenJ9-shared_classes_misc
         this.acc = AccessController.getContext();
-        ucp = new URLClassPath(urls, factory, this.acc, sharedClassServiceProvider);    //IBM-shared_classes_misc
+        ucp = new URLClassPath(urls, factory, this.acc, sharedClassServiceProvider);    //OpenJ9-shared_classes_misc
     }
 
     /* A map (used as a set) to keep track of closeable local resources
@@ -539,37 +539,37 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
     {
         final Class<?> result = null ;
         try {
-            /* Try to find the class from the shared cache using the class name.  If we found the class  //IBM-shared_classes_misc
-             * and if we have its corresponding metadata (codesource and manifest entry) already cached,  //IBM-shared_classes_misc
-             * then we define the class passing in these parameters.  If however, we do not have the  //IBM-shared_classes_misc
-             * metadata cached, then we define the class as normal.  Also, if we do not find the class //IBM-shared_classes_misc
-             * from the shared class cache, we define the class as normal.      //IBM-shared_classes_misc
-             */                                                                 //IBM-shared_classes_misc
-            if (usingSharedClasses()) {                                         //IBM-shared_classes_misc
-            	SharedClassIndexHolder sharedClassIndexHolder = new SharedClassIndexHolder(); /*ibm@94142*/ //IBM-shared_classes_misc
-				IntConsumer consumer = (i)->sharedClassIndexHolder.setIndex(i); //IBM-shared_classes_misc
-                byte[] sharedClazz = sharedClassServiceProvider.findSharedClassURLClasspath(name, consumer); //IBM-shared_classes_misc                                             
-                if (sharedClazz != null) {                                      //IBM-shared_classes_misc
-                    int indexFoundData = sharedClassIndexHolder.index;          //IBM-shared_classes_misc
-                    SharedClassMetaData metadata = sharedClassMetaDataCache.getSharedClassMetaData(indexFoundData);  //IBM-shared_classes_misc
-                    if (metadata != null) {                                     //IBM-shared_classes_misc
-                        try {                                                   //IBM-shared_classes_misc
-                            Class<?> clazz = defineClass(name,sharedClazz,         //IBM-shared_classes_misc
-                                               metadata.getCodeSource(),        //IBM-shared_classes_misc
-                                               metadata.getManifest());         //IBM-shared_classes_misc
-                            return clazz;                                       //IBM-shared_classes_misc
-                        } catch (IOException e) {                               //IBM-shared_classes_misc
-                            e.printStackTrace();                                //IBM-shared_classes_misc
-                        }                                                      //IBM-shared_classes_misc
-                    }                                                          //IBM-shared_classes_misc
-                }                                                               //IBM-shared_classes_misc
-            }                                                           //IBM-shared_classes_misc
-           ClassFinder loader = new ClassFinder(name, this);    /*ibm@80916.1*/ //IBM-shared_classes_misc
-            Class<?>  clazz = (Class)AccessController.doPrivileged(loader, acc);    //IBM-shared_classes_misc
-            if (clazz == null) {                                     /*ibm@802*/ //IBM-shared_classes_misc
-                throw new ClassNotFoundException(name);              /*ibm@802*/ //IBM-shared_classes_misc
-            }                                                                    //IBM-shared_classes_misc
-            return clazz;                                                       //IBM-shared_classes_misc
+            /* Try to find the class from the shared cache using the class name.  If we found the class  //OpenJ9-shared_classes_misc
+             * and if we have its corresponding metadata (codesource and manifest entry) already cached,  //OpenJ9-shared_classes_misc
+             * then we define the class passing in these parameters.  If however, we do not have the  //OpenJ9-shared_classes_misc
+             * metadata cached, then we define the class as normal.  Also, if we do not find the class //OpenJ9-shared_classes_misc
+             * from the shared class cache, we define the class as normal.      //OpenJ9-shared_classes_misc
+             */                                                                 //OpenJ9-shared_classes_misc
+            if (usingSharedClasses()) {                                         //OpenJ9-shared_classes_misc
+            	SharedClassIndexHolder sharedClassIndexHolder = new SharedClassIndexHolder(); /*ibm@94142*/ //OpenJ9-shared_classes_misc
+				IntConsumer consumer = (i)->sharedClassIndexHolder.setIndex(i); //OpenJ9-shared_classes_misc
+                byte[] sharedClazz = sharedClassServiceProvider.findSharedClassURLClasspath(name, consumer); //OpenJ9-shared_classes_misc                                             
+                if (sharedClazz != null) {                                      //OpenJ9-shared_classes_misc
+                    int indexFoundData = sharedClassIndexHolder.index;          //OpenJ9-shared_classes_misc
+                    SharedClassMetaData metadata = sharedClassMetaDataCache.getSharedClassMetaData(indexFoundData);  //OpenJ9-shared_classes_misc
+                    if (metadata != null) {                                     //OpenJ9-shared_classes_misc
+                        try {                                                   //OpenJ9-shared_classes_misc
+                            Class<?> clazz = defineClass(name,sharedClazz,         //OpenJ9-shared_classes_misc
+                                               metadata.getCodeSource(),        //OpenJ9-shared_classes_misc
+                                               metadata.getManifest());         //OpenJ9-shared_classes_misc
+                            return clazz;                                       //OpenJ9-shared_classes_misc
+                        } catch (IOException e) {                               //OpenJ9-shared_classes_misc
+                            e.printStackTrace();                                //OpenJ9-shared_classes_misc
+                        }                                                      //OpenJ9-shared_classes_misc
+                    }                                                          //OpenJ9-shared_classes_misc
+                }                                                               //OpenJ9-shared_classes_misc
+            }                                                           //OpenJ9-shared_classes_misc
+           ClassFinder loader = new ClassFinder(name, this);    /*ibm@80916.1*/ //OpenJ9-shared_classes_misc
+            Class<?>  clazz = (Class)AccessController.doPrivileged(loader, acc);    //OpenJ9-shared_classes_misc
+            if (clazz == null) {                                     /*ibm@802*/ //OpenJ9-shared_classes_misc
+                throw new ClassNotFoundException(name);              /*ibm@802*/ //OpenJ9-shared_classes_misc
+            }                                                                    //OpenJ9-shared_classes_misc
+            return clazz;                                                       //OpenJ9-shared_classes_misc
         } catch (java.security.PrivilegedActionException pae) {
             throw (ClassNotFoundException) pae.getException();
         }
@@ -610,16 +610,16 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      * used.
      */
     private Class<?> defineClass(String name, Resource res) throws IOException {
-        Class clazz = null;                                                    //IBM-shared_classes_misc
-        CodeSource cs = null;                                                  //IBM-shared_classes_misc
-        Manifest man = null;                                                   //IBM-shared_classes_misc
+        Class clazz = null;                                                    //OpenJ9-shared_classes_misc
+        CodeSource cs = null;                                                  //OpenJ9-shared_classes_misc
+        Manifest man = null;                                                   //OpenJ9-shared_classes_misc
         long t0 = System.nanoTime();
         int i = name.lastIndexOf('.');
         URL url = res.getCodeSourceURL();
         if (i != -1) {
             String pkgname = name.substring(0, i);
             // Check if package already loaded.
-            man = res.getManifest();                                           //IBM-shared_classes_misc
+            man = res.getManifest();                                           //OpenJ9-shared_classes_misc
             if (getAndVerifyPackage(pkgname, man, url) == null) {
                 try {
                     if (man != null) {
@@ -653,76 +653,76 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
             clazz = defineClass(name, b, 0, b.length, cs);
 
         }
-        /*                                                                      //IBM-shared_classes_misc
-         * Since we have already stored the class path index (of where this resource came from), we can retrieve //IBM-shared_classes_misc
-         * it here.  The storing is done in getResource() in URLClassPath.java.  The index is the specified //IBM-shared_classes_misc
-         * position in the URL search path (see getLoader()).  The storeSharedClass() call below, stores the //IBM-shared_classes_misc
-        * class in the shared class cache for future use.                      //IBM-shared_classes_misc
-         */                                                                     //IBM-shared_classes_misc
-        if (usingSharedClasses()) {                                             //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-            /* Determine the index into the search path for this class */       //IBM-shared_classes_misc
-            int index = res.getClasspathLoadIndex();                            //IBM-shared_classes_misc
-            /* Check to see if we have already cached metadata for this index */ //IBM-shared_classes_misc
-            SharedClassMetaData metadata = sharedClassMetaDataCache.getSharedClassMetaData(index); //IBM-shared_classes_misc
-            /* If we have not already cached the metadata for this index... */  //IBM-shared_classes_misc
-            if (metadata == null) {                                             //IBM-shared_classes_misc
-                /* ... create a new metadata entry */                           //IBM-shared_classes_misc
-                metadata = new SharedClassMetaData(cs, man);                    //IBM-shared_classes_misc
-                /* Cache the metadata for this index for future use */          //IBM-shared_classes_misc
-                sharedClassMetaDataCache.setSharedClassMetaData(index, metadata); //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-            }                                                                   //IBM-shared_classes_misc
-            boolean storeSuccessful = false;                                    //IBM-shared_classes_misc
-            try {                                                               //IBM-shared_classes_misc
-                /* Store class in shared class cache for future use */           //IBM-shared_classes_misc
-                storeSuccessful =                                               //IBM-shared_classes_misc
-                  sharedClassServiceProvider.storeSharedClassURLClasspath(clazz, index); //IBM-shared_classes_misc
-            } catch (Exception e) {                                             //IBM-shared_classes_misc
-                e.printStackTrace();                                            //IBM-shared_classes_misc
-            }                                                                   //IBM-shared_classes_misc
+        /*                                                                      //OpenJ9-shared_classes_misc
+         * Since we have already stored the class path index (of where this resource came from), we can retrieve //OpenJ9-shared_classes_misc
+         * it here.  The storing is done in getResource() in URLClassPath.java.  The index is the specified //OpenJ9-shared_classes_misc
+         * position in the URL search path (see getLoader()).  The storeSharedClass() call below, stores the //OpenJ9-shared_classes_misc
+        * class in the shared class cache for future use.                      //OpenJ9-shared_classes_misc
+         */                                                                     //OpenJ9-shared_classes_misc
+        if (usingSharedClasses()) {                                             //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+            /* Determine the index into the search path for this class */       //OpenJ9-shared_classes_misc
+            int index = res.getClasspathLoadIndex();                            //OpenJ9-shared_classes_misc
+            /* Check to see if we have already cached metadata for this index */ //OpenJ9-shared_classes_misc
+            SharedClassMetaData metadata = sharedClassMetaDataCache.getSharedClassMetaData(index); //OpenJ9-shared_classes_misc
+            /* If we have not already cached the metadata for this index... */  //OpenJ9-shared_classes_misc
+            if (metadata == null) {                                             //OpenJ9-shared_classes_misc
+                /* ... create a new metadata entry */                           //OpenJ9-shared_classes_misc
+                metadata = new SharedClassMetaData(cs, man);                    //OpenJ9-shared_classes_misc
+                /* Cache the metadata for this index for future use */          //OpenJ9-shared_classes_misc
+                sharedClassMetaDataCache.setSharedClassMetaData(index, metadata); //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+            }                                                                   //OpenJ9-shared_classes_misc
+            boolean storeSuccessful = false;                                    //OpenJ9-shared_classes_misc
+            try {                                                               //OpenJ9-shared_classes_misc
+                /* Store class in shared class cache for future use */           //OpenJ9-shared_classes_misc
+                storeSuccessful =                                               //OpenJ9-shared_classes_misc
+                  sharedClassServiceProvider.storeSharedClassURLClasspath(clazz, index); //OpenJ9-shared_classes_misc
+            } catch (Exception e) {                                             //OpenJ9-shared_classes_misc
+                e.printStackTrace();                                            //OpenJ9-shared_classes_misc
+            }                                                                   //OpenJ9-shared_classes_misc
 
         }
 
-         return clazz;                                                          //IBM-shared_classes_misc
+         return clazz;                                                          //OpenJ9-shared_classes_misc
     }
 
-    /*                                                                          //IBM-shared_classes_misc
-     * Defines a class using the class bytes, codesource and manifest           //IBM-shared_classes_misc
-     * obtained from the specified shared class cache. The resulting            //IBM-shared_classes_misc
-     * class must be resolved before it can be used.  This method is            //IBM-shared_classes_misc
-     * used only in a Shared classes context.                                   //IBM-shared_classes_misc
-     */                                                                         //IBM-shared_classes_misc
-    private Class<?> defineClass(String name, byte[] sharedClazz, CodeSource codesource, Manifest man) throws IOException { //IBM-shared_classes_misc
-       int i = name.lastIndexOf('.');                                          //IBM-shared_classes_misc
-       URL url = codesource.getLocation();                                     //IBM-shared_classes_misc
-       if (i != -1) {                                                          //IBM-shared_classes_misc
-           String pkgname = name.substring(0, i);                              //IBM-shared_classes_misc
-           // Check if package already loaded.                                 //IBM-shared_classes_misc
-           if (getAndVerifyPackage(pkgname, man, url) == null) {                                                             //IBM-shared_classes_misc
-               try {                                                           //IBM-shared_classes_misc
-                   if (null != man) {                                          //IBM-shared_classes_misc
-                      definePackage(pkgname, man, url);                        //IBM-shared_classes_misc
-                   } else {                                                    //IBM-shared_classes_misc
-                      definePackage(pkgname, null, null, null, null, null, null, null); //IBM-shared_classes_misc
-                    }                                                          //IBM-shared_classes_misc
-                } catch (IllegalArgumentException iae) {                       //IBM-shared_classes_misc
-                    // https://github.com/eclipse/openj9/issues/3038           //IBM-shared_classes_misc
-                    // Detect and ignore race between two threads defining different classes in the same package. //IBM-shared_classes_misc
-                    if (getAndVerifyPackage(pkgname, man, url) == null) {      //IBM-shared_classes_misc
-                        // Should never happen                                 //IBM-shared_classes_misc
-                        throw new AssertionError("Cannot find package " + pkgname); //IBM-shared_classes_misc
-                    }                                                          //IBM-shared_classes_misc
-                }                                                              //IBM-shared_classes_misc
-           }                                                                   //IBM-shared_classes_misc
-       }                                                                       //IBM-shared_classes_misc
-       /*                                                                      //IBM-shared_classes_misc
-         * Now read the class bytes and define the class.  We don't need to call  //IBM-shared_classes_misc
-         * storeSharedClass(), since its already in our shared class cache.     //IBM-shared_classes_misc
-         */                                                                     //IBM-shared_classes_misc
-        return defineClass(name, sharedClazz, 0, sharedClazz.length, codesource); //IBM-shared_classes_misc
-     }                                                                          //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
+    /*                                                                          //OpenJ9-shared_classes_misc
+     * Defines a class using the class bytes, codesource and manifest           //OpenJ9-shared_classes_misc
+     * obtained from the specified shared class cache. The resulting            //OpenJ9-shared_classes_misc
+     * class must be resolved before it can be used.  This method is            //OpenJ9-shared_classes_misc
+     * used only in a Shared classes context.                                   //OpenJ9-shared_classes_misc
+     */                                                                         //OpenJ9-shared_classes_misc
+    private Class<?> defineClass(String name, byte[] sharedClazz, CodeSource codesource, Manifest man) throws IOException { //OpenJ9-shared_classes_misc
+       int i = name.lastIndexOf('.');                                          //OpenJ9-shared_classes_misc
+       URL url = codesource.getLocation();                                     //OpenJ9-shared_classes_misc
+       if (i != -1) {                                                          //OpenJ9-shared_classes_misc
+           String pkgname = name.substring(0, i);                              //OpenJ9-shared_classes_misc
+           // Check if package already loaded.                                 //OpenJ9-shared_classes_misc
+           if (getAndVerifyPackage(pkgname, man, url) == null) {                                                             //OpenJ9-shared_classes_misc
+               try {                                                           //OpenJ9-shared_classes_misc
+                   if (null != man) {                                          //OpenJ9-shared_classes_misc
+                      definePackage(pkgname, man, url);                        //OpenJ9-shared_classes_misc
+                   } else {                                                    //OpenJ9-shared_classes_misc
+                      definePackage(pkgname, null, null, null, null, null, null, null); //OpenJ9-shared_classes_misc
+                    }                                                          //OpenJ9-shared_classes_misc
+                } catch (IllegalArgumentException iae) {                       //OpenJ9-shared_classes_misc
+                    // https://github.com/eclipse/openj9/issues/3038           //OpenJ9-shared_classes_misc
+                    // Detect and ignore race between two threads defining different classes in the same package. //OpenJ9-shared_classes_misc
+                    if (getAndVerifyPackage(pkgname, man, url) == null) {      //OpenJ9-shared_classes_misc
+                        // Should never happen                                 //OpenJ9-shared_classes_misc
+                        throw new AssertionError("Cannot find package " + pkgname); //OpenJ9-shared_classes_misc
+                    }                                                          //OpenJ9-shared_classes_misc
+                }                                                              //OpenJ9-shared_classes_misc
+           }                                                                   //OpenJ9-shared_classes_misc
+       }                                                                       //OpenJ9-shared_classes_misc
+       /*                                                                      //OpenJ9-shared_classes_misc
+         * Now read the class bytes and define the class.  We don't need to call  //OpenJ9-shared_classes_misc
+         * storeSharedClass(), since its already in our shared class cache.     //OpenJ9-shared_classes_misc
+         */                                                                     //OpenJ9-shared_classes_misc
+        return defineClass(name, sharedClazz, 0, sharedClazz.length, codesource); //OpenJ9-shared_classes_misc
+     }                                                                          //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
 
     /**
      * Defines a new package by name in this {@code URLClassLoader}.
@@ -1040,33 +1040,33 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
         );
         ClassLoader.registerAsParallelCapable();
     }
-                                                                                //IBM-shared_classes_misc
-final class ClassFinder implements PrivilegedExceptionAction<Class<?>>          //IBM-shared_classes_misc
-  {                                                                              //IBM-shared_classes_misc
-     private String name;                                                        //IBM-shared_classes_misc
-     private ClassLoader classloader;                                            //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-     public ClassFinder(String name, ClassLoader loader) {                       //IBM-shared_classes_misc
-        this.name = name;                                                        //IBM-shared_classes_misc
-        this.classloader = loader;                                               //IBM-shared_classes_misc
-     }                                                                           //IBM-shared_classes_misc
-                                                                                 //IBM-shared_classes_misc
-     public Class<?> run() throws ClassNotFoundException {                         //IBM-shared_classes_misc
-	String path = name.replace('.', '/').concat(".class");                   //IBM-shared_classes_misc
-        try {                                                                    //IBM-shared_classes_misc
-            Resource res = ucp.getResource(path, false, classloader);            //IBM-shared_classes_misc
-            if (res != null)                                                     //IBM-shared_classes_misc
-                return defineClass(name, res);                                   //IBM-shared_classes_misc
-        } catch (IOException e) {                                                //IBM-shared_classes_misc
-                throw new ClassNotFoundException(name, e);                       //IBM-shared_classes_misc
-        }                                                                        //IBM-shared_classes_misc
-        return null;                                                             //IBM-shared_classes_misc
-     }                                                                           //IBM-shared_classes_misc
-  }                                                                              //IBM-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+final class ClassFinder implements PrivilegedExceptionAction<Class<?>>          //OpenJ9-shared_classes_misc
+  {                                                                              //OpenJ9-shared_classes_misc
+     private String name;                                                        //OpenJ9-shared_classes_misc
+     private ClassLoader classloader;                                            //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+     public ClassFinder(String name, ClassLoader loader) {                       //OpenJ9-shared_classes_misc
+        this.name = name;                                                        //OpenJ9-shared_classes_misc
+        this.classloader = loader;                                               //OpenJ9-shared_classes_misc
+     }                                                                           //OpenJ9-shared_classes_misc
+                                                                                 //OpenJ9-shared_classes_misc
+     public Class<?> run() throws ClassNotFoundException {                         //OpenJ9-shared_classes_misc
+	String path = name.replace('.', '/').concat(".class");                   //OpenJ9-shared_classes_misc
+        try {                                                                    //OpenJ9-shared_classes_misc
+            Resource res = ucp.getResource(path, false, classloader);            //OpenJ9-shared_classes_misc
+            if (res != null)                                                     //OpenJ9-shared_classes_misc
+                return defineClass(name, res);                                   //OpenJ9-shared_classes_misc
+        } catch (IOException e) {                                                //OpenJ9-shared_classes_misc
+                throw new ClassNotFoundException(name, e);                       //OpenJ9-shared_classes_misc
+        }                                                                        //OpenJ9-shared_classes_misc
+        return null;                                                             //OpenJ9-shared_classes_misc
+     }                                                                           //OpenJ9-shared_classes_misc
+  }                                                                              //OpenJ9-shared_classes_misc
 }
 
-                                                                                //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
 final class FactoryURLClassLoader extends URLClassLoader {
 
     static {
@@ -1097,4 +1097,4 @@ final class FactoryURLClassLoader extends URLClassLoader {
         return super.loadClass(name, resolve);
     }
 }
-//IBM-shared_classes_misc
+//OpenJ9-shared_classes_misc

--- a/src/java.base/share/classes/jdk/internal/loader/BuiltinClassLoader.java
+++ b/src/java.base/share/classes/jdk/internal/loader/BuiltinClassLoader.java
@@ -31,7 +31,7 @@
 
 package jdk.internal.loader;
 
-import com.ibm.sharedclasses.spi.SharedClassProvider; 				//IBM-shared_classes_misc
+import com.ibm.sharedclasses.spi.SharedClassProvider; 				//OpenJ9-shared_classes_misc
 
 import java.io.File;
 import java.io.FilePermission;
@@ -45,9 +45,9 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;							//IBM-shared_classes_misc
-import java.nio.file.Path;							//IBM-shared_classes_misc
-import java.nio.file.Paths;							//IBM-shared_classes_misc
+import java.nio.file.Files;							//OpenJ9-shared_classes_misc
+import java.nio.file.Path;							//OpenJ9-shared_classes_misc
+import java.nio.file.Paths;							//OpenJ9-shared_classes_misc
 import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.CodeSigner;
@@ -66,10 +66,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.ServiceLoader;							//IBM-shared_classes_misc
+import java.util.ServiceLoader;							//OpenJ9-shared_classes_misc
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.function.IntConsumer;						//IBM-shared_classes_misc
+import java.util.function.IntConsumer;						//OpenJ9-shared_classes_misc
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.stream.Stream;
@@ -121,161 +121,161 @@ public class BuiltinClassLoader
     // the URL class path, or null if there is no class path
     private final URLClassPath ucp;
 
-    // Private member fields used for Shared classes                          		//IBM-shared_classes_misc
-    private static URL jimageURL;													//IBM-shared_classes_misc
-    private SharedClassProvider sharedClassServiceProvider ;						//IBM-shared_classes_misc
-    private SharedClassMetaDataCache sharedClassMetaDataCache;                 		//IBM-shared_classes_misc
-    																				//IBM-shared_classes_misc
-    /*                                                                           	//IBM-shared_classes_misc
-     * Wrapper class for maintaining the index of where the metadata (codesource and manifest)  //IBM-shared_classes_misc
-     * is found - used only in Shared classes context.                           	//IBM-shared_classes_misc
-     */                                                                          	//IBM-shared_classes_misc
-    private static class SharedClassIndexHolder {  								 	//IBM-shared_classes_misc
-        int index;                                                              	//IBM-shared_classes_misc
-    																				//IBM-shared_classes_misc
-        public void setIndex(int index) {                                        	//IBM-shared_classes_misc
-            this.index = index;                                                  	//IBM-shared_classes_misc
-        }                                                                        	//IBM-shared_classes_misc
-    }                                                                            	//IBM-shared_classes_misc
-																					//IBM-shared_classes_misc
-    /*                                                                           	//IBM-shared_classes_misc
-     * Wrapper class for internal storage of metadata (codesource and manifest) associated with   //IBM-shared_classes_misc
-     * shared class - used only in Shared classes context.                       	//IBM-shared_classes_misc
-     */                                                                          	//IBM-shared_classes_misc
-    private class SharedClassMetaData {                                          	//IBM-shared_classes_misc
-        private CodeSource codeSource;                                           	//IBM-shared_classes_misc
-        private Manifest manifest;                                               	//IBM-shared_classes_misc
-																					//IBM-shared_classes_misc
-        SharedClassMetaData(CodeSource codeSource, Manifest manifest) {          	//IBM-shared_classes_misc
-            this.codeSource = codeSource;                                        	//IBM-shared_classes_misc
-            this.manifest = manifest;                                            	//IBM-shared_classes_misc
-        }                                                                        	//IBM-shared_classes_misc
-        public CodeSource getCodeSource() { return codeSource; }                 	//IBM-shared_classes_misc
-        public Manifest getManifest() { return manifest; }                       	//IBM-shared_classes_misc
-    }                                                                            	//IBM-shared_classes_misc
-																					//IBM-shared_classes_misc
-    /*                                                                           	//IBM-shared_classes_misc
-     * Represents a collection of SharedClassMetaData objects retrievable by     	//IBM-shared_classes_misc
-     * index.                                                                    	//IBM-shared_classes_misc
-     */                                                                          	//IBM-shared_classes_misc
-    private class SharedClassMetaDataCache {                                   	//IBM-shared_classes_misc
-        private final static int BLOCKSIZE = 10;                                 	//IBM-shared_classes_misc
-        private SharedClassMetaData[] store;                                     	//IBM-shared_classes_misc
-																					//IBM-shared_classes_misc
-        public SharedClassMetaDataCache(int initialSize) {                       	//IBM-shared_classes_misc
-            // Allocate space for an initial amount of metadata entries				//IBM-shared_classes_misc
-            store = new SharedClassMetaData[initialSize];                        	//IBM-shared_classes_misc
-        }                                                                        	//IBM-shared_classes_misc
-																					//IBM-shared_classes_misc
-        /**                                                                      	//IBM-shared_classes_misc
-         * Retrieves the SharedClassMetaData stored at the given index, or null  	//IBM-shared_classes_misc
-         * if no SharedClassMetaData was previously stored at the given index    	//IBM-shared_classes_misc
-         * or the index is out of range.                                         	//IBM-shared_classes_misc
-         */                                                                      	//IBM-shared_classes_misc
-        public synchronized SharedClassMetaData getSharedClassMetaData(int index) { //IBM-shared_classes_misc
-            if (index < 0 || store.length < (index+1)) {                         	//IBM-shared_classes_misc
-                return null;                                                     	//IBM-shared_classes_misc
-            }                                                                    	//IBM-shared_classes_misc
-            return store[index];                                                 	//IBM-shared_classes_misc
-        }                                                                        	//IBM-shared_classes_misc
-																					//IBM-shared_classes_misc
-        /**                                                                      	//IBM-shared_classes_misc
-         * Stores the supplied SharedClassMetaData at the given index in the     	//IBM-shared_classes_misc
-         * store. The store will be grown to contain the index if necessary.     	//IBM-shared_classes_misc
-         */                                                                      	//IBM-shared_classes_misc
-        public synchronized void setSharedClassMetaData(int index,               	//IBM-shared_classes_misc
-                                                     SharedClassMetaData data) {  	//IBM-shared_classes_misc
-            ensureSize(index);                                                   	//IBM-shared_classes_misc
-            store[index] = data;                                                 	//IBM-shared_classes_misc
-        }                                                                        	//IBM-shared_classes_misc
-																					//IBM-shared_classes_misc
-        // Ensure that the store can hold at least index number of entries    		//IBM-shared_classes_misc
-        private synchronized void ensureSize(int index) {                        	//IBM-shared_classes_misc
-            if (store.length < (index+1)) {                                      	//IBM-shared_classes_misc
-                int newSize = (index+BLOCKSIZE);                                 	//IBM-shared_classes_misc
-                SharedClassMetaData[] newSCMDS = new SharedClassMetaData[newSize];  //IBM-shared_classes_misc
-                System.arraycopy(store, 0, newSCMDS, 0, store.length);           	//IBM-shared_classes_misc
-                store = newSCMDS;                                                	//IBM-shared_classes_misc
-            }                                                                    	//IBM-shared_classes_misc
-        }                                                                        	//IBM-shared_classes_misc
+    // Private member fields used for Shared classes                          		//OpenJ9-shared_classes_misc
+    private static URL jimageURL;													//OpenJ9-shared_classes_misc
+    private SharedClassProvider sharedClassServiceProvider ;						//OpenJ9-shared_classes_misc
+    private SharedClassMetaDataCache sharedClassMetaDataCache;                 		//OpenJ9-shared_classes_misc
+    																				//OpenJ9-shared_classes_misc
+    /*                                                                           	//OpenJ9-shared_classes_misc
+     * Wrapper class for maintaining the index of where the metadata (codesource and manifest)  //OpenJ9-shared_classes_misc
+     * is found - used only in Shared classes context.                           	//OpenJ9-shared_classes_misc
+     */                                                                          	//OpenJ9-shared_classes_misc
+    private static class SharedClassIndexHolder {  								 	//OpenJ9-shared_classes_misc
+        int index;                                                              	//OpenJ9-shared_classes_misc
+    																				//OpenJ9-shared_classes_misc
+        public void setIndex(int index) {                                        	//OpenJ9-shared_classes_misc
+            this.index = index;                                                  	//OpenJ9-shared_classes_misc
+        }                                                                        	//OpenJ9-shared_classes_misc
+    }                                                                            	//OpenJ9-shared_classes_misc
+																					//OpenJ9-shared_classes_misc
+    /*                                                                           	//OpenJ9-shared_classes_misc
+     * Wrapper class for internal storage of metadata (codesource and manifest) associated with   //OpenJ9-shared_classes_misc
+     * shared class - used only in Shared classes context.                       	//OpenJ9-shared_classes_misc
+     */                                                                          	//OpenJ9-shared_classes_misc
+    private class SharedClassMetaData {                                          	//OpenJ9-shared_classes_misc
+        private CodeSource codeSource;                                           	//OpenJ9-shared_classes_misc
+        private Manifest manifest;                                               	//OpenJ9-shared_classes_misc
+																					//OpenJ9-shared_classes_misc
+        SharedClassMetaData(CodeSource codeSource, Manifest manifest) {          	//OpenJ9-shared_classes_misc
+            this.codeSource = codeSource;                                        	//OpenJ9-shared_classes_misc
+            this.manifest = manifest;                                            	//OpenJ9-shared_classes_misc
+        }                                                                        	//OpenJ9-shared_classes_misc
+        public CodeSource getCodeSource() { return codeSource; }                 	//OpenJ9-shared_classes_misc
+        public Manifest getManifest() { return manifest; }                       	//OpenJ9-shared_classes_misc
+    }                                                                            	//OpenJ9-shared_classes_misc
+																					//OpenJ9-shared_classes_misc
+    /*                                                                           	//OpenJ9-shared_classes_misc
+     * Represents a collection of SharedClassMetaData objects retrievable by     	//OpenJ9-shared_classes_misc
+     * index.                                                                    	//OpenJ9-shared_classes_misc
+     */                                                                          	//OpenJ9-shared_classes_misc
+    private class SharedClassMetaDataCache {                                   	//OpenJ9-shared_classes_misc
+        private final static int BLOCKSIZE = 10;                                 	//OpenJ9-shared_classes_misc
+        private SharedClassMetaData[] store;                                     	//OpenJ9-shared_classes_misc
+																					//OpenJ9-shared_classes_misc
+        public SharedClassMetaDataCache(int initialSize) {                       	//OpenJ9-shared_classes_misc
+            // Allocate space for an initial amount of metadata entries				//OpenJ9-shared_classes_misc
+            store = new SharedClassMetaData[initialSize];                        	//OpenJ9-shared_classes_misc
+        }                                                                        	//OpenJ9-shared_classes_misc
+																					//OpenJ9-shared_classes_misc
+        /**                                                                      	//OpenJ9-shared_classes_misc
+         * Retrieves the SharedClassMetaData stored at the given index, or null  	//OpenJ9-shared_classes_misc
+         * if no SharedClassMetaData was previously stored at the given index    	//OpenJ9-shared_classes_misc
+         * or the index is out of range.                                         	//OpenJ9-shared_classes_misc
+         */                                                                      	//OpenJ9-shared_classes_misc
+        public synchronized SharedClassMetaData getSharedClassMetaData(int index) { //OpenJ9-shared_classes_misc
+            if (index < 0 || store.length < (index+1)) {                         	//OpenJ9-shared_classes_misc
+                return null;                                                     	//OpenJ9-shared_classes_misc
+            }                                                                    	//OpenJ9-shared_classes_misc
+            return store[index];                                                 	//OpenJ9-shared_classes_misc
+        }                                                                        	//OpenJ9-shared_classes_misc
+																					//OpenJ9-shared_classes_misc
+        /**                                                                      	//OpenJ9-shared_classes_misc
+         * Stores the supplied SharedClassMetaData at the given index in the     	//OpenJ9-shared_classes_misc
+         * store. The store will be grown to contain the index if necessary.     	//OpenJ9-shared_classes_misc
+         */                                                                      	//OpenJ9-shared_classes_misc
+        public synchronized void setSharedClassMetaData(int index,               	//OpenJ9-shared_classes_misc
+                                                     SharedClassMetaData data) {  	//OpenJ9-shared_classes_misc
+            ensureSize(index);                                                   	//OpenJ9-shared_classes_misc
+            store[index] = data;                                                 	//OpenJ9-shared_classes_misc
+        }                                                                        	//OpenJ9-shared_classes_misc
+																					//OpenJ9-shared_classes_misc
+        // Ensure that the store can hold at least index number of entries    		//OpenJ9-shared_classes_misc
+        private synchronized void ensureSize(int index) {                        	//OpenJ9-shared_classes_misc
+            if (store.length < (index+1)) {                                      	//OpenJ9-shared_classes_misc
+                int newSize = (index+BLOCKSIZE);                                 	//OpenJ9-shared_classes_misc
+                SharedClassMetaData[] newSCMDS = new SharedClassMetaData[newSize];  //OpenJ9-shared_classes_misc
+                System.arraycopy(store, 0, newSCMDS, 0, store.length);           	//OpenJ9-shared_classes_misc
+                store = newSCMDS;                                                	//OpenJ9-shared_classes_misc
+            }                                                                    	//OpenJ9-shared_classes_misc
+        }                                                                        	//OpenJ9-shared_classes_misc
     }
 	
-	/*                                                                           	//IBM-shared_classes_misc
-	 * Initialize support for shared classes.                                    	//IBM-shared_classes_misc
-	 */																				//IBM-shared_classes_misc
-	public synchronized void initializeSharedClassesSupport() {						//IBM-shared_classes_misc
-		int ucpLength = 0;															//IBM-shared_classes_misc
-		if (isSharedClassesEnabled() 													//IBM-shared_classes_miscs
-			&& (null == sharedClassServiceProvider)										//IBM-shared_classes_misc
-		) {																				//IBM-shared_classes_misc
-			URL[] initialClassPath = null;												//IBM-shared_classes_misc
-			if (ucp != null) {															//IBM-shared_classes_misc
-				initialClassPath = ucp.getURLs();										//IBM-shared_classes_misc
-				ucpLength = initialClassPath.length;									//IBM-shared_classes_misc
-			}																			//IBM-shared_classes_misc
-			ServiceLoader<SharedClassProvider> sl = ServiceLoader.load(SharedClassProvider.class);	//IBM-shared_classes_misc
-			for (SharedClassProvider p : sl) {														//IBM-shared_classes_misc
-				if (null != p) {																	//IBM-shared_classes_misc
-					if (null != p.initializeProvider(this, initialClassPath, true, true)){			//IBM-shared_classes_misc
-						sharedClassServiceProvider = p;												//IBM-shared_classes_misc
-						if (null != ucp) {															//IBM-shared_classes_misc
-							ucp.setSharedClassProvider(sharedClassServiceProvider);					//IBM-shared_classes_misc
-						}																			//IBM-shared_classes_misc
-						break;																		//IBM-shared_classes_misc
-					}																				//IBM-shared_classes_misc
-				}																					//IBM-shared_classes_misc
-			}																						//IBM-shared_classes_misc
-		}																							//IBM-shared_classes_misc
+	/*                                                                           	//OpenJ9-shared_classes_misc
+	 * Initialize support for shared classes.                                    	//OpenJ9-shared_classes_misc
+	 */																				//OpenJ9-shared_classes_misc
+	public synchronized void initializeSharedClassesSupport() {						//OpenJ9-shared_classes_misc
+		int ucpLength = 0;															//OpenJ9-shared_classes_misc
+		if (isSharedClassesEnabled() 													//OpenJ9-shared_classes_miscs
+			&& (null == sharedClassServiceProvider)										//OpenJ9-shared_classes_misc
+		) {																				//OpenJ9-shared_classes_misc
+			URL[] initialClassPath = null;												//OpenJ9-shared_classes_misc
+			if (ucp != null) {															//OpenJ9-shared_classes_misc
+				initialClassPath = ucp.getURLs();										//OpenJ9-shared_classes_misc
+				ucpLength = initialClassPath.length;									//OpenJ9-shared_classes_misc
+			}																			//OpenJ9-shared_classes_misc
+			ServiceLoader<SharedClassProvider> sl = ServiceLoader.load(SharedClassProvider.class);	//OpenJ9-shared_classes_misc
+			for (SharedClassProvider p : sl) {														//OpenJ9-shared_classes_misc
+				if (null != p) {																	//OpenJ9-shared_classes_misc
+					if (null != p.initializeProvider(this, initialClassPath, true, true)){			//OpenJ9-shared_classes_misc
+						sharedClassServiceProvider = p;												//OpenJ9-shared_classes_misc
+						if (null != ucp) {															//OpenJ9-shared_classes_misc
+							ucp.setSharedClassProvider(sharedClassServiceProvider);					//OpenJ9-shared_classes_misc
+						}																			//OpenJ9-shared_classes_misc
+						break;																		//OpenJ9-shared_classes_misc
+					}																				//OpenJ9-shared_classes_misc
+				}																					//OpenJ9-shared_classes_misc
+			}																						//OpenJ9-shared_classes_misc
+		}																							//OpenJ9-shared_classes_misc
 		
-		if (usingSharedClasses() && null == sharedClassMetaDataCache) {            					//IBM-shared_classes_misc
-			// Create a metadata cache                                   							//IBM-shared_classes_misc
-			sharedClassMetaDataCache = new SharedClassMetaDataCache(ucpLength);  					//IBM-shared_classes_misc
-		}                                                                    						//IBM-shared_classes_misc
-	}                                																//IBM-shared_classes_misc
-    /*                                                                          					//IBM-shared_classes_misc
-     * Return true if shared classes support is active, otherwise false.         					//IBM-shared_classes_misc
-     */                                                                          					//IBM-shared_classes_misc
-    private boolean usingSharedClasses() {                                       					//IBM-shared_classes_misc
-        return (sharedClassServiceProvider != null);         										//IBM-shared_classes_misc
+		if (usingSharedClasses() && null == sharedClassMetaDataCache) {            					//OpenJ9-shared_classes_misc
+			// Create a metadata cache                                   							//OpenJ9-shared_classes_misc
+			sharedClassMetaDataCache = new SharedClassMetaDataCache(ucpLength);  					//OpenJ9-shared_classes_misc
+		}                                                                    						//OpenJ9-shared_classes_misc
+	}                                																//OpenJ9-shared_classes_misc
+    /*                                                                          					//OpenJ9-shared_classes_misc
+     * Return true if shared classes support is active, otherwise false.         					//OpenJ9-shared_classes_misc
+     */                                                                          					//OpenJ9-shared_classes_misc
+    private boolean usingSharedClasses() {                                       					//OpenJ9-shared_classes_misc
+        return (sharedClassServiceProvider != null);         										//OpenJ9-shared_classes_misc
     }
 	
-    /*                                                                          				//IBM-shared_classes_misc
-     * Returns if -Xshareclasses is used in the command line         							//IBM-shared_classes_misc
-     */  																						//IBM-shared_classes_misc
-    private static boolean isSharedClassesEnabled() {											//IBM-shared_classes_misc
-    	/* 																						//IBM-shared_classes_misc
-    	 * Lambda expression can't be used here due to bootstrap problem 						//IBM-shared_classes_misc
-    	 * when jdk.internal.lambda.dumpProxyClasses is enabled.								//IBM-shared_classes_misc
-    	 * More details are at https://github.com/eclipse/openj9/issues/3399					//IBM-shared_classes_misc
-    	 */																						//IBM-shared_classes_misc
-    	return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {					//IBM-shared_classes_misc
-    		public Boolean run() {																//IBM-shared_classes_misc
-    			return Boolean.getBoolean("com.ibm.oti.shared.enabled");						//IBM-shared_classes_misc
-    		}																					//IBM-shared_classes_misc
-    	});																						//IBM-shared_classes_misc
-   	}																							//IBM-shared_classes_misc
+    /*                                                                          				//OpenJ9-shared_classes_misc
+     * Returns if -Xshareclasses is used in the command line         							//OpenJ9-shared_classes_misc
+     */  																						//OpenJ9-shared_classes_misc
+    private static boolean isSharedClassesEnabled() {											//OpenJ9-shared_classes_misc
+    	/* 																						//OpenJ9-shared_classes_misc
+    	 * Lambda expression can't be used here due to bootstrap problem 						//OpenJ9-shared_classes_misc
+    	 * when jdk.internal.lambda.dumpProxyClasses is enabled.								//OpenJ9-shared_classes_misc
+    	 * More details are at https://github.com/eclipse/openj9/issues/3399					//OpenJ9-shared_classes_misc
+    	 */																						//OpenJ9-shared_classes_misc
+    	return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {					//OpenJ9-shared_classes_misc
+    		public Boolean run() {																//OpenJ9-shared_classes_misc
+    			return Boolean.getBoolean("com.ibm.oti.shared.enabled");						//OpenJ9-shared_classes_misc
+    		}																					//OpenJ9-shared_classes_misc
+    	});																						//OpenJ9-shared_classes_misc
+   	}																							//OpenJ9-shared_classes_misc
 
-    /*                                                                          					//IBM-shared_classes_misc
-     * Gets the URL of the jimage file         														//IBM-shared_classes_misc
-     */  																							//IBM-shared_classes_misc
-	private static void setJimageURL() {															//IBM-shared_classes_misc
-    	/* 																						//IBM-shared_classes_misc
-    	 * Lambda expression can't be used here due to bootstrap problem 						//IBM-shared_classes_misc
-    	 * when jdk.internal.lambda.dumpProxyClasses is enabled.								//IBM-shared_classes_misc
-    	 * More details are at https://github.com/eclipse/openj9/issues/3399					//IBM-shared_classes_misc
-    	 */																						//IBM-shared_classes_misc
-		String javaHome = AccessController.doPrivileged( new PrivilegedAction<String>() {		//IBM-shared_classes_misc
-			public String run() {																//IBM-shared_classes_misc
-				return System.getProperty("java.home");											//IBM-shared_classes_misc
-			}																					//IBM-shared_classes_misc
-		});																						//IBM-shared_classes_misc
-		Path p = Paths.get(javaHome, "lib", "modules");											//IBM-shared_classes_misc
-		if (Files.isRegularFile(p)) {															//IBM-shared_classes_misc
-			try {																				//IBM-shared_classes_misc
-				jimageURL = p.toUri().toURL();													//IBM-shared_classes_misc
-			} catch (MalformedURLException e) {}												//IBM-shared_classes_misc
-		}																						//IBM-shared_classes_misc
-	}																							//IBM-shared_classes_misc
+    /*                                                                          					//OpenJ9-shared_classes_misc
+     * Gets the URL of the jimage file         														//OpenJ9-shared_classes_misc
+     */  																							//OpenJ9-shared_classes_misc
+	private static void setJimageURL() {															//OpenJ9-shared_classes_misc
+    	/* 																						//OpenJ9-shared_classes_misc
+    	 * Lambda expression can't be used here due to bootstrap problem 						//OpenJ9-shared_classes_misc
+    	 * when jdk.internal.lambda.dumpProxyClasses is enabled.								//OpenJ9-shared_classes_misc
+    	 * More details are at https://github.com/eclipse/openj9/issues/3399					//OpenJ9-shared_classes_misc
+    	 */																						//OpenJ9-shared_classes_misc
+		String javaHome = AccessController.doPrivileged( new PrivilegedAction<String>() {		//OpenJ9-shared_classes_misc
+			public String run() {																//OpenJ9-shared_classes_misc
+				return System.getProperty("java.home");											//OpenJ9-shared_classes_misc
+			}																					//OpenJ9-shared_classes_misc
+		});																						//OpenJ9-shared_classes_misc
+		Path p = Paths.get(javaHome, "lib", "modules");											//OpenJ9-shared_classes_misc
+		if (Files.isRegularFile(p)) {															//OpenJ9-shared_classes_misc
+			try {																				//OpenJ9-shared_classes_misc
+				jimageURL = p.toUri().toURL();													//OpenJ9-shared_classes_misc
+			} catch (MalformedURLException e) {}												//OpenJ9-shared_classes_misc
+		}																						//OpenJ9-shared_classes_misc
+	}																							//OpenJ9-shared_classes_misc
     
     /**
      * A module defined/loaded by a built-in class loader.
@@ -287,7 +287,7 @@ public class BuiltinClassLoader
         private final BuiltinClassLoader loader;
         private final ModuleReference mref;
         private final URL codeSourceURL;          // may be null
-		private final URL fileURL;																//IBM-shared_classes_misc
+		private final URL fileURL;																//OpenJ9-shared_classes_misc
 
         LoadedModule(BuiltinClassLoader loader, ModuleReference mref) {
             URL url = null;
@@ -299,7 +299,7 @@ public class BuiltinClassLoader
             this.loader = loader;
             this.mref = mref;
             this.codeSourceURL = url;
-			this.fileURL = convertJrtToFileURL();												//IBM-shared_classes_misc
+			this.fileURL = convertJrtToFileURL();												//OpenJ9-shared_classes_misc
         }
 
         BuiltinClassLoader loader() { return loader; }
@@ -307,17 +307,17 @@ public class BuiltinClassLoader
         String name() { return mref.descriptor().name(); }
         URL codeSourceURL() { return codeSourceURL; }
 		URL fileURL() {return fileURL;}
-		URL convertJrtToFileURL() {																//IBM-shared_classes_misc
-			if (null == jimageURL) {															//IBM-shared_classes_misc
-			   setJimageURL();																	//IBM-shared_classes_misc
-			}																					//IBM-shared_classes_misc
-			if (null != jimageURL) {															//IBM-shared_classes_misc
-				if (codeSourceURL.getProtocol().equals("jrt")) {								//IBM-shared_classes_misc
-					return jimageURL;															//IBM-shared_classes_misc
-				}																				//IBM-shared_classes_misc
-			}																					//IBM-shared_classes_misc
-			return this.codeSourceURL;															//IBM-shared_classes_misc
-		}																						//IBM-shared_classes_misc
+		URL convertJrtToFileURL() {																//OpenJ9-shared_classes_misc
+			if (null == jimageURL) {															//OpenJ9-shared_classes_misc
+			   setJimageURL();																	//OpenJ9-shared_classes_misc
+			}																					//OpenJ9-shared_classes_misc
+			if (null != jimageURL) {															//OpenJ9-shared_classes_misc
+				if (codeSourceURL.getProtocol().equals("jrt")) {								//OpenJ9-shared_classes_misc
+					return jimageURL;															//OpenJ9-shared_classes_misc
+				}																				//OpenJ9-shared_classes_misc
+			}																					//OpenJ9-shared_classes_misc
+			return this.codeSourceURL;															//OpenJ9-shared_classes_misc
+		}																						//OpenJ9-shared_classes_misc
     }
 
 
@@ -864,15 +864,15 @@ public class BuiltinClassLoader
      * @return the resulting Class or {@code null} if not found
      */
     private Class<?> findClassInModuleOrNull(LoadedModule loadedModule, String cn) {
-		Class<?> c = null;												//IBM-shared_classes_misc
-		PrivilegedAction<ModuleReader> paModuleReaderFor = () -> moduleReaderFor(loadedModule.mref()); //IBM-shared_classes_misc
-		ModuleReader reader = AccessController.doPrivileged(paModuleReaderFor); //IBM-shared_classes_misc
-		if (!(reader instanceof PatchedModuleReader)) {					//IBM-shared_classes_misc
-			c = findClassInSharedClassesCache(cn, loadedModule, false);	//IBM-shared_classes_misc
-		}																//IBM-shared_classes_misc
-		if (null != c) {												//IBM-shared_classes_misc
-			return c;													//IBM-shared_classes_misc
-		}																//IBM-shared_classes_misc
+		Class<?> c = null;												//OpenJ9-shared_classes_misc
+		PrivilegedAction<ModuleReader> paModuleReaderFor = () -> moduleReaderFor(loadedModule.mref()); //OpenJ9-shared_classes_misc
+		ModuleReader reader = AccessController.doPrivileged(paModuleReaderFor); //OpenJ9-shared_classes_misc
+		if (!(reader instanceof PatchedModuleReader)) {					//OpenJ9-shared_classes_misc
+			c = findClassInSharedClassesCache(cn, loadedModule, false);	//OpenJ9-shared_classes_misc
+		}																//OpenJ9-shared_classes_misc
+		if (null != c) {												//OpenJ9-shared_classes_misc
+			return c;													//OpenJ9-shared_classes_misc
+		}																//OpenJ9-shared_classes_misc
 
         if (System.getSecurityManager() == null) {
 
@@ -890,10 +890,10 @@ public class BuiltinClassLoader
      * @return the resulting Class or {@code null} if not found
      */
     private Class<?> findClassOnClassPathOrNull(String cn) {
-		Class<?> c = findClassInSharedClassesCache(cn, null, true);		//IBM-shared_classes_misc
-		if (null != c) {												//IBM-shared_classes_misc
-			return c;													//IBM-shared_classes_misc
-		}																//IBM-shared_classes_misc
+		Class<?> c = findClassInSharedClassesCache(cn, null, true);		//OpenJ9-shared_classes_misc
+		if (null != c) {												//OpenJ9-shared_classes_misc
+			return c;													//OpenJ9-shared_classes_misc
+		}																//OpenJ9-shared_classes_misc
 
         String path = cn.replace('.', '/').concat(".class");
         if (System.getSecurityManager() == null) {
@@ -925,74 +925,74 @@ public class BuiltinClassLoader
         }
     }
     
-	 /**																											//IBM-shared_classes_misc
-     * Finds the class with the specified binary name in the shared classes cache.									//IBM-shared_classes_misc
-     *																												//IBM-shared_classes_misc
-     * @return the resulting Class or {@code null} if not found														//IBM-shared_classes_misc
-     */																												//IBM-shared_classes_misc
-	private Class<?> findClassInSharedClassesCache(String cn, LoadedModule module, boolean pkgCheck) {				//IBM-shared_classes_misc
-		if (usingSharedClasses()) {																					//IBM-shared_classes_misc
-			byte[] sharedClazz = null;																				//IBM-shared_classes_misc
-			CodeSource cs = null;																					//IBM-shared_classes_misc
-			Manifest man = null;																					//IBM-shared_classes_misc
-			boolean defineClass = false;																			//IBM-shared_classes_misc
-			if (null == module) {																					//IBM-shared_classes_misc
-				SharedClassIndexHolder sharedClassIndexHolder = new SharedClassIndexHolder(); 						//IBM-shared_classes_misc
-				IntConsumer consumer = (i)->sharedClassIndexHolder.setIndex(i); 									//IBM-shared_classes_misc
-				sharedClazz = sharedClassServiceProvider.findSharedClassURLClasspath(cn, consumer); 				//IBM-shared_classes_misc
-				if (sharedClazz != null) {                                      									//IBM-shared_classes_misc
-					int indexFoundData = sharedClassIndexHolder.index;          									//IBM-shared_classes_misc
-					SharedClassMetaData metadata = sharedClassMetaDataCache.getSharedClassMetaData(indexFoundData); //IBM-shared_classes_misc
-					if (metadata != null) {   																		//IBM-shared_classes_misc
-						cs = metadata.getCodeSource();																//IBM-shared_classes_misc
-						man = metadata.getManifest();																//IBM-shared_classes_misc
-						defineClass = true;																			//IBM-shared_classes_misc
-					} 																								//IBM-shared_classes_misc
-				}																									//IBM-shared_classes_misc
-			} else {																								//IBM-shared_classes_misc
-				// module has its own URL, find the class using the module URL										//IBM-shared_classes_misc
-				sharedClazz = sharedClassServiceProvider.findSharedClassURL(module.fileURL(), cn);					//IBM-shared_classes_misc
-				if (sharedClazz != null) { 																			//IBM-shared_classes_misc
-					cs = new CodeSource(module.codeSourceURL(), (CodeSigner[]) null);								//IBM-shared_classes_misc
-					defineClass = true;																				//IBM-shared_classes_misc
-				}																									//IBM-shared_classes_misc
-			}																									//IBM-shared_classes_misc
-			if (defineClass) {																					//IBM-shared_classes_misc
-				try {                                                   										//IBM-shared_classes_misc
-					Class<?> clazz = defineClass(cn, sharedClazz,         										//IBM-shared_classes_misc
-									cs,        																	//IBM-shared_classes_misc
-									man, pkgCheck);         													//IBM-shared_classes_misc
-					return clazz;                                       										//IBM-shared_classes_misc
-				} catch (IOException e) {                               										//IBM-shared_classes_misc
-					// defineClass() failed                                										//IBM-shared_classes_misc
-				}                                                      											//IBM-shared_classes_misc
-			}																									//IBM-shared_classes_misc
-		}																											//IBM-shared_classes_misc
-		return null;																								//IBM-shared_classes_misc
+	 /**																											//OpenJ9-shared_classes_misc
+     * Finds the class with the specified binary name in the shared classes cache.									//OpenJ9-shared_classes_misc
+     *																												//OpenJ9-shared_classes_misc
+     * @return the resulting Class or {@code null} if not found														//OpenJ9-shared_classes_misc
+     */																												//OpenJ9-shared_classes_misc
+	private Class<?> findClassInSharedClassesCache(String cn, LoadedModule module, boolean pkgCheck) {				//OpenJ9-shared_classes_misc
+		if (usingSharedClasses()) {																					//OpenJ9-shared_classes_misc
+			byte[] sharedClazz = null;																				//OpenJ9-shared_classes_misc
+			CodeSource cs = null;																					//OpenJ9-shared_classes_misc
+			Manifest man = null;																					//OpenJ9-shared_classes_misc
+			boolean defineClass = false;																			//OpenJ9-shared_classes_misc
+			if (null == module) {																					//OpenJ9-shared_classes_misc
+				SharedClassIndexHolder sharedClassIndexHolder = new SharedClassIndexHolder(); 						//OpenJ9-shared_classes_misc
+				IntConsumer consumer = (i)->sharedClassIndexHolder.setIndex(i); 									//OpenJ9-shared_classes_misc
+				sharedClazz = sharedClassServiceProvider.findSharedClassURLClasspath(cn, consumer); 				//OpenJ9-shared_classes_misc
+				if (sharedClazz != null) {                                      									//OpenJ9-shared_classes_misc
+					int indexFoundData = sharedClassIndexHolder.index;          									//OpenJ9-shared_classes_misc
+					SharedClassMetaData metadata = sharedClassMetaDataCache.getSharedClassMetaData(indexFoundData); //OpenJ9-shared_classes_misc
+					if (metadata != null) {   																		//OpenJ9-shared_classes_misc
+						cs = metadata.getCodeSource();																//OpenJ9-shared_classes_misc
+						man = metadata.getManifest();																//OpenJ9-shared_classes_misc
+						defineClass = true;																			//OpenJ9-shared_classes_misc
+					} 																								//OpenJ9-shared_classes_misc
+				}																									//OpenJ9-shared_classes_misc
+			} else {																								//OpenJ9-shared_classes_misc
+				// module has its own URL, find the class using the module URL										//OpenJ9-shared_classes_misc
+				sharedClazz = sharedClassServiceProvider.findSharedClassURL(module.fileURL(), cn);					//OpenJ9-shared_classes_misc
+				if (sharedClazz != null) { 																			//OpenJ9-shared_classes_misc
+					cs = new CodeSource(module.codeSourceURL(), (CodeSigner[]) null);								//OpenJ9-shared_classes_misc
+					defineClass = true;																				//OpenJ9-shared_classes_misc
+				}																									//OpenJ9-shared_classes_misc
+			}																									//OpenJ9-shared_classes_misc
+			if (defineClass) {																					//OpenJ9-shared_classes_misc
+				try {                                                   										//OpenJ9-shared_classes_misc
+					Class<?> clazz = defineClass(cn, sharedClazz,         										//OpenJ9-shared_classes_misc
+									cs,        																	//OpenJ9-shared_classes_misc
+									man, pkgCheck);         													//OpenJ9-shared_classes_misc
+					return clazz;                                       										//OpenJ9-shared_classes_misc
+				} catch (IOException e) {                               										//OpenJ9-shared_classes_misc
+					// defineClass() failed                                										//OpenJ9-shared_classes_misc
+				}                                                      											//OpenJ9-shared_classes_misc
+			}																									//OpenJ9-shared_classes_misc
+		}																											//OpenJ9-shared_classes_misc
+		return null;																								//OpenJ9-shared_classes_misc
 	}
 
 	
-	/*                                                                          				//IBM-shared_classes_misc
-     * Defines a class using the class bytes, codesource and manifest           				//IBM-shared_classes_misc
-     * obtained from the specified shared class cache. The resulting            				//IBM-shared_classes_misc
-     * class must be resolved before it can be used.  This method is            				//IBM-shared_classes_misc
-     * used only in a Shared classes context.                                   				//IBM-shared_classes_misc
-     */                                                                        			 		//IBM-shared_classes_misc
-    private Class<?> defineClass(String name, byte[] sharedClazz, CodeSource codesource, Manifest man, boolean pkgCheck) throws IOException { //IBM-shared_classes_misc
-		if (pkgCheck) {																 			//IBM-shared_classes_misc
-			int i = name.lastIndexOf('.');                                          			//IBM-shared_classes_misc
-			if (-1 != i) {															 			//IBM-shared_classes_misc
-				String pkgname = name.substring(0, i);								 			//IBM-shared_classes_misc
-				URL url = codesource.getLocation();									 			//IBM-shared_classes_misc
-				defineOrCheckPackage(pkgname, man, url);							 			//IBM-shared_classes_misc
-			}																		 			//IBM-shared_classes_misc
-		}																			  			//IBM-shared_classes_misc
-       /*                                                                      					//IBM-shared_classes_misc
-         * Now read the class bytes and define the class.  We don't need to call  				//IBM-shared_classes_misc
-         * storeSharedClass(), since its already in our shared class cache.     				//IBM-shared_classes_misc
-         */                                                                     				//IBM-shared_classes_misc
-        return defineClass(name, sharedClazz, 0, sharedClazz.length, codesource); 				//IBM-shared_classes_misc
-     }                                                                          				//IBM-shared_classes_misc
+	/*                                                                          				//OpenJ9-shared_classes_misc
+     * Defines a class using the class bytes, codesource and manifest           				//OpenJ9-shared_classes_misc
+     * obtained from the specified shared class cache. The resulting            				//OpenJ9-shared_classes_misc
+     * class must be resolved before it can be used.  This method is            				//OpenJ9-shared_classes_misc
+     * used only in a Shared classes context.                                   				//OpenJ9-shared_classes_misc
+     */                                                                        			 		//OpenJ9-shared_classes_misc
+    private Class<?> defineClass(String name, byte[] sharedClazz, CodeSource codesource, Manifest man, boolean pkgCheck) throws IOException { //OpenJ9-shared_classes_misc
+		if (pkgCheck) {																 			//OpenJ9-shared_classes_misc
+			int i = name.lastIndexOf('.');                                          			//OpenJ9-shared_classes_misc
+			if (-1 != i) {															 			//OpenJ9-shared_classes_misc
+				String pkgname = name.substring(0, i);								 			//OpenJ9-shared_classes_misc
+				URL url = codesource.getLocation();									 			//OpenJ9-shared_classes_misc
+				defineOrCheckPackage(pkgname, man, url);							 			//OpenJ9-shared_classes_misc
+			}																		 			//OpenJ9-shared_classes_misc
+		}																			  			//OpenJ9-shared_classes_misc
+       /*                                                                      					//OpenJ9-shared_classes_misc
+         * Now read the class bytes and define the class.  We don't need to call  				//OpenJ9-shared_classes_misc
+         * storeSharedClass(), since its already in our shared class cache.     				//OpenJ9-shared_classes_misc
+         */                                                                     				//OpenJ9-shared_classes_misc
+        return defineClass(name, sharedClazz, 0, sharedClazz.length, codesource); 				//OpenJ9-shared_classes_misc
+     }                                                                          				//OpenJ9-shared_classes_misc
 
     /**
      * Defines the given binary class name to the VM, loading the class
@@ -1006,7 +1006,7 @@ public class BuiltinClassLoader
         try {
             ByteBuffer bb = null;
             URL csURL = null;
-            Manifest man = null;															//IBM-shared_classes_misc
+            Manifest man = null;															//OpenJ9-shared_classes_misc
 			boolean patched = false;
 
             // locate class file, special handling for patched modules to
@@ -1017,10 +1017,10 @@ public class BuiltinClassLoader
                 if (r != null) {
                     bb = r.getByteBuffer();
                     csURL = r.getCodeSourceURL();
-					if (!loadedModule.codeSourceURL().equals(csURL)) {						//IBM-shared_classes_misc
-						// class is not from the module, it is from the patched path. Do not share in this case		//IBM-shared_classes_misc
-						patched = true;														//IBM-shared_classes_misc
-					}																		//IBM-shared_classes_misc
+					if (!loadedModule.codeSourceURL().equals(csURL)) {						//OpenJ9-shared_classes_misc
+						// class is not from the module, it is from the patched path. Do not share in this case		//OpenJ9-shared_classes_misc
+						patched = true;														//OpenJ9-shared_classes_misc
+					}																		//OpenJ9-shared_classes_misc
                 }
             } else {
                 bb = reader.read(rn).orElse(null);
@@ -1036,10 +1036,10 @@ public class BuiltinClassLoader
             try {
                 // define class to VM
                 Class<?> clazz = defineClass(cn, bb, cs);									
-				if ((null != clazz) && !patched) {											//IBM-shared_classes_misc
-					//ignore the return value of storeClassIntoSharedClassesCache()			//IBM-shared_classes_misc
-					storeClassIntoSharedClassesCache(clazz, cs, man, -1, loadedModule);		//IBM-shared_classes_misc
-				}																			//IBM-shared_classes_misc
+				if ((null != clazz) && !patched) {											//OpenJ9-shared_classes_misc
+					//ignore the return value of storeClassIntoSharedClassesCache()			//OpenJ9-shared_classes_misc
+					storeClassIntoSharedClassesCache(clazz, cs, man, -1, loadedModule);		//OpenJ9-shared_classes_misc
+				}																			//OpenJ9-shared_classes_misc
 				return clazz;
             } finally {
                 reader.release(bb);
@@ -1051,34 +1051,34 @@ public class BuiltinClassLoader
         }
     }
     
-	/**																											//IBM-shared_classes_misc
-     * Stores the class into the shared classes cache.															//IBM-shared_classes_misc
-     *																											//IBM-shared_classes_misc
-     * @return whether the class has been stored.																//IBM-shared_classes_misc
-     */																											//IBM-shared_classes_misc
-	private boolean storeClassIntoSharedClassesCache(Class<?> clazz, CodeSource cs, Manifest man, int index, LoadedModule module) {	//IBM-shared_classes_misc
-		boolean storeSuccessful = false;																//IBM-shared_classes_misc
-		if (usingSharedClasses()) {																		//IBM-shared_classes_misc
-			if (null == module) {																		//IBM-shared_classes_misc
-			// Check to see if we have already cached metadata for this index  							//IBM-shared_classes_misc
-				SharedClassMetaData metadata = sharedClassMetaDataCache.getSharedClassMetaData(index); 	//IBM-shared_classes_misc
-				// If we have not already cached the metadata for this index...   						//IBM-shared_classes_misc
-				if (metadata == null) {                                             					//IBM-shared_classes_misc
-					// ... create a new metadata entry                           						//IBM-shared_classes_misc
-					metadata = new SharedClassMetaData(cs, man);                    					//IBM-shared_classes_misc
-					// Cache the metadata for this index for future use         						//IBM-shared_classes_misc
-					sharedClassMetaDataCache.setSharedClassMetaData(index, metadata); 					//IBM-shared_classes_misc
-																										//IBM-shared_classes_misc
-				}                                                                   					//IBM-shared_classes_misc
-				// Store class in shared class cache for future use 									//IBM-shared_classes_misc
-				storeSuccessful = sharedClassServiceProvider.storeSharedClassURLClasspath(clazz, index);//IBM-shared_classes_misc
-			} else {																					//IBM-shared_classes_misc
-				// module has its own URL, store the class using the module URL							//IBM-shared_classes_misc
-				storeSuccessful = sharedClassServiceProvider.storeSharedClassURL(module.fileURL(), clazz);	//IBM-shared_classes_misc
-			}																						//IBM-shared_classes_misc
-		}																							//IBM-shared_classes_misc
-		return storeSuccessful;																		//IBM-shared_classes_misc
-	}																								//IBM-shared_classes_misc
+	/**																											//OpenJ9-shared_classes_misc
+     * Stores the class into the shared classes cache.															//OpenJ9-shared_classes_misc
+     *																											//OpenJ9-shared_classes_misc
+     * @return whether the class has been stored.																//OpenJ9-shared_classes_misc
+     */																											//OpenJ9-shared_classes_misc
+	private boolean storeClassIntoSharedClassesCache(Class<?> clazz, CodeSource cs, Manifest man, int index, LoadedModule module) {	//OpenJ9-shared_classes_misc
+		boolean storeSuccessful = false;																//OpenJ9-shared_classes_misc
+		if (usingSharedClasses()) {																		//OpenJ9-shared_classes_misc
+			if (null == module) {																		//OpenJ9-shared_classes_misc
+			// Check to see if we have already cached metadata for this index  							//OpenJ9-shared_classes_misc
+				SharedClassMetaData metadata = sharedClassMetaDataCache.getSharedClassMetaData(index); 	//OpenJ9-shared_classes_misc
+				// If we have not already cached the metadata for this index...   						//OpenJ9-shared_classes_misc
+				if (metadata == null) {                                             					//OpenJ9-shared_classes_misc
+					// ... create a new metadata entry                           						//OpenJ9-shared_classes_misc
+					metadata = new SharedClassMetaData(cs, man);                    					//OpenJ9-shared_classes_misc
+					// Cache the metadata for this index for future use         						//OpenJ9-shared_classes_misc
+					sharedClassMetaDataCache.setSharedClassMetaData(index, metadata); 					//OpenJ9-shared_classes_misc
+																										//OpenJ9-shared_classes_misc
+				}                                                                   					//OpenJ9-shared_classes_misc
+				// Store class in shared class cache for future use 									//OpenJ9-shared_classes_misc
+				storeSuccessful = sharedClassServiceProvider.storeSharedClassURLClasspath(clazz, index);//OpenJ9-shared_classes_misc
+			} else {																					//OpenJ9-shared_classes_misc
+				// module has its own URL, store the class using the module URL							//OpenJ9-shared_classes_misc
+				storeSuccessful = sharedClassServiceProvider.storeSharedClassURL(module.fileURL(), clazz);	//OpenJ9-shared_classes_misc
+			}																						//OpenJ9-shared_classes_misc
+		}																							//OpenJ9-shared_classes_misc
+		return storeSuccessful;																		//OpenJ9-shared_classes_misc
+	}																								//OpenJ9-shared_classes_misc
 
     /**
      * Defines the given binary class name to the VM, loading the class
@@ -1091,8 +1091,8 @@ public class BuiltinClassLoader
     private Class<?> defineClass(String cn, Resource res) throws IOException {
         URL url = res.getCodeSourceURL();
         Class<?> clazz = null;
-        CodeSource cs = null;								//IBM-shared_classes_misc
-        Manifest man = null;								//IBM-shared_classes_misc
+        CodeSource cs = null;								//OpenJ9-shared_classes_misc
+        Manifest man = null;								//OpenJ9-shared_classes_misc
 
         // if class is in a named package then ensure that the package is defined
         int pos = cn.lastIndexOf('.');
@@ -1115,10 +1115,10 @@ public class BuiltinClassLoader
             clazz = defineClass(cn, b, 0, b.length, cs);
         }
         
-        if (null != clazz) {																	//IBM-shared_classes_misc
-            //ignore the return value of storeClassIntoSharedClassesCache()						//IBM-shared_classes_misc
-            storeClassIntoSharedClassesCache(clazz, cs, man, res.getClasspathLoadIndex(), null);//IBM-shared_classes_misc
-        }																						//IBM-shared_classes_misc
+        if (null != clazz) {																	//OpenJ9-shared_classes_misc
+            //ignore the return value of storeClassIntoSharedClassesCache()						//OpenJ9-shared_classes_misc
+            storeClassIntoSharedClassesCache(clazz, cs, man, res.getClasspathLoadIndex(), null);//OpenJ9-shared_classes_misc
+        }																						//OpenJ9-shared_classes_misc
         return clazz;
     }
 

--- a/src/java.base/share/classes/jdk/internal/loader/Resource.java
+++ b/src/java.base/share/classes/jdk/internal/loader/Resource.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -74,24 +74,24 @@ public abstract class Resource {
      */
     public abstract int getContentLength() throws IOException;
 
-   private InputStream cis;                                                     //IBM-shared_classes_misc
-    /* Stores the classpath index from which this resource was loaded from - used for Shared class support */ //IBM-shared_classes_misc
-    private int classPathLoadIndex;                                             //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-    /*                                                                          //IBM-shared_classes_misc
-     * Sets the classpath index from which this resource was loaded from        //IBM-shared_classes_misc
-     */                                                                         //IBM-shared_classes_misc
-    public void setClasspathLoadIndex(int cpIndex) {                            //IBM-shared_classes_misc
-        classPathLoadIndex = cpIndex;                                           //IBM-shared_classes_misc
-    }                                                                           //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-    /*                                                                          //IBM-shared_classes_misc
-     * Returns the classpath index from which this resource was loaded from     //IBM-shared_classes_misc
-     */                                                                         //IBM-shared_classes_misc
-    public int getClasspathLoadIndex() {                                        //IBM-shared_classes_misc
-        return classPathLoadIndex;                                              //IBM-shared_classes_misc
-    }                                                                           //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
+   private InputStream cis;                                                     //OpenJ9-shared_classes_misc
+    /* Stores the classpath index from which this resource was loaded from - used for Shared class support */ //OpenJ9-shared_classes_misc
+    private int classPathLoadIndex;                                             //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+    /*                                                                          //OpenJ9-shared_classes_misc
+     * Sets the classpath index from which this resource was loaded from        //OpenJ9-shared_classes_misc
+     */                                                                         //OpenJ9-shared_classes_misc
+    public void setClasspathLoadIndex(int cpIndex) {                            //OpenJ9-shared_classes_misc
+        classPathLoadIndex = cpIndex;                                           //OpenJ9-shared_classes_misc
+    }                                                                           //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+    /*                                                                          //OpenJ9-shared_classes_misc
+     * Returns the classpath index from which this resource was loaded from     //OpenJ9-shared_classes_misc
+     */                                                                         //OpenJ9-shared_classes_misc
+    public int getClasspathLoadIndex() {                                        //OpenJ9-shared_classes_misc
+        return classPathLoadIndex;                                              //OpenJ9-shared_classes_misc
+    }                                                                           //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
 
     /* Cache result in case getBytes is called after getByteBuffer. */
     private synchronized InputStream cachedInputStream() throws IOException {
@@ -208,4 +208,4 @@ public abstract class Resource {
         return null;
     }
 }
-//IBM-shared_classes_misc
+//OpenJ9-shared_classes_misc

--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 1997, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 1997, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -132,20 +132,20 @@ public class URLClassPath {
     /* The jar protocol handler to use when creating new URLs */
     private final URLStreamHandler jarHandler;
 
-   /* Fields for shared classes support starts*/                                //IBM-shared_classes_misc
-    /* Shared classes helper. Must be kept up to date with any search path      //IBM-shared_classes_misc
-     * changes.                                                                 //IBM-shared_classes_misc
-     */                                                                         //IBM-shared_classes_misc
-    private SharedClassProvider sharedClassServiceProvider = null;              //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-    /* URLs corresponding to the search path of loaders */                      //IBM-shared_classes_misc
-    private ArrayList loaderURLs = null;                                        //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-    /* The number of entries, starting at the 0th element, into the search path //IBM-shared_classes_misc
-     * that have been updated with the shared classes helper.                   //IBM-shared_classes_misc
-     */                                                                         //IBM-shared_classes_misc
-    private int updatedSearchPathCount = -1;                                    //IBM-shared_classes_misc
-    /* Fields for shared classes support ends*/                                 //IBM-shared_classes_misc
+   /* Fields for shared classes support starts*/                                //OpenJ9-shared_classes_misc
+    /* Shared classes helper. Must be kept up to date with any search path      //OpenJ9-shared_classes_misc
+     * changes.                                                                 //OpenJ9-shared_classes_misc
+     */                                                                         //OpenJ9-shared_classes_misc
+    private SharedClassProvider sharedClassServiceProvider = null;              //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+    /* URLs corresponding to the search path of loaders */                      //OpenJ9-shared_classes_misc
+    private ArrayList loaderURLs = null;                                        //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+    /* The number of entries, starting at the 0th element, into the search path //OpenJ9-shared_classes_misc
+     * that have been updated with the shared classes helper.                   //OpenJ9-shared_classes_misc
+     */                                                                         //OpenJ9-shared_classes_misc
+    private int updatedSearchPathCount = -1;                                    //OpenJ9-shared_classes_misc
+    /* Fields for shared classes support ends*/                                 //OpenJ9-shared_classes_misc
 
     /* Whether this URLClassLoader has been closed yet */
     private boolean closed = false;
@@ -189,84 +189,84 @@ public class URLClassPath {
         else
             this.acc = acc;
     }
-    /* Methods for shared classes support starts*/                              //IBM-shared_classes_misc
-    /* Shared classes version of URLClassPath(URL[], URLStreamHandlerFactory)   //IBM-shared_classes_misc
-     */                                                                         //IBM-shared_classes_misc
-    public URLClassPath(URL[] urls, URLStreamHandlerFactory factory,            //IBM-shared_classes_misc
-                        AccessControlContext acc, SharedClassProvider helper) {                 //IBM-shared_classes_misc
-        /* Call URLClassPath(URL[], URLStreamHandlerFactory, AccessControlContext) constructor */     //IBM-shared_classes_misc
-        this(urls, factory, acc);                                                    //IBM-shared_classes_misc
-        /* Set shared classes helper */                                         //IBM-shared_classes_misc
-        sharedClassServiceProvider = helper;                                 //IBM-shared_classes_misc
-        if (usingSharedClasses()) {                                             //IBM-shared_classes_misc
-            /* create list to hold search path URLs */                          //IBM-shared_classes_misc
-            loaderURLs = new ArrayList(urls.length);                            //IBM-shared_classes_misc
-        }                                                                       //IBM-shared_classes_misc
-    }                                                                           //IBM-shared_classes_misc
+    /* Methods for shared classes support starts*/                              //OpenJ9-shared_classes_misc
+    /* Shared classes version of URLClassPath(URL[], URLStreamHandlerFactory)   //OpenJ9-shared_classes_misc
+     */                                                                         //OpenJ9-shared_classes_misc
+    public URLClassPath(URL[] urls, URLStreamHandlerFactory factory,            //OpenJ9-shared_classes_misc
+                        AccessControlContext acc, SharedClassProvider helper) {                 //OpenJ9-shared_classes_misc
+        /* Call URLClassPath(URL[], URLStreamHandlerFactory, AccessControlContext) constructor */     //OpenJ9-shared_classes_misc
+        this(urls, factory, acc);                                                    //OpenJ9-shared_classes_misc
+        /* Set shared classes helper */                                         //OpenJ9-shared_classes_misc
+        sharedClassServiceProvider = helper;                                 //OpenJ9-shared_classes_misc
+        if (usingSharedClasses()) {                                             //OpenJ9-shared_classes_misc
+            /* create list to hold search path URLs */                          //OpenJ9-shared_classes_misc
+            loaderURLs = new ArrayList(urls.length);                            //OpenJ9-shared_classes_misc
+        }                                                                       //OpenJ9-shared_classes_misc
+    }                                                                           //OpenJ9-shared_classes_misc
     
-    /* Method to set SharedClassProvider and loaderURLs */                      //IBM-shared_classes_misc
-    public void setSharedClassProvider(SharedClassProvider helper) {            //IBM-shared_classes_misc
-        if (null == sharedClassServiceProvider) {                               //IBM-shared_classes_misc
-            sharedClassServiceProvider = helper;                                //IBM-shared_classes_misc
-        }                                                                       //IBM-shared_classes_misc
-        if (usingSharedClasses()) {                                             //IBM-shared_classes_misc
-            loaderURLs = new ArrayList(path.size());                            //IBM-shared_classes_misc
-        }                                                                       //IBM-shared_classes_misc
-    }                                                                           //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-    /* Return true if shared classes support is active, otherwise false.        //IBM-shared_classes_misc
-     */                                                                         //IBM-shared_classes_misc
-    private boolean usingSharedClasses() {                                      //IBM-shared_classes_misc
-        return (sharedClassServiceProvider != null);                         //IBM-shared_classes_misc
-    }                                                                           //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-    /* When using shared classes the shared classes helper's classpath must     //IBM-shared_classes_misc
-     * match this URLClassPath's search path (i.e. the list of loaders). This   //IBM-shared_classes_misc
-     * function "confirms" with the shared classes helper the search path up    //IBM-shared_classes_misc
-     * to the highest index (starting from zero) from which we have loaded a    //IBM-shared_classes_misc
-     * resource.                                                                //IBM-shared_classes_misc
-     *                                                                          //IBM-shared_classes_misc
-     * @param index the index into the search path that should be updated.      //IBM-shared_classes_misc
-     *        If the search path up to the supplied index has not already been  //IBM-shared_classes_misc
-     *        updated, the shared classes helper's classpath will be extended   //IBM-shared_classes_misc
-     *        so that the supplied index will be contained.                     //IBM-shared_classes_misc
-     *        If that index has already been updated, no action will be taken.  //IBM-shared_classes_misc
-     * @throws IllegalStateException if an error occurs when updating the       //IBM-shared_classes_misc
-     *        the search path with the shared classes helper or if the search   //IBM-shared_classes_misc
-     *        path could not be extended to include index.                      //IBM-shared_classes_misc
-     */                                                                         //IBM-shared_classes_misc
-    private synchronized void updateClasspathWithSharedClassesHelper(int index) { //IBM-shared_classes_misc
-        /* do nothing if not using shared classes */                            //IBM-shared_classes_misc
-        if (!usingSharedClasses()) {                                            //IBM-shared_classes_misc
-            return;                                                             //IBM-shared_classes_misc
-        }                                                                       //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-        /* Update the loader search path with the shared classes helper if      //IBM-shared_classes_misc
-         * the search path has expanded since the previous update.              //IBM-shared_classes_misc
-         */                                                                     //IBM-shared_classes_misc
-        int searchPathSize = loaderURLs.size();                                 //IBM-shared_classes_misc
-        if (updatedSearchPathCount < searchPathSize) {                          //IBM-shared_classes_misc
-            URL[] newSearchPath = new URL[searchPathSize];                      //IBM-shared_classes_misc
-            newSearchPath = (URL[])loaderURLs.toArray(newSearchPath);           //IBM-shared_classes_misc
-                                                                          //IBM-shared_classes_misc
-                /* update shared classes helper with the extended search path */ //IBM-shared_classes_misc
-            if (sharedClassServiceProvider.setURLClasspath(newSearchPath)) {     //IBM-shared_classes_misc
-                updatedSearchPathCount = searchPathSize;         /*ibm@96437*/ /* ibm@96499 */ //IBM-shared_classes_misc
+    /* Method to set SharedClassProvider and loaderURLs */                      //OpenJ9-shared_classes_misc
+    public void setSharedClassProvider(SharedClassProvider helper) {            //OpenJ9-shared_classes_misc
+        if (null == sharedClassServiceProvider) {                               //OpenJ9-shared_classes_misc
+            sharedClassServiceProvider = helper;                                //OpenJ9-shared_classes_misc
+        }                                                                       //OpenJ9-shared_classes_misc
+        if (usingSharedClasses()) {                                             //OpenJ9-shared_classes_misc
+            loaderURLs = new ArrayList(path.size());                            //OpenJ9-shared_classes_misc
+        }                                                                       //OpenJ9-shared_classes_misc
+    }                                                                           //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+    /* Return true if shared classes support is active, otherwise false.        //OpenJ9-shared_classes_misc
+     */                                                                         //OpenJ9-shared_classes_misc
+    private boolean usingSharedClasses() {                                      //OpenJ9-shared_classes_misc
+        return (sharedClassServiceProvider != null);                         //OpenJ9-shared_classes_misc
+    }                                                                           //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+    /* When using shared classes the shared classes helper's classpath must     //OpenJ9-shared_classes_misc
+     * match this URLClassPath's search path (i.e. the list of loaders). This   //OpenJ9-shared_classes_misc
+     * function "confirms" with the shared classes helper the search path up    //OpenJ9-shared_classes_misc
+     * to the highest index (starting from zero) from which we have loaded a    //OpenJ9-shared_classes_misc
+     * resource.                                                                //OpenJ9-shared_classes_misc
+     *                                                                          //OpenJ9-shared_classes_misc
+     * @param index the index into the search path that should be updated.      //OpenJ9-shared_classes_misc
+     *        If the search path up to the supplied index has not already been  //OpenJ9-shared_classes_misc
+     *        updated, the shared classes helper's classpath will be extended   //OpenJ9-shared_classes_misc
+     *        so that the supplied index will be contained.                     //OpenJ9-shared_classes_misc
+     *        If that index has already been updated, no action will be taken.  //OpenJ9-shared_classes_misc
+     * @throws IllegalStateException if an error occurs when updating the       //OpenJ9-shared_classes_misc
+     *        the search path with the shared classes helper or if the search   //OpenJ9-shared_classes_misc
+     *        path could not be extended to include index.                      //OpenJ9-shared_classes_misc
+     */                                                                         //OpenJ9-shared_classes_misc
+    private synchronized void updateClasspathWithSharedClassesHelper(int index) { //OpenJ9-shared_classes_misc
+        /* do nothing if not using shared classes */                            //OpenJ9-shared_classes_misc
+        if (!usingSharedClasses()) {                                            //OpenJ9-shared_classes_misc
+            return;                                                             //OpenJ9-shared_classes_misc
+        }                                                                       //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+        /* Update the loader search path with the shared classes helper if      //OpenJ9-shared_classes_misc
+         * the search path has expanded since the previous update.              //OpenJ9-shared_classes_misc
+         */                                                                     //OpenJ9-shared_classes_misc
+        int searchPathSize = loaderURLs.size();                                 //OpenJ9-shared_classes_misc
+        if (updatedSearchPathCount < searchPathSize) {                          //OpenJ9-shared_classes_misc
+            URL[] newSearchPath = new URL[searchPathSize];                      //OpenJ9-shared_classes_misc
+            newSearchPath = (URL[])loaderURLs.toArray(newSearchPath);           //OpenJ9-shared_classes_misc
+                                                                          //OpenJ9-shared_classes_misc
+                /* update shared classes helper with the extended search path */ //OpenJ9-shared_classes_misc
+            if (sharedClassServiceProvider.setURLClasspath(newSearchPath)) {     //OpenJ9-shared_classes_misc
+                updatedSearchPathCount = searchPathSize;         /*ibm@96437*/ /* ibm@96499 */ //OpenJ9-shared_classes_misc
 			} else {
-				throw new IllegalStateException(                                //IBM-shared_classes_misc
+				throw new IllegalStateException(                                //OpenJ9-shared_classes_misc
                             "Unable to set shared class path");
 			}
-                                                                                //IBM-shared_classes_misc
-        }                                                                       //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-        if (index >= searchPathSize) {                                          //IBM-shared_classes_misc
-            /* Unable to extend the search path to contain supplied index */    //IBM-shared_classes_misc
-            throw new IllegalStateException(                                    //IBM-shared_classes_misc
-                        "Unable to extend shared class path to index " + index); //IBM-shared_classes_misc
-        }                                                                       //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
-    }                                                                           //IBM-shared_classes_misc
-    /* Methods for shared classes support ends*/                                //IBM-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+        }                                                                       //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+        if (index >= searchPathSize) {                                          //OpenJ9-shared_classes_misc
+            /* Unable to extend the search path to contain supplied index */    //OpenJ9-shared_classes_misc
+            throw new IllegalStateException(                                    //OpenJ9-shared_classes_misc
+                        "Unable to extend shared class path to index " + index); //OpenJ9-shared_classes_misc
+        }                                                                       //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
+    }                                                                           //OpenJ9-shared_classes_misc
+    /* Methods for shared classes support ends*/                                //OpenJ9-shared_classes_misc
 
     public URLClassPath(URL[] urls, AccessControlContext acc) {
         this(urls, null, acc);
@@ -405,7 +405,7 @@ public class URLClassPath {
      * @param check     whether to perform a security check
      * @return the Resource, or null if not found
      */
-    public Resource getResource(String name, boolean check, ClassLoader classloader) { //IBM-shared_classes_misc
+    public Resource getResource(String name, boolean check, ClassLoader classloader) { //OpenJ9-shared_classes_misc
         if (DEBUG) {
             System.err.println("URLClassPath.getResource(\"" + name + "\")");
         }
@@ -414,9 +414,9 @@ public class URLClassPath {
         for (int i = 0; (loader = getLoader(i)) != null; i++) {
             Resource res = loader.getResource(name, check);
             if (res != null) {
-               res.setClasspathLoadIndex(i); /* Store the classpath index that this resource came from */ //IBM-shared_classes_misc
-               /* Update the search path with shared Classes Helper, this is only if we are using Shared classes */ //IBM-shared_classes_misc
-               updateClasspathWithSharedClassesHelper(i);                       //IBM-shared_classes_misc
+               res.setClasspathLoadIndex(i); /* Store the classpath index that this resource came from */ //OpenJ9-shared_classes_misc
+               /* Update the search path with shared Classes Helper, this is only if we are using Shared classes */ //OpenJ9-shared_classes_misc
+               updateClasspathWithSharedClassesHelper(i);                       //OpenJ9-shared_classes_misc
                 return res;
             }
         }
@@ -466,11 +466,11 @@ public class URLClassPath {
         };
     }
 
-    public Resource getResource(String name, boolean check) {                    //IBM-shared_classes_misc
-        return getResource(name, check, null);                            //IBM-shared_classes_misc
-    }                                                                           //IBM-shared_classes_misc
+    public Resource getResource(String name, boolean check) {                    //OpenJ9-shared_classes_misc
+        return getResource(name, check, null);                            //OpenJ9-shared_classes_misc
+    }                                                                           //OpenJ9-shared_classes_misc
     public Resource getResource(String name) {
-        return getResource(name, true, null);                            //IBM-shared_classes_misc
+        return getResource(name, true, null);                            //OpenJ9-shared_classes_misc
     }
 
     /**
@@ -570,11 +570,11 @@ public class URLClassPath {
             // Finally, add the Loader to the search path.
             loaders.add(loader);
             lmap.put(urlNoFragString, loader);
-           if (usingSharedClasses()) {                                          //IBM-shared_classes_misc
-               /* update search path URLs */                                    //IBM-shared_classes_misc
-               loaderURLs.add(url);                                             //IBM-shared_classes_misc
-           }                                                                    //IBM-shared_classes_misc
-                                                                                //IBM-shared_classes_misc
+           if (usingSharedClasses()) {                                          //OpenJ9-shared_classes_misc
+               /* update search path URLs */                                    //OpenJ9-shared_classes_misc
+               loaderURLs.add(url);                                             //OpenJ9-shared_classes_misc
+           }                                                                    //OpenJ9-shared_classes_misc
+                                                                                //OpenJ9-shared_classes_misc
         }
         return loaders.get(index);
     }
@@ -597,12 +597,12 @@ public class URLClassPath {
                                         file.endsWith("!/")) {
                                     // extract the nested URL
                                     URL nestedUrl = new URL(file.substring(0, file.length() - 2));
-                                    return new JarLoader(nestedUrl, jarHandler, lmap, acc, usingSharedClasses());   //IBM-shared_classes_misc
+                                    return new JarLoader(nestedUrl, jarHandler, lmap, acc, usingSharedClasses());   //OpenJ9-shared_classes_misc
                                 } else {
                                     return new Loader(url);
                                 }
                             } else {
-                                return new JarLoader(url, jarHandler, lmap, acc, usingSharedClasses());   //IBM-shared_classes_misc
+                                return new JarLoader(url, jarHandler, lmap, acc, usingSharedClasses());   //OpenJ9-shared_classes_misc
                             }
                         }
                     }, acc);
@@ -814,7 +814,7 @@ public class URLClassPath {
         private JarIndex index;
         private URLStreamHandler handler;
         private final HashMap<String, Loader> lmap;
-        private boolean usingSharedClasses;                                     //IBM-shared_classes_misc
+        private boolean usingSharedClasses;                                     //OpenJ9-shared_classes_misc
         private final AccessControlContext acc;
         private boolean closed = false;
         private static final JavaUtilZipFileAccess zipAccess =
@@ -826,11 +826,11 @@ public class URLClassPath {
          */
         JarLoader(URL url, URLStreamHandler jarHandler,
                   HashMap<String, Loader> loaderMap,
-                  AccessControlContext acc, boolean usingSharedClasses)   //IBM-shared_classes_misc
+                  AccessControlContext acc, boolean usingSharedClasses)   //OpenJ9-shared_classes_misc
             throws IOException
         {
             super(new URL("jar", "", -1, url + "!/", jarHandler));
-            this.usingSharedClasses = usingSharedClasses;                       //IBM-shared_classes_misc
+            this.usingSharedClasses = usingSharedClasses;                       //OpenJ9-shared_classes_misc
             csu = url;
             handler = jarHandler;
             lmap = loaderMap;
@@ -870,12 +870,12 @@ public class URLClassPath {
                                 }
 
                                 jar = getJarFile(csu);
-                                if (usingSharedClasses) {                       //IBM-shared_classes_misc
-                                    /* do not use Jar indexing with shared classes */ //IBM-shared_classes_misc
-                                    index = null;                                   //IBM-shared_classes_misc
-                                } else {                                         //IBM-shared_classes_misc
-                                    index = JarIndex.getJarIndex(jar); //IBM-shared_classes_misc
-                                }                                                //IBM-shared_classes_misc
+                                if (usingSharedClasses) {                       //OpenJ9-shared_classes_misc
+                                    /* do not use Jar indexing with shared classes */ //OpenJ9-shared_classes_misc
+                                    index = null;                                   //OpenJ9-shared_classes_misc
+                                } else {                                         //OpenJ9-shared_classes_misc
+                                    index = JarIndex.getJarIndex(jar); //OpenJ9-shared_classes_misc
+                                }                                                //OpenJ9-shared_classes_misc
                                 if (index != null) {
                                     String[] jarfiles = index.getJarFiles();
                                 // Add all the dependent URLs to the lmap so that loaders
@@ -1096,7 +1096,7 @@ public class URLClassPath {
                                 new PrivilegedExceptionAction<>() {
                                     public JarLoader run() throws IOException {
                                         return new JarLoader(url, handler,
-                                            lmap, acc, usingSharedClasses);   //IBM-shared_classes_misc
+                                            lmap, acc, usingSharedClasses);   //OpenJ9-shared_classes_misc
                                     }
                                 }, acc);
 
@@ -1376,4 +1376,4 @@ public class URLClassPath {
         }
     }
 }
-//IBM-shared_classes_misc
+//OpenJ9-shared_classes_misc

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -60,7 +60,7 @@ import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.JavaLangModuleAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.perf.PerfCounter;
-import jdk.internal.loader.ClassLoaders;						//IBM-shared_classes_misc
+import jdk.internal.loader.ClassLoaders;						//OpenJ9-shared_classes_misc
 
 /**
  * Initializes/boots the module system.
@@ -461,10 +461,10 @@ public final class ModuleBootstrap {
                 limitedFinder = new SafeModuleFinder(finder);
         }
 
-        ClassLoader appLoader = ClassLoaders.appClassLoader();                                                  //IBM-shared_classes_misc
-        ClassLoader platformLoader = ClassLoaders.platformClassLoader();                                //IBM-shared_classes_misc
-        ((BuiltinClassLoader)platformLoader).initializeSharedClassesSupport();                  //IBM-shared_classes_misc
-        ((BuiltinClassLoader)appLoader).initializeSharedClassesSupport();                               //IBM-shared_classes_misc
+        ClassLoader appLoader = ClassLoaders.appClassLoader();                                                  //OpenJ9-shared_classes_misc
+        ClassLoader platformLoader = ClassLoaders.platformClassLoader();                                //OpenJ9-shared_classes_misc
+        ((BuiltinClassLoader)platformLoader).initializeSharedClassesSupport();                  //OpenJ9-shared_classes_misc
+        ((BuiltinClassLoader)appLoader).initializeSharedClassesSupport();                               //OpenJ9-shared_classes_misc
 
         // Module graph can be archived at CDS dump time. Only allow the
         // unnamed module case for now.

--- a/src/java.rmi/share/classes/sun/rmi/server/LoaderHandler.java
+++ b/src/java.rmi/share/classes/sun/rmi/server/LoaderHandler.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1012,15 +1012,15 @@ public final class LoaderHandler {
 
         // createClassLoader permission needed to create loader in context
         perms.add(new RuntimePermission("createClassLoader"));
-        // allow the applet classloader access to shared classes.               //IBM-shared_classes_misc
-        ServiceLoader<SharedClassProvider> sl = ServiceLoader.load(SharedClassProvider.class); 											//IBM-shared_classes_misc
-		for (SharedClassProvider sharedClassServiceProvider : sl) {																		//IBM-shared_classes_misc
-			if (null != sharedClassServiceProvider) {																					//IBM-shared_classes_misc
-				if (sharedClassServiceProvider.isSharedClassEnabled()){																	//IBM-shared_classes_misc
-					perms.add(sharedClassServiceProvider.createPermission("sun.rmi.server.LoaderHandler$Loader", "read,write"));		//IBM-shared_classes_misc
-				}																														//IBM-shared_classes_misc
-				break;																													//IBM-shared_classes_misc
-			}																															//IBM-shared_classes_misc
+        // allow the applet classloader access to shared classes.               //OpenJ9-shared_classes_misc
+        ServiceLoader<SharedClassProvider> sl = ServiceLoader.load(SharedClassProvider.class); 											//OpenJ9-shared_classes_misc
+		for (SharedClassProvider sharedClassServiceProvider : sl) {																		//OpenJ9-shared_classes_misc
+			if (null != sharedClassServiceProvider) {																					//OpenJ9-shared_classes_misc
+				if (sharedClassServiceProvider.isSharedClassEnabled()){																	//OpenJ9-shared_classes_misc
+					perms.add(sharedClassServiceProvider.createPermission("sun.rmi.server.LoaderHandler$Loader", "read,write"));		//OpenJ9-shared_classes_misc
+				}																														//OpenJ9-shared_classes_misc
+				break;																													//OpenJ9-shared_classes_misc
+			}																															//OpenJ9-shared_classes_misc
 		}
 		
         // add permissions to read any "java.*" property
@@ -1241,4 +1241,4 @@ public final class LoaderHandler {
     }
 
 }
-//IBM-shared_classes_misc
+//OpenJ9-shared_classes_misc


### PR DESCRIPTION
Replace `IBM-shared_classes_misc` with `OpenJ9-shared_classes_misc`

Update shared classes specific comments.

ibmruntimes/openj9-openjdk-jdk11#114 for jdk

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>