### PR TITLE
Update CMake Windows support

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -164,6 +164,9 @@ AC_DEFUN([OPENJ9_CONFIGURE_COMPILERS],
   AC_ARG_WITH(openj9-developer-dir, [AS_HELP_STRING([--with-openj9-developer-dir], [build OpenJ9 with a specific Xcode version])],
     [OPENJ9_DEVELOPER_DIR=$with_openj9_developer_dir],
     [OPENJ9_DEVELOPER_DIR=])
+  if test "x$OPENJDK_BUILD_OS" = xwindows ; then
+    UTIL_REQUIRE_PROGS([OPENJ9_CLANG], [clang])
+  fi
 
   AC_SUBST(OPENJ9_CC)
   AC_SUBST(OPENJ9_CXX)
@@ -695,26 +698,29 @@ AC_DEFUN([OPENJ9_GENERATE_TOOL_WRAPPER],
   echo "#!/bin/sh" > $tool_file
   # We need to insert an empty string ([]), to stop M4 treating "$@" as a
   # variable reference
-  printf '%s "%s" "$[]@"\n' "$FIXPATH" "$2" >> $tool_file
+  printf '%s "$[]@"\n' "$2" >> $tool_file
   chmod +x $tool_file
 ])
 
 # Generate all the tool wrappers required for cmake on windows
 AC_DEFUN([OPENJ9_GENERATE_TOOL_WRAPPERS],
 [
-  MSVC_BIN_DIR=$($DIRNAME $CC)
-  SDK_BIN_DIR=$($DIRNAME $RC)
-
   mkdir -p "$OPENJ9_TOOL_DIR"
+
+  UTIL_REQUIRE_TOOLCHAIN_PROGS(MC, mc)
+  # Note: the assembler found by OpenJDK macros is 'ml', which is the 32-bit assembler.
+  UTIL_REQUIRE_TOOLCHAIN_PROGS(ML64, ml64)
+
   OPENJ9_GENERATE_TOOL_WRAPPER([cl], [$CC])
+  OPENJ9_GENERATE_TOOL_WRAPPER([clang], [$OPENJ9_CLANG])
+  OPENJ9_GENERATE_TOOL_WRAPPER([jar], [$JAR])
+  OPENJ9_GENERATE_TOOL_WRAPPER([java], [$JAVA])
+  OPENJ9_GENERATE_TOOL_WRAPPER([javac], [$JAVAC])
   OPENJ9_GENERATE_TOOL_WRAPPER([lib], [$AR])
   OPENJ9_GENERATE_TOOL_WRAPPER([link], [$LD])
-  OPENJ9_GENERATE_TOOL_WRAPPER([ml], [$MSVC_BIN_DIR/ml])
-  OPENJ9_GENERATE_TOOL_WRAPPER([ml64], [$MSVC_BIN_DIR/ml64])
-  OPENJ9_GENERATE_TOOL_WRAPPER([rc], [$RC])
-  OPENJ9_GENERATE_TOOL_WRAPPER([mc], [$SDK_BIN_DIR/mc])
+  OPENJ9_GENERATE_TOOL_WRAPPER([mc], [$MC])
+  OPENJ9_GENERATE_TOOL_WRAPPER([ml], [$AS])
+  OPENJ9_GENERATE_TOOL_WRAPPER([ml64], [$ML64])
   OPENJ9_GENERATE_TOOL_WRAPPER([nasm], [$NASM])
-  OPENJ9_GENERATE_TOOL_WRAPPER([java], [$JAVA])
-  OPENJ9_GENERATE_TOOL_WRAPPER([jar], [$JAR])
-  OPENJ9_GENERATE_TOOL_WRAPPER([javac], [$JAVAC])
+  OPENJ9_GENERATE_TOOL_WRAPPER([rc], [$RC])
 ])

--- a/closed/autoconf/toolchain-win.cmake.in
+++ b/closed/autoconf/toolchain-win.cmake.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -26,6 +26,7 @@ set(CMAKE_SYSTEM_PROCESSOR "@OPENJDK_TARGET_CPU@")
 set(tool_dir "@OPENJ9_TOOL_DIR@")
 set(CMAKE_C_COMPILER "${tool_dir}/cl" CACHE FILEPATH "")
 set(CMAKE_CXX_COMPILER "${tool_dir}/cl" CACHE FILEPATH "")
+set(CMAKE_J9VM_CXX_COMPILER "${tool_dir}/clang" CACHE FILEPATH "")
 set(CMAKE_AR "${tool_dir}/lib" CACHE FILEPATH "")
 set(CMAKE_LINKER "${tool_dir}/link" CACHE FILEPATH "")
 set(CMAKE_MC_COMPILER "${tool_dir}/mc" CACHE FILEPATH "")


### PR DESCRIPTION
- Enable using clang to compile the interpreter
- Update tool wrappers to work with new fixpath


Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>