### PR TITLE
Include j9vrb_full library in mixed references builds

### DIFF
--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -69,6 +69,7 @@ $(call openj9_copy_shlibs, \
 	j9vm29 \
 	j9vmchk29 \
 	j9vrb29 \
+	$(if $(filter static,$(OMR_MIXED_REFERENCES_MODE)),j9vrb_full29) \
 	j9zlib29 \
 	jclse29 \
 	jvm \


### PR DESCRIPTION
Port of: https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/378

For: https://github.com/eclipse/openj9/pull/11662

Includes the j9vrb_full library in the JDK for mixed references builds.