### PR TITLE
Disable LUDCL by default

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -25,7 +25,7 @@
 
 /*
  * =======================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * =======================================================================
  */
 
@@ -336,12 +336,12 @@ public class ObjectInputStream
      }
   
 
-      /** if true LUDCL/forName results would be cached, true by default starting Java8 */
+      /** if true LUDCL/forName results would be cached, false by default starting Java8 */
      private static final class GetClassCachingSettingAction
      implements PrivilegedAction<Boolean> {
  public Boolean run() {
      String property =
-         System.getProperty("com.ibm.enableClassCaching", "true");
+         System.getProperty("com.ibm.enableClassCaching", "false");
      return property.equalsIgnoreCase("true");
  }
  }


### PR DESCRIPTION
An Issue has been found with LUDCL in OpenJ9. The wrong class loader is cached causing a ClassNotFoundException. Disabling this feature by default until this is resolved. https://github.com/eclipse/openj9/issues/7332

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>