### PR TITLE
Include DDR support in the 'exploded-image'

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -224,13 +224,19 @@ $(call openj9_add_jdk_lib, java.base, \
 	)
 
 ifeq (true,$(OPENJ9_ENABLE_DDR))
-$(call openj9_add_jdk_bin, java.base, j9ddr.dat)
+
+$(call openj9_add_jdk_basic, \
+	$(addsuffix /$(OPENJ9_LIBS_SUBDIR), $(JDK_OUTPUTDIR)/lib $(call FindLibDirForModule, java.base)), \
+	j9ddr.dat)
 
 .PHONY : run-ddrgen
+
 $(OUTPUTDIR)/vm/j9ddr.dat : run-ddrgen
+
 run-ddrgen :
 	export CC="$(CC)" CXX="$(CXX)" $(EXPORT_MSVS_ENV_VARS) \
 		&& $(MAKE) -C $(OUTPUTDIR)/vm/ddr -f run_omrddrgen.mk
+
 endif # OPENJ9_ENABLE_DDR
 
 $(eval $(call openj9_add_jdk_rules, \

--- a/closed/make/DDR.gmk
+++ b/closed/make/DDR.gmk
@@ -190,15 +190,23 @@ $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
 	DEPENDS := $(BUILD_DDR_STUBS) \
 	))
 
-# Finally, build the jar for the openj9.dtfj module.
+# Build the jar for the openj9.dtfj module.
+DDR_MODULE_JAR := $(call FindLibDirForModule, openj9.dtfj)/ddr/j9ddr.jar
+
 $(eval $(call SetupJarArchive,BUILD_J9DDR_JAR, \
 	DEPENDENCIES := $(BUILD_J9DDR_MAIN_CLASSES), \
 	SRCS := $(DDR_MAIN_BIN), \
 	SUFFIXES := .class .dat .properties, \
 	EXCLUDES := $(DDR_TOP_PACKAGE)/vm29/structure, \
-	JAR := $(call FindLibDirForModule, openj9.dtfj)/ddr/j9ddr.jar \
+	JAR := $(DDR_MODULE_JAR) \
 	))
 
-build_jar : $(BUILD_J9DDR_TEST_CLASSES) $(BUILD_J9DDR_JAR)
+# Finally, put a copy of the jar in the build JDK.
+DDR_JDKOUT_JAR := $(JDK_OUTPUTDIR)/lib/ddr/j9ddr.jar
+
+$(DDR_JDKOUT_JAR) : $(DDR_MODULE_JAR) $(BUILD_J9DDR_JAR)
+	$(call install-file)
+
+build_jar : $(BUILD_J9DDR_TEST_CLASSES) $(DDR_JDKOUT_JAR)
 
 endif # DDR_GENSRC_DIR

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -68,6 +68,6 @@ openj9.dtfj-ddr-gen : j9vm-build $(addsuffix -java, java.base java.desktop openj
 openj9.dtfj-ddr-jar : openj9.dtfj-ddr-gen
 	+$(MAKE) -f $(TOPDIR)/closed/make/DDR.gmk SPEC=$(SPEC) build_jar
 
-openj9.dtfj-jmod : openj9.dtfj-ddr-jar
+openj9.dtfj-launchers : openj9.dtfj-ddr-jar
 
 endif # OPENJ9_ENABLE_DDR


### PR DESCRIPTION
* put j9ddr.dat in the correct directory on Windows
* build j9ddr.jar a prerequisite of openj9.dtfj-launchers

See eclipse/openj9#6998.