### PR TITLE
Use pConfig JAVA13 at head extension

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -498,7 +498,7 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 		com.ibm.jpp.commandline.CommandlineBuilder \
 			-verdict \
 			-baseDir "$(JPP_BASE_DIR)/" \
-			-config JAVA12 \
+			-config JAVA13 \
 			-srcRoot jcl/ \
 			-xml jpp_configuration.xml \
 			-dest "$(JPP_DEST)" \


### PR DESCRIPTION
Use `pConfig JAVA13` at head extension

Changed `JAVA12` to `JAVA13`.

Manually verified that `JDK13` can be built and `-version` output is:
```
openjdk version "13-internal" 2019-09-17
OpenJDK Runtime Environment (build 13-internal+0-adhoc.jason.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build master-9d606fc, JRE 13 Linux amd64-64-Bit Compressed References 20190225_000000 (JIT enabled, AOT enabled)
OpenJ9   - 9d606fc
OMR      - e6c6285
JCL      - b0f7ca0 based on jdk-13+6)
```

Related: https://github.com/eclipse/openj9/issues/4857, https://github.com/eclipse/openj9/pull/4877

Reviewer: @DanHeidinga
FYI: @andrew-m-leonard 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>