### PR TITLE
CMake: Ensure cmake uses the NASM executable that we tested

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -374,6 +374,9 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
     else
       CMAKE_ARGS += -DCMAKE_CXX_COMPILER="$(ac_cv_prog_CXX)"
     endif
+    ifneq (,$(NASM))
+      CMAKE_ARGS += -DCMAKE_ASM_NASM_COMPILER="$(NASM)"
+    endif
   endif # windows
 
   ifneq (,$(CCACHE))

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -441,36 +441,33 @@ AC_DEFUN([OPENJ9_CHECK_NASM_VERSION],
   OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($host_cpu)
 
   if test "x$OPENJ9_CPU" = xx86-64 ; then
-    AC_PATH_PROG([NASM],[nasm])
-    if test "x$NASM" != x ; then
-      AC_MSG_CHECKING([whether nasm version requirement is met])
+    UTIL_REQUIRE_PROGS([NASM], [nasm])
+    AC_MSG_CHECKING([whether nasm version requirement is met])
 
-      # Require NASM v2.11+. This is checked by trying to build conftest.c
-      # containing an instruction that makes use of zmm registers that are
-      # supported on NASM v2.11+
-      AC_LANG_CONFTEST([AC_LANG_SOURCE([vdivpd zmm0, zmm1, zmm3;])])
+    # Require NASM v2.11+. This is checked by trying to build conftest.c
+    # containing an instruction that makes use of zmm registers that are
+    # supported on NASM v2.11+
+    AC_LANG_CONFTEST([AC_LANG_SOURCE([vdivpd zmm0, zmm1, zmm3;])])
 
-      # the following hack is needed because conftest.c contains C preprocessor
-      # directives defined in confdefs.h that would cause nasm to error out
-      $SED -i -e '/vdivpd/!d' conftest.c
+    # the following hack is needed because conftest.c contains C preprocessor
+    # directives defined in confdefs.h that would cause nasm to error out
+    $SED -i -e '/vdivpd/!d' conftest.c
 
-      if $NASM -f elf64 conftest.c 2> /dev/null ; then
-        AC_MSG_RESULT([yes])
-      else
-        # NASM version string is of the following format:
-        # ---
-        # NASM version 2.14.02 compiled on Dec 27 2018
-        # ---
-        # Some builds may not contain any text after the version number
-        #
-        # NASM_VERSION is set within square brackets so that the sed expression would not
-        # require quadrigraps to represent square brackets
-        [NASM_VERSION=`$NASM -v | $SED -e 's/^.* \([2-9]\.[0-9][0-9]\.[0-9][0-9]\).*$/\1/'`]
-        AC_MSG_ERROR([nasm version detected: $NASM_VERSION; required version 2.11+])
-      fi
+    if $NASM -f elf64 conftest.c 2> /dev/null ; then
+      AC_MSG_RESULT([yes])
     else
-      AC_MSG_ERROR([nasm not found])
+      # NASM version string is of the following format:
+      # ---
+      # NASM version 2.14.02 compiled on Dec 27 2018
+      # ---
+      # Some builds may not contain any text after the version number
+      #
+      # NASM_VERSION is set within square brackets so that the sed expression would not
+      # require quadrigraps to represent square brackets
+      [NASM_VERSION=`$NASM -v | $SED -e 's/^.* \([2-9]\.[0-9][0-9]\.[0-9][0-9]\).*$/\1/'`]
+      AC_MSG_ERROR([nasm version detected: $NASM_VERSION; required version 2.11+])
     fi
+    AC_SUBST([NASM])
   fi
 ])
 

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -39,6 +39,7 @@ OPENJ9OMR_TOPDIR        := @OPENJ9OMR_TOPDIR@
 OPENJ9_CC               := @OPENJ9_CC@
 OPENJ9_CXX              := @OPENJ9_CXX@
 OPENJ9_DEVELOPER_DIR    := @OPENJ9_DEVELOPER_DIR@
+NASM                    := @NASM@
 
 # treatment of warnings in native code
 WARNINGS_AS_ERRORS_OMR    := @WARNINGS_AS_ERRORS_OMR@

--- a/closed/autoconf/toolchain-win.cmake.in
+++ b/closed/autoconf/toolchain-win.cmake.in
@@ -37,11 +37,12 @@ else()
 endif()
 set(CMAKE_ASM_NASM_COMPILER "${tool_dir}/nasm" CACHE FILEPATH "")
 
-set(Java_JAR_EXECUTABLE "${tool_dir}/jar" CACHE FILEPATH "")
-set(Java_JAVA_EXECUTABLE "${tool_dir}/java" CACHE FILEPATH "")
-set(Java_JAVAC_EXECUTABLE "${tool_dir}/javac" CACHE FILEPATH "")
+set(CMAKE_Java_AR "${tool_dir}/jar" CACHE FILEPATH "")
+set(CMAKE_Java_RUNTIME "${tool_dir}/java" CACHE FILEPATH "")
+set(CMAKE_Java_COMPILER "${tool_dir}/javac" CACHE FILEPATH "")
 
-set(OMR_EXE_LAUNCHER "@FIXPATH_BIN@;-c" CACHE STRING "")
+separate_arguments(FIXPATH UNIX_COMMAND "@FIXPATH@")
+set(OMR_EXE_LAUNCHER "${FIXPATH}" CACHE STRING "")
 
 # CMake will test to see if compiler works by getting it to compile files in
 # /usr/lib, which fixpath wont translate


### PR DESCRIPTION
On some platforms (osx, windows), CMake uses a hardcoded search path
rather than walking $PATH. To make sure that we use the version of
NASM that we tested, manually sed the cache variable (as we do for the
C/C++ compilers)

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>