### PR TITLE
Replace obsoleted PATH_SEP with PathList call

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -121,7 +121,7 @@ $(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
 $(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(BUILD_DDR_TOOLS)
 	@$(ECHO) Generating DDR pointer and structure class files
 	@$(RM) -rf $(DDR_CLASSES_BIN)
-	@$(JAVA) -cp "$(DDR_TOOLS_BIN)$(PATH_SEP)$(DDR_VM_SRC_ROOT)" \
+	@$(JAVA) -cp $(call PathList, $(DDR_TOOLS_BIN) $(DDR_VM_SRC_ROOT)) \
 		com.ibm.j9ddr.tools.ClassGenerator \
 			--blob=$(DDR_BLOB_FILE) \
 			--out=$(DDR_CLASSES_BIN)


### PR DESCRIPTION
`PATH_SEP` has been removed, use `PathList` call instead.

With this PR, `JDK16` builds and `-version` output is as following:
```
openjdk version "16-internal" 2021-03-16
OpenJDK Runtime Environment (build 16-internal+0-adhoc.fengjcaibmcom.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build moduleread-e28ba30599, JRE 16 Mac OS X amd64-64-Bit Compressed References 20201208_000000 (JIT enabled, AOT enabled)
OpenJ9   - e28ba30599
OMR      - da9530688
JCL      - 0e3d8884eda based on jdk-16+27)
```

closes https://github.com/eclipse/openj9/issues/11402

fyi @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>