### PR TITLE
Export com.ibm.dtfj.utils so jdmpview can work

### DIFF
--- a/closed/make/modules/openj9.dtfjview/Launcher.gmk
+++ b/closed/make/modules/openj9.dtfjview/Launcher.gmk
@@ -24,4 +24,5 @@ $(eval $(call SetupBuildLauncher, jdmpview, \
     MAIN_MODULE := openj9.dtfjview, \
     MAIN_CLASS := com.ibm.jvm.dtfjview.DTFJView, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+    JAVA_ARGS := --add-exports=openj9.dtfj/com.ibm.dtfj.utils=ALL-UNNAMED, \
 ))


### PR DESCRIPTION
Otherwise IllegalAccessError occurs with the new default
`--illegal-access=deny`.

Issue https://github.com/eclipse/openj9/issues/11445

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>