### PR TITLE
Add a check for illegal key size for native AES-CBC and AES-GCM

### DIFF
--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -33,6 +33,7 @@ package com.sun.crypto.provider;
 import java.security.InvalidKeyException;
 import java.security.ProviderException;
 import java.util.ArrayDeque;
+import com.sun.crypto.provider.AESCrypt;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 
@@ -151,6 +152,11 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
 
         if ((key == null) || (iv == null) || (iv.length != blockSize)) {
             throw new InvalidKeyException("Internal error");
+        }
+
+        if (!AESCrypt.isKeySizeValid(key.length)) {
+            throw new InvalidKeyException("Invalid AES key length: " +
+                key.length + " bytes");
         }
 
         this.iv = iv.clone();

--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
@@ -35,6 +35,7 @@ import java.io.*;
 import java.security.*;
 import javax.crypto.*;
 import static com.sun.crypto.provider.AESConstants.AES_BLOCK_SIZE;
+import com.sun.crypto.provider.AESCrypt;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 
@@ -219,6 +220,11 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
               throws InvalidKeyException {
         if (keyValue == null || ivValue == null) {
             throw new InvalidKeyException("Internal error");
+        }
+
+        if (!AESCrypt.isKeySizeValid(keyValue.length)) {
+            throw new InvalidKeyException("Invalid AES key length: " +
+                keyValue.length + " bytes");
         }
 
         this.key = keyValue.clone();
@@ -413,7 +419,7 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
         if (len < tagLenBytes) {
             throw new AEADBadTagException("Input too short - need tag");
         }
- 
+
         // do this check here can also catch the potential integer overflow
         // scenario for the subsequent output buffer capacity check.
         checkDataLength(ibuffer.size(), (len - tagLenBytes));


### PR DESCRIPTION
Same as https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/152