### PR TITLE
Remove JCL patch after contribution of JDK-8260289

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -23,10 +23,6 @@
 # questions.
 #
 
-# ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
-# ===========================================================================
-
 ifndef _MODULES_GMK
 _MODULES_GMK := 1
 
@@ -34,9 +30,6 @@ _MODULES_GMK := 1
 # Setup module sets for classloaders
 
 include $(TOPDIR)/make/conf/module-loader-map.conf
-
-# Hook to include the corresponding custom file, if present.
-$(eval $(call IncludeCustomExtension, common/Modules.gmk))
 
 # Append platform-specific and upgradeable modules
 PLATFORM_MODULES += $(PLATFORM_MODULES_$(OPENJDK_TARGET_OS)) \


### PR DESCRIPTION
The JCL patch is invalid after JDK-8260289 has been contributed as https://github.com/openjdk/jdk/pull/2219

Signed-off-by: Jason Feng <fengj@ca.ibm.com>