### PR TITLE
Fix jdk_vector PreferredSpeciesTest for JDK17

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -39,6 +39,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.graal.enabled", "false");
             map.put("vm.bits", vmBits());
             map.put("vm.hasJFR", "false");
+            map.put("vm.compiler2.enabled", "false");
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
- Add vm.compiler2.enabled parameter for openj9, which is required by jdk_vector PreferredSpeciesTest
- Related Issue: https://github.com/eclipse/openj9/issues/12270

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>