### PR TITLE
Improve support for builds with multiple configurations

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -1,0 +1,67 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+.PHONY : all
+
+all :
+
+include $(SPEC)
+include $(TOPDIR)/make/common/MakeBase.gmk
+
+J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
+JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
+
+RecursiveWildcard = $(foreach dir,$(wildcard $1/*),$(call RecursiveWildcard,$(dir),$2) $(filter $(subst *,%,$2),$(dir)))
+AllJclSource = $(call RecursiveWildcard,$(OPENJ9_TOPDIR)/jcl/src,*.java)
+
+JPP_TAGS := PLATFORM-$(OPENJ9_PLATFORM_CODE)
+
+ifeq (true,$(OPENJ9_ENABLE_INLINE_TYPES))
+  JPP_TAGS += INLINE-TYPES
+endif # OPENJ9_ENABLE_INLINE_TYPES
+
+ifeq (true,$(OPENJ9_ENABLE_OPENJDK_METHODHANDLES))
+  JPP_TAGS += OPENJDK_METHODHANDLES
+endif # OPENJ9_ENABLE_OPENJDK_METHODHANDLES
+
+$(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
+	@$(ECHO) Building OpenJ9 Java Preprocessor
+	@$(MKDIR) -p $(J9TOOLS_DIR)
+	$(MAKE) $(MAKE_ARGS) -C $(OPENJ9_TOPDIR)/sourcetools -f buildj9tools.mk \
+		BOOT_JDK=$(BOOT_JDK) \
+		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
+		JAVA_HOME=$(BOOT_JDK) \
+		$(call FixPath,$(JPP_JAR))
+	@$(ECHO) Generating J9JCL sources
+	@$(BOOT_JDK)/bin/java \
+		-cp "$(call FixPath,$(JPP_JAR))" \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-verdict \
+			-baseDir "$(call FixPath,$(OPENJ9_TOPDIR))/" \
+			-config JAVA$(VERSION_FEATURE) \
+			-srcRoot jcl/ \
+			-xml jpp_configuration.xml \
+			-dest "$(call FixPath,$(J9JCL_SOURCES_DIR))" \
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
+	@$(MKDIR) -p $(@D)
+	@$(TOUCH) $@
+
+all : $(J9JCL_SOURCES_DONEFILE)

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -86,21 +86,15 @@ ifeq (false,$(WARNINGS_AS_ERRORS_OPENJ9))
 endif
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
-  # convert unix path to windows path
-  FixPath = $(shell $(CYGPATH) -m $1)
   # convert windows path to unix path
   UnixPath = $(shell $(CYGPATH) -u $1)
   # set Visual Studio environment
   # wrap PATH in quotes as it contains spaces (unix path)
   # INCLUDE, LIB are already wrapped in quotes (windows paths)
   EXPORT_MSVS_ENV_VARS := PATH="$(PATH)" INCLUDE=$(INCLUDE) LIB=$(LIB)
-  # set the output directory for shared libraries
-  OPENJ9_BIN_OR_LIB_DIR := bin
 else
-  FixPath = $1
   UnixPath = $1
   EXPORT_MSVS_ENV_VARS :=
-  OPENJ9_BIN_OR_LIB_DIR := lib
 endif
 
 .PHONY : \
@@ -108,7 +102,6 @@ endif
 	clean-j9 \
 	clean-j9-dist \
 	clean-openj9-thirdparty-binaries \
-	generate-j9jcl-sources \
 	run-preprocessors-j9 \
 	stage-j9 \
 	#
@@ -331,7 +324,6 @@ $(OPENJ9_VM_BUILD_DIR)/omr/OMR_VERSION_STRING : $(call DependOnVariable, OPENJ9O
 	$(ECHO) '#define OMR_VERSION_STRING "$(OPENJ9OMR_SHA)"' > $@
 
 run-preprocessors-j9 : \
-	generate-j9jcl-sources \
 	$(OPENJ9_VM_BUILD_DIR)/omr/OMR_VERSION_STRING \
 	$(OPENJ9_VM_BUILD_DIR)/compiler/jit.version \
 	$(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h
@@ -503,48 +495,6 @@ build-j9 : run-preprocessors-j9
 		$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm all
 	@$(ECHO) OpenJ9 compile complete
 	+$(DDR_COMMAND)
-
-J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl_sources.done
-
-recur_wildcard = $(foreach dir,$(wildcard $1/*),$(call recur_wildcard,$(dir),$2) $(filter $(subst *,%,$2),$(dir)))
-AllJclSource   = $(call recur_wildcard,$(OPENJ9_TOPDIR)/jcl/src,*.java)
-
-JPP_DEST := $(SUPPORT_OUTPUTDIR)/j9jcl_sources
-JPP_JAR  := $(J9TOOLS_DIR)/jpp.jar
-JPP_TAGS := PLATFORM-$(OPENJ9_PLATFORM_CODE)
-
-ifeq (true,$(OPENJ9_ENABLE_INLINE_TYPES))
-  JPP_TAGS += INLINE-TYPES
-endif # OPENJ9_ENABLE_INLINE_TYPES
-
-ifeq (true,$(OPENJ9_ENABLE_OPENJDK_METHODHANDLES))
-  JPP_TAGS += OPENJDK_METHODHANDLES
-endif # OPENJ9_ENABLE_OPENJDK_METHODHANDLES
-
-$(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
-	@$(ECHO) Building OpenJ9 Java Preprocessor
-	@$(MKDIR) -p $(J9TOOLS_DIR)
-	$(MAKE) $(MAKE_ARGS) -C $(OPENJ9_TOPDIR)/sourcetools -f buildj9tools.mk \
-		BOOT_JDK=$(BOOT_JDK) \
-		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
-		JAVA_HOME=$(BOOT_JDK) \
-		$(call FixPath,$(JPP_JAR))
-	@$(ECHO) Generating J9JCL sources
-	@$(BOOT_JDK)/bin/java \
-		-cp "$(call FixPath,$(JPP_JAR))" \
-		-Dfile.encoding=US-ASCII \
-		com.ibm.jpp.commandline.CommandlineBuilder \
-			-verdict \
-			-baseDir "$(call FixPath,$(OPENJ9_TOPDIR))/" \
-			-config JAVA$(VERSION_FEATURE) \
-			-srcRoot jcl/ \
-			-xml jpp_configuration.xml \
-			-dest "$(call FixPath,$(JPP_DEST))" \
-			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
-	@$(MKDIR) -p $(@D)
-	@$(TOUCH) $@
-
-generate-j9jcl-sources : $(J9JCL_SOURCES_DONEFILE)
 
 clean-j9 : clean-openj9-thirdparty-binaries
 	+$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm clean

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -156,5 +156,8 @@ else
   OPENJ9_VM_BUILD_DIR = $(OUTPUTDIR)/vm
 endif
 
+J9JCL_SOURCES_DIR      := $(SUPPORT_OUTPUTDIR)/j9jcl
+J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl.done
+
 # Disable all hotspot features.
 JVM_FEATURES_server :=

--- a/closed/custom/Docs.gmk
+++ b/closed/custom/Docs.gmk
@@ -74,7 +74,7 @@ OPENJ9_JAVADOC_TEMP  := $(SUPPORT_OUTPUTDIR)/docs/_javadoc_temp.html
 JDK_API_CUSTOM_TARGETS += $(OPENJ9_JAVADOC_MARKER)
 
 ################################################################################
-# The OpenJ9 classes are built from the j9jcl_sources and closed/src
+# The OpenJ9 classes are built from the $(J9JCL_SOURCES_DIR) and closed/src
 # directories.
 # The packages are beneath directories called /share/classes (or /unix/classes,
 # /windows/classes etc.) which do not appear in the javadoc tree structure.
@@ -102,7 +102,7 @@ OPENJ9_JAVADOC_SCRIPT_BODY = \
 # replaced after the javadoc has been created.
 $(OPENJ9_JAVADOC_MARKER) : $(OPENJDK_JAVADOC_MARKER) $(OPENJ9_ONLY_JAVADOC_MARKER)
 	$(ECHO) '$(OPENJ9_JAVADOC_SCRIPT_BODY)' >$(OPENJ9_JAVADOC_SCRIPT)
-	$(CD) $(SUPPORT_OUTPUTDIR)/j9jcl_sources ; \
+	$(CD) $(J9JCL_SOURCES_DIR) ; \
 		$(FIND) . -type f -name '*.java' \
 			| $(SED) -e 's|/[^/]\+/classes/|/|' -e 's|package-info.java$$|package-summary.html|' -e 's|\.java$$|.html|' \
 			| $(XARGS) $(BASH) $(OPENJ9_JAVADOC_SCRIPT)
@@ -155,8 +155,8 @@ OPENJ9_ONLY_INDEX_HTML := $(IMAGES_OUTPUTDIR)/openj9-docs/api/index.html
 # (via OPENJ9_ONLY_JAVADOC_FILELIST) to identify when the javadoc needs
 # regenerating.
 
-OPENJ9_ONLY_FILELIST := $(shell $(FIND) $(SUPPORT_OUTPUTDIR)/j9jcl_sources -type f)
-OPENJ9_ONLY_JAVADOC_FILELIST := $(shell $(FIND) $(SUPPORT_OUTPUTDIR)/j9jcl_sources -type f  '(' -path '*/openj9.*/*.java' -o -path '*/jdk.management/*.java' ')')
+OPENJ9_ONLY_FILELIST := $(shell $(FIND) $(J9JCL_SOURCES_DIR) -type f)
+OPENJ9_ONLY_JAVADOC_FILELIST := $(shell $(FIND) $(J9JCL_SOURCES_DIR) -type f  '(' -path '*/openj9.*/*.java' -o -path '*/jdk.management/*.java' ')')
 OPENJ9_ONLY_JAVADOC_FILES := $(SUPPORT_OUTPUTDIR)/openj9-docs/_javadoc_openj9_files.txt
 
 # Set up the javadoc command line options.
@@ -283,7 +283,7 @@ OPENJ9_ONLY_JAVADOC_SCRIPT_BODY = \
 OPENJ9_ONLY_JAVADOC_SCRIPT_BODY_ESC = $(subst ','\'',$(OPENJ9_ONLY_JAVADOC_SCRIPT_BODY))
 
 # Create a stub package-info.java file for each package with source files in
-# j9jcl_sources but no package-info.java file. This is then used by javadoc
+# $(J9JCL_SOURCES_DIR) but no package-info.java file. This is then used by javadoc
 # instead of the openjdk version to direct the user to the Oracle online
 # documentation for that package.
 

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -22,7 +22,6 @@ CLEAN_DIRS += vm
 
 .PHONY : \
 	debug-image \
-	generate-j9jcl-sources \
 	j9vm-build \
 	test-image-openj9 \
 	#
@@ -44,9 +43,6 @@ OPENJ9_MAKE := $(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/OpenJ9.gmk
 # rules make that happen.
 
 create-main-targets-include java.base-gensrc : generate-j9jcl-sources
-
-generate-j9jcl-sources :
-	@+$(OPENJ9_MAKE) $@
 
 j9vm-build : buildtools-langtools
   ifeq ($(BUILD_OPENSSL),yes)

--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -36,5 +36,18 @@ MODULES_FILTER += \
 
 TOP_SRC_DIRS += \
     $(TOPDIR)/closed/src \
-    $(SUPPORT_OUTPUTDIR)/j9jcl_sources \
+    $(J9JCL_SOURCES_DIR) \
     #
+
+.PHONY : generate-j9jcl-sources
+
+generate-j9jcl-sources $(J9JCL_SOURCES_DONEFILE) :
+	@+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/GensrcJ9JCL.gmk
+
+# When building multiple configurations at once (e.g. 'make CONF= images')
+# the 'create-main-targets-include' target will only be considered for the
+# first configuration; J9JCL source generation will be delayed for other
+# configurations. In order to produce a complete module-deps.gmk, we need
+# to ensure that the J9JCL source has been generated.
+
+-include $(J9JCL_SOURCES_DONEFILE)


### PR DESCRIPTION
* move j9jcl preprocessing to a separate makefile to enable reuse to ensure `module-deps.gmk` is based on the right set of modules
* remove redundant definition of FixPath
* remove unused macro OPENJ9_BIN_OR_LIB_DIR

The OpenJDK build system supports [multiple configurations](https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/master/doc/building.md#using-multiple-configurations).

One example use might be building both with UMA and with cmake (while cmake development is ongoing):
```
$ bash configure --with-cmake --with-conf-name=cmake
$ bash configure --with-freemarker-jar=$HOME/freemarker.jar --with-conf-name=uma
```
Or you might be working on code sensitive to how references are represented [1]:
```
$ bash configure --with-cmake --with-conf-name=normal
$ bash configure --with-cmake --with-noncompressedrefs --with-conf-name=xl
$ bash configure --with-cmake --with-mixedrefs=dynamic --with-conf-name=dynamic
$ bash configure --with-cmake --with-mixedrefs=static --with-conf-name=static
```
With multiple configurations, you can say `make CONF= reconfigure` or `make CONF= clean`, but `make CONF= images` would fail. You could say (for the first example):
```
$ make -C build/cmake images && make -C build/uma images
```
but that is somewhat tedious, and gets worse as the number of configuration grows. With these changes the shorter `make CONF= images` command will work.

[1] see ibmruntimes/openj9-openjdk-jdk11#359