### PR TITLE
Set base text/data load address on aix

### DIFF
--- a/make/launcher/LauncherCommon.gmk
+++ b/make/launcher/LauncherCommon.gmk
@@ -96,6 +96,16 @@ define SetupBuildLauncherBody
     endif
   endif
   
+  # Set text/data load address for 64 bit aix to 0x100,0000,0000 (1TB) for launchers,
+  # ensures that it's out of the way of compressed heap allocation.
+  ifeq ($(OPENJDK_TARGET_OS), aix)
+    ifeq ($(OPENJDK_TARGET_CPU_BITS), 32)
+      $1_LDFLAGS += -bmaxdata:0xa0000000/dsa
+    else
+      $1_LDFLAGS += -bpT:0x10000000000
+    endif
+  endif
+  
   ifeq ($$($1_OPTIMIZATION), )
     $1_OPTIMIZATION := LOW
   endif


### PR DESCRIPTION
Set the load address for 64 bit aix to 0x100,0000,0000 (1TB) for launchers. This ensures that the text/data segment is out of the way of compressed heap allocation.

**Before:**
```
100000000         100016332              88K r-x   m     MAINTEXT   8c0b18           java 
110000b84         110009940              35K rw-   m     MAINDATA   80b1c1           java
```
**After:**
```
10000000000       10000025a32           150K r-x   m     MAINTEXT   8a1594           java 
10010000dd0       10010009ce0            35K rw-   m     MAINDATA   82a0a5           java 
```

Issue: https://github.com/eclipse/openj9/issues/7458

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>