### PR TITLE
Add launcher for jstack

### DIFF
--- a/closed/make/CompileJavaModules.gmk
+++ b/closed/make/CompileJavaModules.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # 
 # This code is free software; you can redistribute it and/or modify it
@@ -22,4 +22,5 @@
 
 java.base_COPY += ExternalMessages.properties
 openj9.gpu_COPY += ibm_gpu_thresholds.properties
+jdk.jcmd_EXCLUDES += sun
 

--- a/closed/make/closed_make/launcher/Launcher-jdk.jcmd.gmk
+++ b/closed/make/closed_make/launcher/Launcher-jdk.jcmd.gmk
@@ -24,7 +24,13 @@ include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jps, \
     MAIN_MODULE := jdk.jcmd, \
-    MAIN_CLASS := openj9.tools.attach.diagnostics.Jps, \
+    MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jps, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
     JAVA_ARGS := -Djdk.attach.allowAttachSelf=true, \
+))
+
+$(eval $(call SetupBuildLauncher, jstack, \
+    MAIN_MODULE := jdk.jcmd, \
+    MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jstack, \
+    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))


### PR DESCRIPTION
Update jps and jstack packages to match OpenJ9
Requires https://github.com/eclipse/openj9/pull/5150
Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>