### PR TITLE
Fix reference to JAVADOC_DISABLED_DOCLINT_WARNINGS

### DIFF
--- a/closed/custom/Docs.gmk
+++ b/closed/custom/Docs.gmk
@@ -160,7 +160,7 @@ OPENJ9_ONLY_JAVADOC_FILELIST := $(shell $(FIND) $(J9JCL_SOURCES_DIR) -type f  '(
 OPENJ9_ONLY_JAVADOC_FILES := $(SUPPORT_OUTPUTDIR)/openj9-docs/_javadoc_openj9_files.txt
 
 # Temporarily disable some extra javadoc diagnostics (using 'sort' to remove any duplication).
-OPENJ9_JAVADOC_DISABLED_DOCLINT = $(sort $(JAVADOC_DISABLED_DOCLINT) accessibility html missing syntax reference)
+OPENJ9_JAVADOC_DISABLED_DOCLINT_WARNINGS = $(sort $(JAVADOC_DISABLED_DOCLINT_WARNINGS) accessibility html missing syntax reference)
 
 # Set up the javadoc command line options.
 # Use  -linkoffline to redirect the links to the documentation for the classes
@@ -174,7 +174,7 @@ OPENJ9_ONLY_JAVADOC_OPTIONS = $(filter-out --expand-requires transitive,$(JAVADO
 OPENJ9_ONLY_JAVADOC_OPTIONS += -linkoffline $(JAVASE_BASE_URL)/ $(DOCS_OUTPUTDIR)/api/
 OPENJ9_ONLY_JAVADOC_OPTIONS += $(JAVADOC_TAGS)
 OPENJ9_ONLY_JAVADOC_OPTIONS += --module-source-path $(call PathList,$(OPENJ9_STUBS_DIR) $(MODULES_SOURCE_PATH))
-OPENJ9_ONLY_JAVADOC_OPTIONS += -Xdoclint:all,$(call CommaList, $(addprefix -, $(OPENJ9_JAVADOC_DISABLED_DOCLINT)))
+OPENJ9_ONLY_JAVADOC_OPTIONS += -Xdoclint:all,$(call CommaList, $(addprefix -, $(OPENJ9_JAVADOC_DISABLED_DOCLINT_WARNINGS)))
 
 OPENJ9_DOC_TITLE = $(JDK_LONG_NAME)<br>Version $(VERSION_SPECIFICATION)
 OPENJ9_WINDOW_TITLE = $(subst &amp;,&,$(JDK_SHORT_NAME))


### PR DESCRIPTION
Renamed upstream from `JAVADOC_DISABLED_DOCLINT` to `JAVADOC_DISABLED_DOCLINT_WARNINGS` in
* 8263827: Suspend "missing" javadoc doclint checks for smartcardio

~Note: this targets the `openj9-staging` branch.~