### PR TITLE
Copyrights JDK8 : Found Oracle Proprietary copyright under jdk/test

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
@@ -313,6 +313,9 @@ check () {
     make/ide/*)
       trace  "$1 deemed not to be in the built JDK because it matches case parameter expansion make/ide/*"
       IN_JDK=0;;
+    jdk/test/*)
+      trace  "$1 deemed not to be in the built JDK because it matches case parameter expansion jdk/test/*"
+      IN_JDK=0;;
     make/jdk/src/classes/build/tools/*)
       trace  "$1 deemed not to be in the built JDK because it matches case parameter expansion make/jdk/src/classes/build/tools/*"
       IN_JDK=0;;  


### PR DESCRIPTION
https://github.ibm.com/runtimes/openjdk-contribution/issues/1246
excluding jdk/test in script.

Raising with OpenJDK as well in sametime. Locally tested the changes and
it works.

Signed-off-by: Archana Nogriya <archana.nogriya@uk.ibm.com>