### PR TITLE
Modify ProcessBuilder/Basic test options to avoid dumps for OOM

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 4199068 4738465 4937983 4930681 4926230 4931433 4932663 4986689
  *      5026830 5023243 5070673 4052517 4811767 6192449 6397034 6413313
@@ -1772,6 +1778,10 @@ public class Basic {
             List<String> list = new ArrayList<String>(javaChildArgs);
             list.add(1, String.format("-XX:OnOutOfMemoryError=%s -version",
                                       javaExe));
+            // Disable OpenJ9 OOM dumps for this OOM test, but enable others to catch unexpected problems.
+            list.add(2, "-Xdump:system:none");
+            list.add(3, "-Xdump:heap:none");
+            list.add(4, "-Xdump:system:events=gpf+abort+traceassert+corruptcache");
             list.add("ArrayOOME");
             ProcessResults r = run(new ProcessBuilder(list));
             check(r.err().contains("java.lang.OutOfMemoryError:"));


### PR DESCRIPTION
See https://github.com/AdoptOpenJDK/openjdk-tests/pull/1699

Setting the options via the test harness, either on the command line or
in the environment via OPENJ9_JAVA_OPTIONS, doesn't affect the
sub-process.

By the time a JTReg test is running, the environment has been purged.
i.e.
```
{PATH=/bin:/usr/bin:/usr/sbin, DISPLAY=:0,
CLASSPATH=/home/jenkins/workspace/Grinder/etc, LANG=en_US.UTF-8,
HOME=/home/jenkins}
```

The default OpenJ9 options produce unnecessary system dumps which are
multi GB in size. When failures occur or results are archived, the
system dumps bloat the size of the result artifact, consuming more space
and increasing download times.

See also https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/404
Tested via https://ci.eclipse.org/openj9/view/Test/job/Grinder/837