### PR TITLE
Use spaces instead of tabs in module-info files

### DIFF
--- a/closed/src/jdk.internal.vm.ci/share/classes/module-info.java
+++ b/closed/src/jdk.internal.vm.ci/share/classes/module-info.java
@@ -1,13 +1,12 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
- * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  
+ * published by the Free Software Foundation.
  *
- * IBM designates this particular file as subject to the "Classpath" exception 
+ * IBM designates this particular file as subject to the "Classpath" exception
  * as provided by IBM in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
@@ -18,9 +17,8 @@
  *
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
- * 
  * ===========================================================================
  */
 module jdk.internal.vm.ci {
-	requires java.base;
+  requires java.base;
 }


### PR DESCRIPTION
Tabs are not supported by the dependency discovery mechanism in openjdk.

See also eclipse/openj9#5260.