### PR TITLE
Corrected declaration of linker_md.c method to match openjdk

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/export/sys.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/export/sys.h
@@ -43,7 +43,7 @@
 
 /* Implemented in linker_md.c */
 
-void    dbgsysBuildLibName(char *, size_t, const char *, const char *);
+void    dbgsysBuildLibName(char *, int, const char *, const char *);
 void *  dbgsysLoadLibrary(const char *, char *err_buf, int err_buflen);
 void    dbgsysUnloadLibrary(void *);
 void *  dbgsysFindLibraryEntry(void *, const char *);


### PR DESCRIPTION
Fixes a problem when an openj9 patch was added to openjdk, but this file was not updated when the openjdk code was merged.
Fixes https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/146
FYI @pshipton

Signed-off-by: Adam-Thorpe <adam.thorpe@ibm.com>