### PR TITLE
Fixing */share/classes/sun/security/util/math/intpoly/FieldGen.jsh path

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
@@ -310,7 +310,7 @@ check () {
     nashorn/make/*)
       trace  "$1 deemed not to be in the built JDK because it matches case parameter expansion nashorn/make/*"
       IN_JDK=0;;
-    share/classes/sun/security/util/math/intpoly/FieldGen.jsh)
+    */share/classes/sun/security/util/math/intpoly/FieldGen.jsh)
       trace  "$1 is not part of the built JDK"
       IN_JDK=0;;
     *) IN_JDK=1;;


### PR DESCRIPTION
Fixing */share/classes/sun/security/util/math/intpoly/FieldGen.jsh path the correct path for all java versions

Signed-off-by: Archana Nogriya <archana.nogriya@uk.ibm.com>