### PR TITLE
Support including healthcenter agent module

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -42,6 +42,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   OPENJ9_CONFIGURE_COMPILERS
   OPENJ9_CONFIGURE_CUDA
   OPENJ9_CONFIGURE_DDR
+  OPENJ9_CONFIGURE_HEALTHCENTER
   OPENJ9_CONFIGURE_NUMA
   OPENJ9_CONFIGURE_WARNINGS
   OPENJ9_CONFIGURE_JITSERVER
@@ -265,6 +266,34 @@ AC_DEFUN([OPENJ9_CONFIGURE_DDR],
   fi
 
   AC_SUBST(OPENJ9_ENABLE_DDR)
+])
+
+AC_DEFUN([OPENJ9_CONFIGURE_HEALTHCENTER],
+[
+  HEALTHCENTER_JAR=
+  AC_ARG_WITH(healthcenter, [AS_HELP_STRING([--with-healthcenter], [import healthcenter artifacts from this archive])],
+    [
+      if test "x$with_healthcenter" != xno ; then
+        healthcenter_jar="$with_healthcenter"
+        UTIL_FIXUP_PATH(healthcenter_jar)
+        AC_MSG_CHECKING([healthcenter])
+        if ! test -f "$healthcenter_jar" ; then
+          AC_MSG_ERROR([healthcenter archive not found at $with_healthcenter])
+        else
+          if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
+            # UTIL_FIXUP_PATH yields a Unix-style path, but we need a mixed-mode path
+            healthcenter_jar="`$CYGPATH -m $healthcenter_jar`"
+          fi
+          if test "$healthcenter_jar" = "$with_healthcenter" ; then
+            AC_MSG_RESULT([$with_healthcenter])
+          else
+            AC_MSG_RESULT([$with_healthcenter @<:@$healthcenter_jar@:>@])
+          fi
+          HEALTHCENTER_JAR=$healthcenter_jar
+        fi
+      fi
+    ])
+  AC_SUBST(HEALTHCENTER_JAR)
 ])
 
 AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -145,6 +145,9 @@ else
 	$1
 endif
 
+# Archive from which to import Health Center content.
+HEALTHCENTER_JAR := @HEALTHCENTER_JAR@
+
 # OpenSSL
 BUILD_OPENSSL           := @BUILD_OPENSSL@
 OPENSSL_BUNDLE_LIB_PATH := @OPENSSL_BUNDLE_LIB_PATH@

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -112,3 +112,8 @@ clean-openj9-only-docs :
 	$(RM) -rf $(IMAGES_OUTPUTDIR)/openj9-docs $(SUPPORT_OUTPUTDIR)/openj9-docs
 
 ALL_TARGETS += clean-openj9-only-docs
+
+ifneq (,$(HEALTHCENTER_JAR))
+  # The content must be extracted before module-info can be compiled.
+  ibm.healthcenter-java : ibm.healthcenter-copy
+endif # HEALTHCENTER_JAR

--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -29,6 +29,12 @@ PLATFORM_MODULES += \
 	openj9.gpu \
 	openj9.zosconditionhandling \
 	#
+
+ifneq (,$(HEALTHCENTER_JAR))
+  PLATFORM_MODULES += ibm.healthcenter
+else
+  MODULES_FILTER   += ibm.healthcenter
+endif
 
 MODULES_FILTER += \
 	jdk.aot \

--- a/closed/make/modules/ibm.healthcenter/Copy.gmk
+++ b/closed/make/modules/ibm.healthcenter/Copy.gmk
@@ -1,0 +1,86 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include $(TOPDIR)/closed/CopySupport.gmk
+
+ifneq (,$(HEALTHCENTER_JAR))
+
+# Extract the contents of HEALTHCENTER_JAR to HEALTHCENTER_HOME.
+
+HEALTHCENTER_HOME := $(SUPPORT_OUTPUTDIR)/healthcenter
+HEALTHCENTER_EXTRACT := $(HEALTHCENTER_HOME)/extract_marker
+
+$(HEALTHCENTER_EXTRACT) : $(HEALTHCENTER_JAR)
+	@$(ECHO) Extracting contents of $(HEALTHCENTER_JAR)
+	@$(RM) -rf $(@D)
+	$(call MakeDir, $(@D))
+	$(UNZIP) -q $< -d $(@D)
+	@$(TOUCH) $@
+
+# Copy the properties file, changing the default transport to jrmp.
+
+TRANSPORT_PROPERTY_NAME       := com.ibm.java.diagnostics.healthcenter.agent.transport
+TRANSPORT_PROPERTY_REGEX      := $(subst .,\.,$(TRANSPORT_PROPERTY_NAME))
+TRANSPORT_PROPERTY_SED_SCRIPT := -e 's|$(TRANSPORT_PROPERTY_REGEX)\s*=.*|$(TRANSPORT_PROPERTY_NAME)=jrmp|'
+
+# Extract the content from jars.
+
+HEALTHCENTER_COPY := $(JDK_OUTPUTDIR)/modules/$(MODULE)/_the.$(MODULE)_copy_marker
+
+HEALTHCENTER_JARS := \
+	$(HEALTHCENTER_HOME)/healthcenter.jar \
+	$(HEALTHCENTER_HOME)/monitoring-api.jar \
+	#
+
+HEALTHCENTER_EXCLUDED_PACKAGES := \
+	com.ibm.jvm \
+	com.ibm.tools.attach \
+	com.sun.tools.attach \
+	#
+
+HEALTHCENTER_EXCLUSIONS := \
+	"META-INF/MANIFEST.MF" \
+	"deps/*TraceFormat*.dat" \
+	$(foreach package, $(HEALTHCENTER_EXCLUDED_PACKAGES), "$(subst .,/,$(package))/*")
+
+# Not all components are available on all platforms, hence the use of $(wildcard).
+# Also note that evaluation must be delayed, so we use '=' instead of ':='.
+HEALTHCENTER_LIBRARIES = \
+	$(HEALTHCENTER_HOME)/$(call SHARED_LIBRARY,healthcenter) \
+	$(HEALTHCENTER_HOME)/plugins/$(call SHARED_LIBRARY,hcapiplugin) \
+	$(wildcard $(HEALTHCENTER_HOME)/plugins/$(call SHARED_LIBRARY,hcmqtt))
+
+$(HEALTHCENTER_COPY) : $(HEALTHCENTER_EXTRACT)
+	$(call MakeDir, $(LIB_DST_DIR))
+	@$(ECHO) Copying healthcenter.properties
+	$(SED) $(TRANSPORT_PROPERTY_SED_SCRIPT) \
+		< $(HEALTHCENTER_HOME)/healthcenter.properties \
+		> $(LIB_DST_DIR)/healthcenter.properties
+	$(CP) -f $(HEALTHCENTER_LIBRARIES) $(LIB_DST_DIR)/
+	$(call MakeDir, $(@D))
+	$(foreach jar, $(HEALTHCENTER_JARS), \
+		@$(ECHO) Extracting contents of $(notdir $(jar)) $(NEWLINE) \
+		$(UNZIP) -o -q $(jar) -d $(@D) -x $(HEALTHCENTER_EXCLUSIONS) $(NEWLINE) \
+	)
+	@$(TOUCH) $@
+
+TARGETS += $(HEALTHCENTER_COPY)
+
+endif # HEALTHCENTER_JAR

--- a/closed/src/ibm.healthcenter/share/classes/module-info.java
+++ b/closed/src/ibm.healthcenter/share/classes/module-info.java
@@ -1,0 +1,45 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */
+
+/**
+ * Provides the agent that supports IBM Monitoring and Diagnostic Tools - Health Center.
+ */
+module ibm.healthcenter {
+  requires java.logging;
+  requires java.management;
+  requires java.naming;
+  requires java.rmi;
+  exports com.ibm.java.diagnostics.healthcenter.agent.mbean;
+  exports com.ibm.java.diagnostics.healthcenter.api;
+  exports com.ibm.java.diagnostics.healthcenter.api.classes;
+  exports com.ibm.java.diagnostics.healthcenter.api.cpu;
+  exports com.ibm.java.diagnostics.healthcenter.api.environment;
+  exports com.ibm.java.diagnostics.healthcenter.api.factory;
+  exports com.ibm.java.diagnostics.healthcenter.api.gc;
+  exports com.ibm.java.diagnostics.healthcenter.api.io;
+  exports com.ibm.java.diagnostics.healthcenter.api.locking;
+  exports com.ibm.java.diagnostics.healthcenter.api.methodtrace;
+  exports com.ibm.java.diagnostics.healthcenter.api.nativememory;
+  exports com.ibm.java.diagnostics.healthcenter.api.profiling;
+  exports com.ibm.java.diagnostics.healthcenter.api.threads;
+  exports com.ibm.java.diagnostics.healthcenter.api.vmcontrol;
+}

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -224,6 +224,21 @@ grant codeBase "jrt:/jdk.zipfs" {
     permission java.util.PropertyPermission "user.name", "read";
 };
 
+grant codeBase "jrt:/ibm.healthcenter" {
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+    permission java.lang.management.ManagementPermission "monitor";
+    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.jndi.url.rmi";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+    permission java.lang.RuntimePermission "getStackTrace";
+    permission java.lang.RuntimePermission "loadLibrary.*";
+    permission java.net.SocketPermission "*", "accept,connect,listen,resolve";
+    permission java.util.logging.LoggingPermission "control";
+    permission java.util.PropertyPermission "*", "read,write";
+    permission javax.management.MBeanPermission "com.ibm.java.diagnostics.healthcenter.agent.mbean.HealthCenter#-[IBM:type=HCMBeanServer]", "registerMBean";
+    permission javax.management.MBeanServerPermission "createMBeanServer";
+    permission javax.management.MBeanTrustPermission "register";
+};
+
 grant codeBase "jrt:/openj9.cuda" {
     permission java.lang.RuntimePermission "accessClassInPackage.com.ibm.oti.vm";
     permission java.lang.RuntimePermission "loadLibrary.cuda4j29";


### PR DESCRIPTION
* unpack artifacts from archive named via `--with-healthcenter` option
* set default transport to `jrmp`
* add to list of platform modules
* add required security permissions

This is a replay of ibmruntimes/openj9-openjdk-jdk11#395 for Java 17.