### PR TITLE
Export OPENJDK_VERSION_NUMBER_FOUR_POSITIONS only for UMA

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -230,13 +230,8 @@ $(call openj9_add_jdk_bin, java.base, j9ddr.dat)
 .PHONY : run-ddrgen
 $(OUTPUTDIR)/vm/j9ddr.dat : run-ddrgen
 run-ddrgen :
-	export \
-		CC="$(CC)" \
-		CXX="$(CXX)" \
-		$(EXPORT_MSVS_ENV_VARS) \
-		OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
-		VERSION_MAJOR=$(VERSION_FEATURE) \
-	&& $(MAKE) -C $(OUTPUTDIR)/vm/ddr -f run_omrddrgen.mk
+	export CC="$(CC)" CXX="$(CXX)" $(EXPORT_MSVS_ENV_VARS) \
+		&& $(MAKE) -C $(OUTPUTDIR)/vm/ddr -f run_omrddrgen.mk
 endif
 
 $(eval $(call openj9_add_jdk_rules, \
@@ -452,6 +447,7 @@ run-preprocessors-j9 : stage-j9 \
 		$(OUTPUTDIR)/vm/include/openj9_version_info.h
 	@$(ECHO) Running OpenJ9 preprocessors with OPENJ9_BUILDSPEC: $(OPENJ9_BUILDSPEC)
 	export BOOT_JDK=$(BOOT_JDK) $(EXPORT_MSVS_ENV_VARS) \
+		OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
 		&& $(MAKE) -C $(OUTPUTDIR)/vm $(MAKEFLAGS) -f buildtools.mk \
 			BUILD_ID=$(BUILD_ID) \
 			CMAKE=$(CMAKE) \
@@ -463,6 +459,7 @@ run-preprocessors-j9 : stage-j9 \
 			OPENJ9_BUILD=true \
 			SPEC=$(OPENJ9_BUILDSPEC) \
 			UMA_OPTIONS_EXTRA="-buildDate $(shell date +'%Y%m%d')" \
+			VERSION_MAJOR=$(VERSION_FEATURE) \
 			tools
 
 build-j9 : run-preprocessors-j9

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -5,7 +5,7 @@
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
 #
-# IBM designates this particular file as subject to the "Classpath" exception 
+# IBM designates this particular file as subject to the "Classpath" exception
 # as provided by IBM in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
@@ -35,7 +35,7 @@ JVM_TEST_IMAGE_TARGETS :=
 DEFAULT_JMOD_DEPS := j9vm-build
 PHASE_MAKEDIRS := $(TOPDIR)/closed/make/closed_make $(PHASE_MAKEDIRS)
 
-OPENJ9_MAKE := $(MAKE) -f $(TOPDIR)/closed/OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_FEATURE) OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS)
+OPENJ9_MAKE := $(MAKE) -f $(TOPDIR)/closed/OpenJ9.gmk SPEC=$(SPEC)
 OPENSSL_MAKE := $(MAKE) -f $(TOPDIR)/closed/openssl.gmk SPEC=$(SPEC)
 
 openssl-build : buildtools-langtools


### PR DESCRIPTION
With eclipse/openj9#5838 `OPENJDK_VERSION_NUMBER_FOUR_POSITIONS` and `VERSION_MAJOR` don't need to be exported as widely.