### PR TITLE
Ability to pass a reference repo to get_source.sh

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -33,10 +33,12 @@ usage() {
 	echo "                    or git@github.com:<namespace>/openj9.git"
 	echo "  -openj9-branch    the OpenJ9 git branch: master"
 	echo "  -openj9-sha       a commit SHA for the OpenJ9 repository"
+	echo "  -openj9-reference a local repo to use as a clone reference"
 	echo "  -omr-repo         the OpenJ9/omr repository url: https://github.com/eclipse/openj9-omr.git"
 	echo "                    or git@github.com:<namespace>/openj9-omr.git"
 	echo "  -omr-branch       the OpenJ9/omr git branch: openj9"
 	echo "  -omr-sha          a commit SHA for the omr repository"
+	echo "  -omr-reference    a local repo to use as a clone reference"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
 	echo ""
 	exit 1
@@ -52,6 +54,7 @@ declare -A branches
 declare -A commands
 declare -A git_urls
 declare -A shas
+declare -A references
 
 git_urls[openj9]=https://github.com/eclipse/openj9
 branches[openj9]=master
@@ -79,6 +82,10 @@ for i in "$@" ; do
 			shas[openj9]="${i#*=}"
 			;;
 
+		-openj9-reference=* )
+			references[openj9]="${i#*=}"
+			;;
+
 		-omr-repo=* )
 			git_urls[omr]="${i#*=}"
 			;;
@@ -89,6 +96,10 @@ for i in "$@" ; do
 
 		-omr-sha=* )
 			shas[omr]="${i#*=}"
+			;;
+
+		-omr-reference=* )
+			references[omr]="${i#*=}"
 			;;
 
 		-parallel=* )
@@ -130,7 +141,10 @@ for i in "${!git_urls[@]}" ; do
 		fi
 		cd - > /dev/null
 	else
-		git_clone_command="git clone --recursive -b ${branch} ${git_urls[$i]} ${i}"
+		if [ ${references[$i]+_} ] ; then
+			reference="--reference ${references[$i]}"
+		fi
+		git_clone_command="git clone ${reference} --recursive -b ${branch} ${git_urls[$i]} ${i}"
 		commands[$i]=$git_clone_command
 
 		echo

--- a/get_source.sh
+++ b/get_source.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,12 @@ usage() {
 	echo "                    or git@github.com:<namespace>/openj9.git"
 	echo "  -openj9-branch    the OpenJ9 git branch: master"
 	echo "  -openj9-sha       a commit SHA for the OpenJ9 repository"
+	echo "  -openj9-reference a local repo to use as a clone reference"
 	echo "  -omr-repo         the OpenJ9/omr repository url: https://github.com/eclipse/openj9-omr.git"
 	echo "                    or git@github.com:<namespace>/openj9-omr.git"
 	echo "  -omr-branch       the OpenJ9/omr git branch: openj9"
 	echo "  -omr-sha          a commit SHA for the omr repository"
+	echo "  -omr-reference    a local repo to use as a clone reference"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
 	echo "  --openssl-version Specify the version of OpenSSL source to download"
 	echo ""
@@ -54,7 +56,7 @@ for i in "$@" ; do
 			usage
 			;;
 
-		-openj9-repo=* | -openj9-branch=* | -openj9-sha=* | -omr-repo=* | -omr-branch=* | -omr-sha=* | -parallel=* )
+		-openj9-repo=* | -openj9-branch=* | -openj9-sha=* | -openj9-reference=* | -omr-repo=* | -omr-branch=* | -omr-sha=* | -omr-reference=* | -parallel=* )
 			j9options="${j9options} ${i}"
 			;;
 


### PR DESCRIPTION
- Speed up get_source clones by using a local
  reference repository cache.

Issue eclipse/openj9#6744

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>