### PR TITLE
Add empty files PhantomReference.c and Reference.c

### DIFF
--- a/closed/src/java.base/share/native/libjava/PhantomReference.c
+++ b/closed/src/java.base/share/native/libjava/PhantomReference.c
@@ -1,0 +1,21 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */

--- a/closed/src/java.base/share/native/libjava/Reference.c
+++ b/closed/src/java.base/share/native/libjava/Reference.c
@@ -1,0 +1,21 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */


### PR DESCRIPTION
Recently added in Java 16 is `Reference.refersTo(Object)`; the openjdk natives are inappropriate for use with OpenJ9 which has it's own implementation of `Reference` and `PhantomReference`. These empty files suppress use of the openjdk native code.

```
23:20:42  ./src/java.base/share/native/libjava/PhantomReference.c:27:10: fatal error: java_lang_ref_PhantomReference.h: No such file or directory
23:20:42   #include "java_lang_ref_PhantomReference.h"
23:20:42            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Note this targets the openj9-staging branch.

Fixes https://github.com/eclipse/openj9/issues/11119