### PR TITLE
Update makefiles for recent openjdk changes (part 2)

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -185,7 +185,7 @@ DDR_ALIAS_FILES := \
 
 # Compile the Java sources.
 $(eval $(call SetupJavaCompilation,BUILD_J9DDR_MAIN_CLASSES, \
-	ADD_JAVAC_FLAGS := --upgrade-module-path $(JDK_OUTPUTDIR)/modules --system none, \
+	JAVAC_FLAGS := --upgrade-module-path $(JDK_OUTPUTDIR)/modules --system none, \
 	BIN := $(DDR_MAIN_BIN), \
 	CLASSPATH := $(DDR_CLASSPATH), \
 	SRC := $(DDR_VM_SRC_ROOT) $(DDR_GENSRC_DIR), \
@@ -197,7 +197,7 @@ $(eval $(call SetupJavaCompilation,BUILD_J9DDR_MAIN_CLASSES, \
 # Compile DDR code again, to ensure compatibility with class files
 # as they would be dynamically generated from the blob.
 $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
-	ADD_JAVAC_FLAGS := --upgrade-module-path $(JDK_OUTPUTDIR)/modules --system none, \
+	JAVAC_FLAGS := --upgrade-module-path $(JDK_OUTPUTDIR)/modules --system none, \
 	BIN := $(DDR_TEST_BIN), \
 	CLASSPATH := $(DDR_CLASSES_BIN) $(DDR_CLASSPATH), \
 	SRC := $(DDR_VM_SRC_ROOT), \


### PR DESCRIPTION
Adapt organization of makefiles for:
  8244044: Refactor phase makefiles to be structured per module

The `ADD_JAVAC_FLAGS` argument to `SetupJavaCompilation` has been renamed to `JAVAC_FLAGS` (this change was missed in #202).

Note this is a merge to the openj9-staging branch.