### PR TITLE
Remove the check on a specific OpenSSL API for JITServer

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -616,19 +616,6 @@ AC_DEFUN([CONFIGURE_OPENSSL],
     AC_MSG_CHECKING([if we should bundle openssl])
     AC_MSG_RESULT([$BUNDLE_OPENSSL])
 
-    if test "x$OPENJ9_ENABLE_JITSERVER" = xtrue ; then
-      if test "x$OPENJDK_TARGET_OS" = xlinux ; then
-        if test "x$OPENSSL_DIR" != x ; then
-          AC_MSG_CHECKING([if the required OPENSSL API exists for JITServer in $OPENSSL_DIR])
-          if $GREP -q -w SSL_CTX_set_ecdh_auto "$OPENSSL_DIR/include/openssl/ssl.h" 2> /dev/null ; then
-            AC_MSG_RESULT([yes])
-          else
-            AC_MSG_RESULT([no])
-            AC_MSG_ERROR([SSL_CTX_set_ecdh_auto is required by JITServer])
-          fi
-        fi
-      fi
-    fi
   fi
 
   AC_SUBST(OPENSSL_BUNDLE_LIB_PATH)


### PR DESCRIPTION
With the change in eclipse/openj9#8145, `OpenSSL` symbols are
dynamically loaded at the runtime. During the build time,
there is no longer a dependency on the installed `OpenSSL`
version on the build machines. Removed the code that
checks `SSL_CTX_set_ecdh_auto` during config.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>