### PR TITLE
Fix jdk_io GlobalFilterTest for JDK17

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2020 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2021 All Rights Reserved
  * ===========================================================================
  * 
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
         try {
             map.put("vm.graal.enabled", "false");
             map.put("vm.bits", vmBits());
+            map.put("vm.hasJFR", "false");
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
- Add vm.hasJFR parameter for openj9, which is required by jdk_io GlobalFilterTest
- Related Issue: https://github.com/eclipse/openj9/issues/12079

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>