### PR TITLE
Hook to include custom file should follow module setup for classloader

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -23,16 +23,20 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+
 ifndef _MODULES_GMK
 _MODULES_GMK := 1
-
-# Hook to include the corresponding custom file, if present.
-$(eval $(call IncludeCustomExtension, common/Modules.gmk))
 
 ################################################################################
 # Setup module sets for classloaders
 
 include $(TOPDIR)/make/conf/module-loader-map.conf
+
+# Hook to include the corresponding custom file, if present.
+$(eval $(call IncludeCustomExtension, common/Modules.gmk))
 
 # Append platform-specific and upgradeable modules
 PLATFORM_MODULES += $(PLATFORM_MODULES_$(OPENJDK_TARGET_OS)) \


### PR DESCRIPTION
Adjust the order to setup module sets for classloaders first, then call hook to include the corresponding custom file, if present.

Verified manually (`Mac OSX` platform) that this fixes the issue reported via https://github.com/eclipse/openj9/issues/11512
~Note: latest `openj9-staging` branch still fails due to https://github.com/eclipse/openj9/issues/11515.~

closes https://github.com/eclipse/openj9/issues/11512

Signed-off-by: Jason Feng <fengj@ca.ibm.com>