### PR TITLE
OpenJ9 Adopts RI java.lang.String

### DIFF
--- a/src/java.base/share/classes/java/lang/StringCoding.java
+++ b/src/java.base/share/classes/java/lang/StringCoding.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang;
 
 import java.io.UnsupportedEncodingException;
@@ -600,7 +606,7 @@ class StringCoding {
     }
 
     @IntrinsicCandidate
-    private static int implEncodeISOArray(byte[] sa, int sp,
+    public static int implEncodeISOArray(byte[] sa, int sp,
                                           byte[] da, int dp, int len) {
         int i = 0;
         for (; i < len; i++) {


### PR DESCRIPTION
Add OpenJ9 specific fields/methods into RI `java.lang.String`;
Make `StringCoding.implEncodeISOArray()` `public` which is required by RI `String`;
A separated PR (https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/296) is to remove legacy `StringCoding` code.

Note: this change to `java.lang.String` has no impact on current JDK17 build cause it is not included by OpenJ9 yet.

This unlocks https://github.com/eclipse/openj9/pull/12209.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>