### PR TITLE
Remove unneeded ibm copyright

### DIFF
--- a/src/java.desktop/share/native/libawt/awt/image/gif/gifdecoder.c
+++ b/src/java.desktop/share/native/libawt/awt/image/gif/gifdecoder.c
@@ -22,11 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
- * ===========================================================================
- */
 
 #include <stdio.h>
 #include "jni.h"


### PR DESCRIPTION
We removed out only extensions patch to this file, but did not
remove the ibm copyright notice afterwards.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>