### PR TITLE
Workaround missing rule for test-image-failure-handler

### DIFF
--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -112,3 +112,11 @@ openj9.dtfj-ddr-jar : openj9.dtfj-ddr-gen
 openj9.dtfj-launchers : openj9.dtfj-ddr-jar
 
 endif # OPENJ9_ENABLE_DDR
+
+# An unconditional dependency is declared in make/Main.gmk:
+#   test-image : test-image-failure-handler
+# If BUILD_FAILURE_HANDLER is not true, test-image-failure-handler
+# is not even declared as a .PHONY target: this fixes that.
+ifneq (true,$(BUILD_FAILURE_HANDLER))
+  .PHONY : test-image-failure-handler
+endif


### PR DESCRIPTION
Configure sets `BUILD_FAILURE_HANDLER` to true or false dependending on whether `JT_HOME` is set or not. In our builds `configure` says:
```
checking if the jtreg failure handler is available... no (jtreg not present)
checking if the jtreg failure handler should be built... disabled, from default 'auto'
```
The dependency
```
test-image : test-image-failure-handler
```
is unconditional, but the rule for `test-image-failure-handler` is only declared if `BUILD_FAILURE_HANDLER` is true. The declaration that it is a `.PHONY` target is also conditional.

This works around that deficiency of openjdk makefiles.

Note this is a merge to the openj9-staging branch.