### PR TITLE
JDK changes to support JEP383 with OpenJ9

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -23,6 +23,11 @@
  *  questions.
  *
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved.
+ * ===========================================================================
+ */
 
 package java.lang.invoke;
 
@@ -45,7 +50,7 @@ import java.util.function.BiFunction;
 /* package */ class IndirectVarHandle extends VarHandle {
 
     @Stable
-    private final MethodHandle[] handleMap = new MethodHandle[AccessMode.values().length];
+    private final MethodHandle[] handleMap;
     private final VarHandle directTarget; // cache, for performance reasons
     private final VarHandle target;
     private final BiFunction<AccessMode, MethodHandle, MethodHandle> handleFactory;
@@ -59,6 +64,7 @@ import java.util.function.BiFunction;
         this.directTarget = target.asDirect();
         this.value = value;
         this.coordinates = coordinates;
+        this.handleMap = this.handleTable = VarHandle.populateMHsJEP383(target, handleFactory);
     }
 
     @Override
@@ -95,14 +101,15 @@ import java.util.function.BiFunction;
     MethodHandle getMethodHandle(int mode) {
         MethodHandle handle = handleMap[mode];
         if (handle == null) {
-            MethodHandle targetHandle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
-            handle = handleMap[mode] = handleFactory.apply(AccessMode.values()[mode], targetHandle);
+            /* OpenJ9 pre-initializes the handleMap in the constructor. So, there is no need to reapply handleFactory here. */
+            handle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
         }
         return handle;
     }
 
     @Override
     public MethodHandle toMethodHandle(AccessMode accessMode) {
-        return getMethodHandle(accessMode.ordinal()).bindTo(directTarget);
+        MethodHandle mh = getMethodHandle(accessMode.ordinal());
+        return MethodHandles.insertArguments(mh, mh.type().parameterCount() - 1, directTarget);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved.
+ * ===========================================================================
+ */
 
 package java.lang.invoke;
 
@@ -338,13 +343,7 @@ final class VarHandles {
     }
 
     private static VarHandle maybeAdapt(VarHandle target) {
-        if (!VAR_HANDLE_IDENTITY_ADAPT) return target;
-        target = filterValue(target,
-                        MethodHandles.identity(target.varType()), MethodHandles.identity(target.varType()));
-        MethodType mtype = target.accessModeType(VarHandle.AccessMode.GET).dropParameterTypes(0, 1);
-        for (int i = 0 ; i < mtype.parameterCount() ; i++) {
-            target = filterCoordinates(target, i, MethodHandles.identity(mtype.parameterType(i)));
-        }
+        /* This optimization is disabled in OpenJ9. */
         return target;
     }
 
@@ -620,7 +619,7 @@ final class VarHandles {
             }
         } else if (handle instanceof DelegatingMethodHandle) {
             noCheckedExceptions(((DelegatingMethodHandle)handle).getTarget());
-        } else {
+        } else if (handle instanceof BoundMethodHandle) {
             //bound
             BoundMethodHandle boundHandle = (BoundMethodHandle)handle;
             for (int i = 0 ; i < boundHandle.fieldCount() ; i++) {
@@ -628,6 +627,11 @@ final class VarHandles {
                 if (arg instanceof MethodHandle){
                     noCheckedExceptions((MethodHandle) arg);
                 }
+            }
+        } else {
+            /* Temporary code to handle OpenJ9's MethodHandle implementation. This will be removed in a future release. */
+            if (MethodHandles.hasCheckedException(handle)) {
+                throw newIllegalArgumentException("Cannot adapt a var handle with a method handle which throws checked exceptions");
             }
         }
     }


### PR DESCRIPTION
The following methods have been updated to support JEP383 with OpenJ9:

- IndirectVarHandle's constructor
- IndirectVarHandle.getMethodHandle
- IndirectVarHandle.toMethodHandle
- VarHandles.maybeAdapt
- VarHandles.noCheckedExceptions

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>