### PR TITLE
Do not use rebind in StringConcatFactory

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved.
+ * ===========================================================================
+ */
 
 package java.lang.invoke;
 
@@ -646,7 +651,7 @@ public final class StringConcatFactory {
             MethodHandle prepend = JLA.stringConcatHelper("prepend",
                     methodType(long.class, long.class, byte[].class,
                             Wrapper.asPrimitiveType(c), String.class));
-            return prepend.rebind();
+            return prepend;
         }
     };
 
@@ -663,7 +668,7 @@ public final class StringConcatFactory {
         public MethodHandle apply(Class<?> c) {
             MethodHandle mix = JLA.stringConcatHelper("mix",
                     methodType(long.class, long.class, Wrapper.asPrimitiveType(c)));
-            return mix.rebind();
+            return mix;
         }
     };
 
@@ -673,7 +678,7 @@ public final class StringConcatFactory {
         if (mh == null) {
             MethodHandle simpleConcat = JLA.stringConcatHelper("simpleConcat",
                     methodType(String.class, Object.class, Object.class));
-            SIMPLE_CONCAT = mh = simpleConcat.rebind();
+            SIMPLE_CONCAT = mh = simpleConcat;
         }
         return mh;
     }
@@ -684,7 +689,7 @@ public final class StringConcatFactory {
         if (mh == null) {
             MethodHandle newString = JLA.stringConcatHelper("newString",
                     methodType(String.class, byte[].class, long.class));
-            NEW_STRING = mh = newString.rebind();
+            NEW_STRING = mh = newString;
         }
         return mh;
     }
@@ -695,7 +700,7 @@ public final class StringConcatFactory {
         if (mh == null) {
             MethodHandle newArrayWithSuffix = JLA.stringConcatHelper("newArrayWithSuffix",
                     methodType(byte[].class, String.class, long.class));
-            NEW_ARRAY_SUFFIX = mh = newArrayWithSuffix.rebind();
+            NEW_ARRAY_SUFFIX = mh = newArrayWithSuffix;
         }
         return MethodHandles.insertArguments(mh, 0, suffix);
     }


### PR DESCRIPTION
OpenJ9 does not support MethodHandle.rebind. So, its usage has been temporarily
removed from StringConcatFactory until OpenJ9 supports OpenJDK MethodHandles.

Fixes: eclipse/openj9#9771

Identical to https://github.com/ibmruntimes/openj9-openjdk-jdk15/pull/4.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>