### PR TITLE
Use $(PHASE_MAKEDIRS) for the Java phase for consistency

### DIFF
--- a/make/CompileJavaModules.gmk
+++ b/make/CompileJavaModules.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 # This must be the first rule
 default: all
 
@@ -86,7 +90,7 @@ CreateHkTargets = \
 ################################################################################
 # Include module specific build settings
 
--include $(TOPDIR)/make/modules/$(MODULE)/Java.gmk
+-include Java.gmk
 
 ################################################################################
 # Setup the main compilation

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
 # ===========================================================================
 
 ################################################################################
@@ -191,6 +191,7 @@ JAVA_TARGETS := $(addsuffix -java, $(JAVA_MODULES))
 define DeclareCompileJavaRecipe
   $1-java:
 	+($(CD) $(TOPDIR)/make && $(MAKE) $(MAKE_ARGS) \
+	    $(patsubst %,-I%/modules/$1,$(PHASE_MAKEDIRS)) \
 	    -f CompileJavaModules.gmk MODULE=$1)
 endef
 


### PR DESCRIPTION
The pre-hook and post-hook in `CompileJavaModules.gmk` were removed by

* 8258407 Split up CompileJavaModules.gmk into make/modules/$M/Java.gmk

and the include directive for `Java.gmk` uses an absolute path leaving no path to customizations. This updates `Main.gmk` to define an include path based on `PHASE_MAKEDIRS` for make as was done for other phases in

* 8252998 ModuleWrapper.gmk doesn't consult include path

This is required by part of the anticipated fix for eclipse/openj9#11464.