### PR TITLE
Fix LUDCL optimization

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -336,12 +336,12 @@ public class ObjectInputStream
     }
   
 
-    /** if true LUDCL/forName results would be cached, false by default starting Java8 */
+    /** if true LUDCL/forName results would be cached, true by default starting Java8 */
     private static final class GetClassCachingSettingAction
     implements PrivilegedAction<Boolean> {
         public Boolean run() {
             String property =
-                System.getProperty("com.ibm.enableClassCaching", "false");
+                System.getProperty("com.ibm.enableClassCaching", "true");
             return property.equalsIgnoreCase("true");
         }
     }
@@ -2336,7 +2336,7 @@ public class ObjectInputStream
                         curContext = new SerialCallbackContext(obj, slotDesc);
 
                         bin.setBlockDataMode(true);
-                        
+
                         /* user code is invoked */
                         refreshLudcl = true;
                         slotDesc.invokeReadObject(obj, this);

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -346,6 +346,10 @@ public class ObjectInputStream
         }
     }
     private ClassLoader cachedLudcl;
+    /* If user code is invoked in the middle of a call to readObject the cachedLudcl
+     * must be refreshed as the ludcl could have been changed while in user code.
+     */
+    private boolean refreshLudcl = false;
 
     /**
      * Creates an ObjectInputStream that reads from the specified InputStream.
@@ -494,9 +498,9 @@ public class ObjectInputStream
         }
 
         ClassLoader oldCachedLudcl = null;
-	boolean setCached = false;
+	    boolean setCached = false;
 	
-	if ((curContext == null) && (isClassCachingEnabled)) {
+	    if (((null == curContext) || refreshLudcl) && (isClassCachingEnabled)) {
             oldCachedLudcl = cachedLudcl;
 
             // If caller is not provided, follow the standard path to get the cachedLudcl.
@@ -509,6 +513,7 @@ public class ObjectInputStream
             }
 
             setCached = true;
+            refreshLudcl = false;
         }
 
         // if nested read, passHandle contains handle of enclosing object
@@ -613,10 +618,11 @@ public class ObjectInputStream
         ClassLoader oldCachedLudcl = null;
         boolean setCached = false; 
 
-        if ((curContext == null) && (isClassCachingEnabled)) {
+        if (((null == curContext) || refreshLudcl) && (isClassCachingEnabled)) {
             oldCachedLudcl = cachedLudcl;
             cachedLudcl = latestUserDefinedLoader();
             setCached = true;
+            refreshLudcl = false;
         }
 
         // if nested read, passHandle contains handle of enclosing object
@@ -793,10 +799,15 @@ public class ObjectInputStream
     {
         String name = desc.getName();
         try {
-        	return ((classCache == null) ?
-        	        Class.forName(name, false, latestUserDefinedLoader()) :
-        	        classCache.get(name, cachedLudcl));
-           	
+            if (null == classCache) {
+                return Class.forName(name, false, latestUserDefinedLoader());
+            } else {
+                if (refreshLudcl) {
+                    cachedLudcl = latestUserDefinedLoader();
+                    refreshLudcl = false;
+                }
+                return classCache.get(name, cachedLudcl);
+            }
         } catch (ClassNotFoundException ex) {
             Class<?> cl = primClasses.get(name);
             if (cl != null) {
@@ -2203,6 +2214,8 @@ public class ObjectInputStream
             handles.lookupException(passHandle) == null &&
             desc.hasReadResolveMethod())
         {
+            /* user code is invoked */
+            refreshLudcl = true;
             Object rep = desc.invokeReadResolve(obj);
             if (unshared && rep.getClass().isArray()) {
                 rep = cloneArray(rep);
@@ -2323,6 +2336,9 @@ public class ObjectInputStream
                         curContext = new SerialCallbackContext(obj, slotDesc);
 
                         bin.setBlockDataMode(true);
+                        
+                        /* user code is invoked */
+                        refreshLudcl = true;
                         slotDesc.invokeReadObject(obj, this);
                     } catch (ClassNotFoundException ex) {
                         /*
@@ -2375,6 +2391,8 @@ public class ObjectInputStream
                     slotDesc.hasReadObjectNoDataMethod() &&
                     handles.lookupException(passHandle) == null)
                 {
+                    /* user code is invoked */
+                    refreshLudcl = true;
                     slotDesc.invokeReadObjectNoData(obj);
                 }
             }

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -326,25 +326,25 @@ public class ObjectInputStream
      * read* requests
      */
 
-      /* ClassCache Entry for caching class.forName results upon enableClassCaching */
-     private static final ClassCache classCache;
-     private static final boolean isClassCachingEnabled;
-     static {
-          isClassCachingEnabled =
-             AccessController.doPrivileged(new GetClassCachingSettingAction());
-         classCache = (isClassCachingEnabled ? new ClassCache() : null);
-     }
+    /* ClassCache Entry for caching class.forName results upon enableClassCaching */
+    private static final ClassCache classCache;
+    private static final boolean isClassCachingEnabled;
+    static {
+        isClassCachingEnabled =
+            AccessController.doPrivileged(new GetClassCachingSettingAction());
+        classCache = (isClassCachingEnabled ? new ClassCache() : null);
+    }
   
 
-      /** if true LUDCL/forName results would be cached, false by default starting Java8 */
-     private static final class GetClassCachingSettingAction
-     implements PrivilegedAction<Boolean> {
- public Boolean run() {
-     String property =
-         System.getProperty("com.ibm.enableClassCaching", "false");
-     return property.equalsIgnoreCase("true");
- }
- }
+    /** if true LUDCL/forName results would be cached, false by default starting Java8 */
+    private static final class GetClassCachingSettingAction
+    implements PrivilegedAction<Boolean> {
+        public Boolean run() {
+            String property =
+                System.getProperty("com.ibm.enableClassCaching", "false");
+            return property.equalsIgnoreCase("true");
+        }
+    }
     private ClassLoader cachedLudcl;
 
     /**


### PR DESCRIPTION
Port from ibmruntimes/openj9-openjdk-jdk8#341
Doc issue: eclipse/openj9-docs#413

The assumption that the ludcl will not change during a call to readObject/readUnshared can only be made if user code is not invoked. This change triggers a refresh of the cachedLudcl when a user method is invoked.
Re-enable ludcl caching by default (com.ibm.enableClassCaching)

Signed-off-by: Theresa Mammarella Theresa.T.Mammarella@ibm.com