### PR TITLE
The exclusion as know issue was done only for jdk8 and not for jdk 15.

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
@@ -608,6 +608,8 @@ echo "jdk/make/src/native/add_gnu_debuglink/add_gnu_debuglink.c" >>$TEMPFILE
 echo "jdk/make/src/native/fix_empty_sec_hdr_flags/fix_empty_sec_hdr_flags.c" >>$TEMPFILE
 echo "jdk/src/macosx/native/jobjc/JObjC.xcodeproj/default.pbxuser" >>$TEMPFILE
 echo "jdk/src/share/classes/org/jcp/xml/dsig/internal/dom/DOMXPathFilter2Transform.java" >>$TEMPFILE
+echo "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMXPathFilter2Transform.java" >>$TEMPFILE
+echo "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/XMLDSigRI.java" >>$TEMPFILE
 echo "jdk/src/share/classes/org/jcp/xml/dsig/internal/dom/XMLDSigRI.java" >>$TEMPFILE
 # The following file refers to the license in other source files. That license is GPL v3 without classpath exception, but the files
 # themselves are not actually present in the openjdk source repository


### PR DESCRIPTION
https://github.ibm.com/runtimes/javanext/issues/235


Signed-off-by: Archana Nogriya <archana.nogriya@uk.ibm.com>