### PR TITLE
Update CMake toolchain file for windows

### DIFF
--- a/closed/autoconf/toolchain-win.cmake.in
+++ b/closed/autoconf/toolchain-win.cmake.in
@@ -37,11 +37,12 @@ else()
 endif()
 set(CMAKE_ASM_NASM_COMPILER "${tool_dir}/nasm" CACHE FILEPATH "")
 
-set(Java_JAR_EXECUTABLE "${tool_dir}/jar" CACHE FILEPATH "")
-set(Java_JAVA_EXECUTABLE "${tool_dir}/java" CACHE FILEPATH "")
-set(Java_JAVAC_EXECUTABLE "${tool_dir}/javac" CACHE FILEPATH "")
+set(CMAKE_Java_AR "${tool_dir}/jar" CACHE FILEPATH "")
+set(CMAKE_Java_RUNTIME "${tool_dir}/java" CACHE FILEPATH "")
+set(CMAKE_Java_COMPILER "${tool_dir}/javac" CACHE FILEPATH "")
 
-set(OMR_EXE_LAUNCHER "@FIXPATH_BIN@;-c" CACHE STRING "")
+separate_arguments(FIXPATH UNIX_COMMAND "@FIXPATH@")
+set(OMR_EXE_LAUNCHER "${FIXPATH}" CACHE STRING "")
 
 # CMake will test to see if compiler works by getting it to compile files in
 # /usr/lib, which fixpath wont translate


### PR DESCRIPTION
- Use new style CMAKE_Java_X variables instead of JAVA_X_EXECUTABLE
- Stop hardcoding arguments to fixpath

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>