### PR TITLE
Setup paths without FIXPATH to OMR configure

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -45,6 +45,7 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 	@$(ECHO) Building OpenJ9 Java Preprocessor
 	@$(MKDIR) -p $(J9TOOLS_DIR)
 	$(MAKE) $(MAKE_ARGS) -C $(OPENJ9_TOPDIR)/sourcetools -f buildj9tools.mk \
+		JAVA_SPEC_VERSION=$(VERSION_FEATURE) \
 		BOOT_JDK=$(BOOT_JDK) \
 		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
 		JAVA_HOME=$(BOOT_JDK) \

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -215,8 +215,8 @@ SedUmaCommand = -e '/<property name="uma_make_cmd_$(strip $2)"/s|value="[^"]*"|v
 
 # Copy configured values to relevant UMA properties in .spec files.
 SPEC_SED_SCRIPT := \
-	$(call SedUmaCommand, CC,  cc) \
-	$(call SedUmaCommand, CXX, cxx) \
+	$(call SedUmaCommand, CC_NOFIXPATH,  cc) \
+	$(call SedUmaCommand, CXX_NOFIXPATH, cxx) \
 	$(call SedUmaCommand, CXX, interp_gcc) \
 	$(call SedUmaCommand, CXX, ppc_gcc_cxx) \
 	#

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -168,7 +168,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CUDA],
       if test -f "$cuda_home/include/cuda.h" ; then
         if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
           # UTIL_FIXUP_PATH yields a Unix-style path, but we need a mixed-mode path
-          cuda_home="`$CYGPATH -m $cuda_home`"
+          cuda_home="`cygpath -m $cuda_home`"
         fi
         if test "$cuda_home" = "$with_cuda" ; then
           AC_MSG_RESULT([$with_cuda])
@@ -190,7 +190,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CUDA],
       if test -f "$gdk_home/include/nvml.h" ; then
         if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
           # UTIL_FIXUP_PATH yields a Unix-style path, but we need a mixed-mode path
-          gdk_home="`$CYGPATH -m $gdk_home`"
+          gdk_home="`cygpath -m $gdk_home`"
         fi
         if test "$gdk_home" = "$with_gdk" ; then
           AC_MSG_RESULT([$with_gdk])
@@ -464,7 +464,7 @@ AC_DEFUN([OPENJ9_THIRD_PARTY_REQUIREMENTS],
     fi
 
     if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
-      FREEMARKER_JAR=`$CYGPATH -m "$with_freemarker_jar"`
+      FREEMARKER_JAR=`cygpath -m "$with_freemarker_jar"`
     else
       FREEMARKER_JAR=$with_freemarker_jar
     fi
@@ -514,6 +514,10 @@ AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
   CONFIGURE_OPENSSL
 
   CLOSED_AUTOCONF_DIR="$TOPDIR/closed/autoconf"
+
+  AC_SUBST(VS_INCLUDE_NOFIXPATH)
+  AC_SUBST(VS_LIB_NOFIXPATH)
+  AC_SUBST(PATH)
 
   # Create the custom-spec.gmk
   AC_CONFIG_FILES([$OUTPUTDIR/custom-spec.gmk:$CLOSED_AUTOCONF_DIR/custom-spec.gmk.in])

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -115,8 +115,9 @@ export ac_cv_prog_CXX   := @CXX@
 ifeq ($(OPENJDK_TARGET_OS), windows)
   # Set environment variables for Microsoft Visual Studio toolchain.
   # Note that PATH is set in spec.gmk.
-  export INCLUDE := "@VS_INCLUDE@"
-  export LIB := "@VS_LIB@"
+  export INCLUDE := "@VS_INCLUDE_NOFIXPATH@"
+  export LIB := "@VS_LIB_NOFIXPATH@"
+  export PATH := @PATH@
   export MSVC_VERSION := @TOOLCHAIN_VERSION@
 endif
 

--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 m4_include([basic_tools.m4])
 m4_include([basic_windows.m4])
 
@@ -389,6 +393,9 @@ AC_DEFUN_ONCE([BASIC_SETUP_OUTPUT_DIR],
   AC_SUBST(CONF_NAME)
   AC_SUBST(OUTPUTDIR)
   AC_SUBST(CONFIGURESUPPORT_OUTPUTDIR)
+
+  AC_SUBST(CC_NOFIXPATH)
+  AC_SUBST(CXX_NOFIXPATH)
 
   # The spec.gmk file contains all variables for the make system.
   AC_CONFIG_FILES([$OUTPUTDIR/spec.gmk:$AUTOCONF_DIR/spec.gmk.in])

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 # Configured @DATE_WHEN_CONFIGURED@ to build
 # for target system @OPENJDK_TARGET_OS@-@OPENJDK_TARGET_CPU@
 #   (called @OPENJDK_TARGET_AUTOCONF_NAME@ by autoconf)
@@ -493,6 +497,8 @@ ADLC_LDFLAGS=@ADLC_LDFLAGS@
 
 # Tools that potentially need to be cross compilation aware.
 CC := @CCACHE@ @ICECC@ @CC@
+CC_NOFIXPATH := @CC_NOFIXPATH@
+CXX_NOFIXPATH := @CXX_NOFIXPATH@
 
 # CFLAGS used to compile the jdk native libraries (C-code)
 CFLAGS_JDKLIB:=@CFLAGS_JDKLIB@

--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 ###############################################################################
 # Appends a string to a path variable, only adding the : when needed.
 AC_DEFUN([UTIL_APPEND_TO_PATH],
@@ -395,6 +399,12 @@ AC_DEFUN([UTIL_LOOKUP_PROGS],
             $1="$full_path"
             UTIL_FIXUP_EXECUTABLE($1, $3, $4)
             result="[$]$1"
+            if test "x$1" == xPOTENTIAL_CC; then
+              CC_NOFIXPATH="$full_path"
+            fi
+            if test "x$1" == xPOTENTIAL_CXX; then
+              CXX_NOFIXPATH="$full_path"
+            fi
 
             # If we have FIXPATH enabled, strip all instances of it and prepend
             # a single one, to avoid double fixpath prefixing.

--- a/make/scripts/extract-vs-env.cmd
+++ b/make/scripts/extract-vs-env.cmd
@@ -22,6 +22,10 @@ REM or visit www.oracle.com if you need additional information or have any
 REM questions.
 REM
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 set vcvarscmd=%1
 set output=%2
 if not "%3" == "auto" set version=-vcvars_ver=%3
@@ -40,6 +44,13 @@ call :extract "%VCToolsRedistDir%", VCToolsRedistDir
 call :extract "%WindowsSdkDir%", WindowsSdkDir
 call :extract "%WINDOWSSDKDIR%", WINDOWSSDKDIR
 
+call :extractNoFix "%INCLUDE%", VS_INCLUDE_NOFIXPATH
+call :extractNoFix "%LIB%", VS_LIB_NOFIXPATH
+
+exit /b 0
+
+:extractNoFix
+echo %~2='%~1' >> %output%
 exit /b 0
 
 :extract


### PR DESCRIPTION
Pass `JAVA_SPEC_VERSION` to `buildj9tools.mk` to accommodate `JDK16+` specific change;
Setup paths without `FIXPATH` such as `CC_NOFIXPATH`, `CXX_NOFIXPATH`, `VS_INCLUDE_NOFIXPATH`, and  `VS_LIB_NOFIXPATH`.

With this PR and its dependent PR, now JDK17 Windows builds and the `-version` output is:
```
openjdk version "17-internal" 2021-09-14
OpenJDK Runtime Environment (build 17-internal+0-adhoc.Administrator.openj9-openjdk-jdk)
Eclipse OpenJ9 VM (build jdk17win-f1de38020, JRE 17 Windows Server 2016 amd64-64-Bit Compressed References 20201227_000000 (JIT enabled, AOT enabled)
OpenJ9   - f1de38020
OMR      - 62dd1d42a
JCL      - bbf9223aedc based on jdk-17+3)
```

Depends on https://github.com/eclipse/openj9/pull/11543
closes https://github.com/eclipse/openj9/issues/11410

Signed-off-by: Jason Feng <fengj@ca.ibm.com>