### PR TITLE
Add accelerated zlibNX to LIBPATH for AIX P9 or newer systems and set system zlib as default on AIX

### DIFF
--- a/make/autoconf/lib-bundled.m4
+++ b/make/autoconf/lib-bundled.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 ################################################################################
 # Setup bundled libraries.
 #
@@ -165,8 +169,8 @@ AC_DEFUN_ONCE([LIB_SETUP_ZLIB],
   AC_MSG_CHECKING([for which zlib to use])
 
   DEFAULT_ZLIB=system
-  if test "x$OPENJDK_TARGET_OS" = xwindows -o "x$OPENJDK_TARGET_OS" = xaix; then
-    # On windows and aix default is bundled, on others default is system
+  if test "x$OPENJDK_TARGET_OS" = xwindows; then
+    # On windows default is bundled, on others default is system
     DEFAULT_ZLIB=bundled
   fi
 

--- a/src/java.base/unix/native/libjli/java_md.h
+++ b/src/java.base/unix/native/libjli/java_md.h
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
+
 #ifndef JAVA_MD_H
 #define JAVA_MD_H
 
@@ -61,6 +67,29 @@ static jboolean GetJREPath(char *path, jint pathsize, jboolean speculative);
 
 #if defined(_AIX)
 #include "java_md_aix.h"
+
+#define ZLIBNX_PATH "/usr/opt/zlibNX/lib"
+
+#ifndef POWER_9
+#define POWER_9 0x20000 /* 9 class CPU */
+#endif
+
+#ifndef POWER_10
+#define POWER_10 0x40000 /* 10 class CPU */
+#endif
+
+#define power_9_andup() ((POWER_9  == _system_configuration.implementation) \
+                        || (POWER_10 == _system_configuration.implementation))
+
+#ifndef SC_NX_CAP
+#define SC_NX_CAP 60
+#endif
+
+#ifndef NX_GZIP_PRESENT
+#define NX_GZIP_PRESENT 0x00000001
+#endif
+
+#define power_nx_gzip() (0 != ((long)getsystemcfg(SC_NX_CAP) & NX_GZIP_PRESENT))
 #endif
 
 #if defined(MACOSX)


### PR DESCRIPTION
zlibNX is an accelerated replacement for zlib, it make use of the NX accelerator in P9 and newer systems.
This PR enable the use of zlibNX for AIX systems by adding it to the LIBPATH if the system is P9 or newer and has the NX accelerator enabled.

This PR also sets system zlib as default instead of bundled zlib on AIX systems to allow zlibNX
For reference, the change to bundle zlib on AIX is https://bugs.openjdk.java.net/browse/JDK-8223685

Signed-off-by: Abdulrahman Alattas rmnattas@gmail.com