### PR TITLE
Rename OpenJ9 build specs for Linux PPC LE platforms

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -356,10 +356,8 @@ AC_DEFUN([OPENJ9_PLATFORM_SETUP],
     fi
   elif test "x$OPENJ9_CPU" = xppc-64_le ; then
     OPENJ9_PLATFORM_CODE=xl64
-    if test "x$OPENJ9_LIBS_SUBDIR" = xdefault ; then
-      OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_le_gcc"
-    else
-      OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_cmprssptrs_le_gcc"
+    if test "x$OPENJ9_LIBS_SUBDIR" != xdefault ; then
+      OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_cmprssptrs_le"
     fi
   elif test "x$OPENJ9_CPU" = x390-64 ; then
     OPENJ9_PLATFORM_CODE=xz64


### PR DESCRIPTION
Rename OPENJ9_BUILDSPEC for the Linux PPC LE, remove _gcc from their
names.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>