### PR TITLE
Supply OpenJ9 VENDOR info in a file version-numbers

### DIFF
--- a/closed/autoconf/version-numbers
+++ b/closed/autoconf/version-numbers
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
 # ===========================================================================
 # 
 # This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,9 @@
 # 
 # ===========================================================================
 
-OPENJ9OMR_SHA := $(shell git -C $(OPENJ9OMR_TOPDIR) rev-parse --short HEAD)
-OPENJ9_SHA  := $(shell git -C $(OPENJ9_TOPDIR)  rev-parse --short HEAD)
-SOURCE_REVISION = OpenJDK:$(OPENJDK_SHA) OpenJ9:$(OPENJ9_SHA) OMR:$(OPENJ9OMR_SHA)
+
+# Default version numbers to use unless overridden by configure
+
+COMPANY_NAME="Eclipse OpenJ9"
+VENDOR_URL=http://www.eclipse.org/openj9
+VENDOR_URL_BUG=https://github.com/eclipse/openj9/issues

--- a/make/autoconf/jdk-version.m4
+++ b/make/autoconf/jdk-version.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+
 ###############################################################################
 #
 # Setup version numbers
@@ -59,6 +63,7 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
 [
   # Source the version numbers file
   . $AUTOCONF_DIR/version-numbers
+  . $TOPDIR/closed/autoconf/version-numbers
 
   # Some non-version number information is set in that file
   AC_SUBST(LAUNCHER_NAME)


### PR DESCRIPTION
Supply `OpenJ9 VENDOR` info in a file `version-numbers`

`OpenJ9` specific `VENDOR` info `COMPANY_NAME`, `VENDOR_URL` and `VENDOR_URL_BUG` are supplied within `closed/autoconf/version-numbers`;
`jdk-version.m4` processes the variables from this new file `version-numbers` besides `autoconf/version-numbers`. These `VENDOR` info becomes part of `java.lang.VersionProps.java` and eventually are set to system property values for `java.vendor`, `java.vendor.url` and `java.vendor.url.bug`.

Manually verified this fix the system property `java.vendor` value in #4660.

Reviewer: @pshipton 
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>