### PR TITLE
Set OpenJ9 ProdDefns requires class

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -71,6 +71,9 @@ requires.properties= \
     docker.support \
     test.vm.gc.nvdimm
 
+# Unset Hotspot VMProps ProdDefns requires class and replace with optional OpenJ9 class
+requires.extraPropDefns = [../../../closed/test/jtreg-ext/requires/OpenJ9PropsExt.java]
+
 # Minimum jtreg version
 requiredVersion=4.2 b14
 


### PR DESCRIPTION
Some hotspot tests apply to Openj9, which we'd like to run them regularly in test builds or run manually. In that case unset Hotspot VMProps ProdDefns requires class and replace with optional OpenJ9 class is necessary.

Signed-off-by: Sophia Guo sophiag@ca.ibm.com
