### PR TITLE
Set default load address for launchers on s390x

### DIFF
--- a/make/launcher/LauncherCommon.gmk
+++ b/make/launcher/LauncherCommon.gmk
@@ -23,6 +23,11 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+#
+
 include JdkNativeCompilation.gmk
 include Modules.gmk
 include ProcessMarkdown.gmk
@@ -81,6 +86,16 @@ JAVA_MANIFEST := $(TOPDIR)/src/java.base/windows/native/launcher/java.manifest
 SetupBuildLauncher = $(NamedParamsMacroTemplate)
 define SetupBuildLauncherBody
   # Setup default values (unless overridden)
+  
+  ifeq ($(OPENJDK_TARGET_OS), linux)
+  # Set the image base address for zLinux 64 to 0x60000 for launchers,
+  # allows compressedRefsShift to be 0 when -Xmx is set to 2040m or more.
+  # / RTC PR 100052
+    ifeq ($(OPENJDK_TARGET_CPU), s390x)
+      $1_LDFLAGS += -Wl,-Ttext-segment=0x60000
+    endif
+  endif
+  
   ifeq ($$($1_OPTIMIZATION), )
     $1_OPTIMIZATION := LOW
   endif


### PR DESCRIPTION
Sets the load address of the launchers to 0x60000 on zlinux 64 systems. This enables compressed references with shift 0 for big heap sizes

**Before:**
```
80000000-80001000 r-xp 00000000 fd:01 12720136                           /java
80002000-80003000 r--p 00001000 fd:01 12720136                           /java
80003000-80004000 rw-p 00002000 fd:01 12720136                         /java
```
**After:**
```
00060000-00062000 r-xp 00000000 fd:01 12596074                          /java
00062000-00063000 r--p 00001000 fd:01 12596074                           /java
00063000-00064000 rw-p 00002000 fd:01 12596074                         /java
```

Issue: https://github.com/eclipse/openj9/issues/7115

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>