### PR TITLE
Use Reference.reachabilityFence to keep the object alive

### DIFF
--- a/test/jdk/java/foreign/TestLibraryLookup.java
+++ b/test/jdk/java/foreign/TestLibraryLookup.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved.
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
@@ -82,6 +88,7 @@ public class TestLibraryLookup {
         LibraryLookup lookup = LibraryLookup.ofLibrary("LookupTest");
         assertTrue(lookup.lookup("nonExistent").isEmpty());
         assertEquals(LibrariesHelper.numLoadedLibraries(), 1);
+        java.lang.ref.Reference.reachabilityFence(lookup);
         lookup = null;
         symbol = null;
         waitUnload();


### PR DESCRIPTION
This is to accommodate OpenJ9 aggressive GC polices.

Related https://github.com/eclipse/openj9/issues/11838

Signed-off-by: Jason Feng <fengj@ca.ibm.com>