### PR TITLE
Add new flag J9VM_OPT_JITSERVER to enable JITServer

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -219,9 +219,9 @@ endif
 
 # Adjust JITServer enablement flags.
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-  FEATURE_SED_SCRIPT += $(call SedEnable,build_jitserver)
+  FEATURE_SED_SCRIPT += $(call SedEnable,opt_jitserver)
 else
-  FEATURE_SED_SCRIPT += $(call SedDisable,build_jitserver)
+  FEATURE_SED_SCRIPT += $(call SedDisable,opt_jitserver)
 endif
 
 # Disable windows rebase.
@@ -317,7 +317,7 @@ ifneq (,$(OPENJ9_DEVELOPER_DIR))
 endif
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
   ifneq (true,$(OPENJ9_ENABLE_CMAKE))
-    CUSTOM_COMPILER_ENV_VARS += JITSERVER_SUPPORT=1
+    CUSTOM_COMPILER_ENV_VARS += J9VM_OPT_JITSERVER=1
 
     ifneq (,$(OPENSSL_CFLAGS))
       CUSTOM_COMPILER_ENV_VARS += OPENSSL_CFLAGS="$(OPENSSL_CFLAGS)"


### PR DESCRIPTION
The macro used for building JITServer in OpenJ9 is changed from
JITSERVER_SUPPORT to J9VM_OPT_JITSERVER. The makefile OpenJ9.mk
needs to be updated to set the correct env variable.
~~Older env variable JITSERVER_SUPPORT would be kept until changes
in OpenJ9 are not done to avoid any build breaks.~~

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>