### PR TITLE
Enhancing GCM ByteBuffer Implementation

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1308,7 +1308,11 @@ final class CipherCore {
             return cipher.decryptFinal(src, dst);
         } else {
             if (buffered > 0) {
-                ((GaloisCounterMode)cipher).encrypt(buffer, 0, buffered);
+                if (useNativeGCM) {
+                    ((NativeGaloisCounterMode) cipher).encrypt(buffer, 0, buffered);
+                } else {
+                    ((GaloisCounterMode) cipher).encrypt(buffer, 0, buffered);
+                }
             }
             return cipher.encryptFinal(src, dst);
         }

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * @test
@@ -62,7 +67,9 @@ public class GCMBufferTest implements Cloneable {
     int[] sizes;
     boolean incremental = false;
     // In some cases the theoretical check is too complicated to verify
-    boolean theoreticalCheck;
+    boolean theoreticalCheckFinal;
+    // This variable is never set to true in order to disable length verification after cipher.update for GCM Buffer Tests
+    boolean theoreticalCheckUpdate;
     List<Data> dataSet;
     int inOfs = 0, outOfs = 0;
 
@@ -128,7 +135,8 @@ public class GCMBufferTest implements Cloneable {
     GCMBufferTest(String algo, List<dtype> ops) {
         this.algo = algo;
         this.ops = ops;
-        theoreticalCheck = true;
+        theoreticalCheckUpdate = false;
+        theoreticalCheckFinal = true;
         dataSet = datamap.get(algo);
     }
 
@@ -416,7 +424,7 @@ public class GCMBufferTest implements Cloneable {
                     default -> throw new Exception("Unknown op: " + v.name());
                 }
 
-                if (theoreticalCheck) {
+                if (theoreticalCheckUpdate) {
                     pbuflen += plen - rlen;
                     if (encrypt && rlen != theoreticallen) {
                         throw new Exception("Wrong update return len (" +
@@ -473,7 +481,7 @@ public class GCMBufferTest implements Cloneable {
                     default -> throw new Exception("Unknown op: " + v.name());
                 }
 
-                if (theoreticalCheck && rlen != olen - outOfs) {
+                if (theoreticalCheckFinal && rlen != olen - outOfs) {
                     throw new Exception("Wrong doFinal return len (" +
                         v.name() + "):  " + "rlen=" + rlen +
                         ", expected output len=" + (olen - outOfs));
@@ -569,7 +577,7 @@ public class GCMBufferTest implements Cloneable {
                 }
 
                 // Check that the theoretical return value matches the actual.
-                if (theoreticalCheck && encrypt && rlen != theorticallen) {
+                if (theoreticalCheckUpdate && encrypt && rlen != theorticallen) {
                     throw new Exception("Wrong update return len (" +
                         v.name() + "):  " + "rlen=" + rlen +
                         ", expected output len=" + theorticallen);


### PR DESCRIPTION
Fixing [OpenJ9's Issue 11390](https://github.com/eclipse/openj9/issues/11390). Specifically, some of the AEAD tests were failing in the jtreg test harness. This PR fixes them by:

* Adding necessary functions to `NativeGaloisCounterMode` to support processing ByteBuffer input and output.
* Editing the jtreg test _GCMBufferTest.java_ to not check for the output length after `cipher.update`. This is because `cipher.update` doesn't have to return the encrypted input length. In our JDK, the `cipher.update` behaves differently depending on whether the machine used does have native crypto or not:
   * If native crypto is used, the `cipher.update` processes the input by adding it to a buffer, which will be processed when `cipher.doFinal` is called. Hence, the `cipher.update` returns zero.
   * However, when native crypto is not used, `cipher.update` returns 16.
