### PR TITLE
Implement ClassLoaderHelper.mapAlternativeName() for AIX .a library

### DIFF
--- a/src/java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java
+++ b/src/java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.loader;
+
+import java.io.File;
+import java.util.ArrayList;
+
+class ClassLoaderHelper {
+
+    private ClassLoaderHelper() {}
+
+    /**
+     * Returns an alternate path name for the given file
+     * such that if the original pathname did not exist, then the
+     * file may be located at the alternate location.
+     * For AIX, this replaces the final .so suffix with .a
+     */
+    static File mapAlternativeName(File lib) {
+        String name = lib.toString();
+        int index = name.lastIndexOf('.');
+        if (index < 0) {
+            return null;
+        }
+        return new File(name.substring(0, index) + ".a");
+    }
+
+    /**
+     * Parse a PATH env variable.
+     *
+     * Empty elements will be replaced by dot.
+     */
+    static String[] parsePath(String ldPath) {
+        char ps = File.pathSeparatorChar;
+        ArrayList<String> paths = new ArrayList<>();
+        int pathStart = 0;
+        int pathEnd;
+        while ((pathEnd = ldPath.indexOf(ps, pathStart)) >= 0) {
+            paths.add((pathStart < pathEnd) ?
+                    ldPath.substring(pathStart, pathEnd) : ".");
+            pathStart = pathEnd + 1;
+        }
+        int ldLen = ldPath.length();
+        paths.add((pathStart < ldLen) ?
+                ldPath.substring(pathStart, ldLen) : ".");
+        return paths.toArray(new String[paths.size()]);
+    }
+}


### PR DESCRIPTION
**Implement ClassLoaderHelper.mapAlternativeName() for AIX .a library**

Create `java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java`;
Replace the final `.so` suffix with `.a` for `AIX` platform.

Verified that with this PR, `-version` still runs successfully after renaming `libnio.so` to `libnio.a`, w/o it, `UnsatisfiedLinkError` occurs as following:
```
Exception in thread "main" java/lang/UnsatisfiedLinkError: sun/nio/fs/UnixNativeDispatcher.init()I
        at sun/nio/fs/UnixNativeDispatcher.<clinit> (java.base@9/UnixNativeDispatcher.java:654)
        at sun/nio/fs/UnixFileSystem.<init> (java.base@9/UnixFileSystem.java:65)
        at sun/nio/fs/AixFileSystem.<init> (java.base@9/AixFileSystem.java:42)
        at sun/nio/fs/AixFileSystemProvider.newFileSystem (java.base@9/AixFileSystemProvider.java:42)
        at sun/nio/fs/AixFileSystemProvider.newFileSystem (java.base@9/AixFileSystemProvider.java:35)
        at sun/nio/fs/UnixFileSystemProvider.<init> (java.base@9/UnixFileSystemProvider.java:56)
        at sun/nio/fs/DefaultFileSystemProvider.<clinit> (java.base@9/DefaultFileSystemProvider.java:35)
        at java/nio/file/FileSystems.getDefault (java.base@9/FileSystems.java:185)
        at java/nio/file/Path.of (java.base@9/Path.java:147)
        at java/nio/file/Paths.get (java.base@9/Paths.java:69)
        at jdk/internal/loader/BuiltinClassLoader.setJimageURL (java.base@9/BuiltinClassLoader.java:271)
        at jdk/internal/loader/BuiltinClassLoader$LoadedModule.convertJrtToFileURL (java.base@9/BuiltinClassLoader.java:331)
        at jdk/internal/loader/BuiltinClassLoader$LoadedModule.<init> (java.base@9/BuiltinClassLoader.java:305)
        at jdk/internal/loader/BuiltinClassLoader.loadModule (java.base@9/BuiltinClassLoader.java:390)
        at jdk/internal/loader/BootLoader.loadModule (java.base@9/BootLoader.java:119)
        at jdk/internal/module/ModuleBootstrap.boot (java.base@9/ModuleBootstrap.java:236)
        at java/lang/ClassLoader.initializeClassLoaders (java.base@9/ClassLoader.java:211)
        at java/lang/Thread.initialize (java.base@9/Thread.java:436)
        at java/lang/Thread.<init> (java.base@9/Thread.java:161)
```

A few notes:
1. Reuse `java.base/unix/classes/jdk/internal/loader/ClassLoaderHelper.java` which has an empty implementation, if there is a need for unix-alike platform, `java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java` can be created instead.
2. This is a replay of `OSX` https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/81a6e58c25e4ce880037d14345a068011e4a0d3f/src/java.base/macosx/classes/jdk/internal/loader/ClassLoaderHelper.java#L35-L48 for `AIX` platform.
3. This PR can only help the code invoking `ClassLoaderHelper.mapAlternativeName(libname)` after a failed attempt with `System.mapLibraryName(name)` https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/521b2f12fc414d54b42baebf0cbdec6ec8a27390/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java#L307-L323
It won't help the code only invoking `System.mapLibraryName(name)` https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/521b2f12fc414d54b42baebf0cbdec6ec8a27390/src/java.management/share/classes/javax/management/loading/MLet.java#L1011-L1018
4. We would like contribute this PR to OpenJDK community and also request to add fallback code `ClassLoaderHelper.mapAlternativeName(libname)` for all code invoking `System.mapLibraryName(name)`.

Related: https://github.com/eclipse/openj9/issues/9518

Reviewer: @DanHeidinga 
FYI: @andrew-m-leonard 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>