### PR TITLE
DDR: do test compile with minimal set of fields

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -96,9 +96,13 @@ $(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS, \
 # Patch the DDR tools if present in the boot jdk.
 DDR_TOOLS_OPTIONS := --patch-module=openj9.dtfj=$(DDR_TOOLS_BIN)
 
+# Only fields listed in this file can be directly accessed by hand-written DDR code;
+# its contents influence the generated class files.
+DDR_FIELDS_FILE := $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/AuxFieldInfo29.dat
+
 # When StructureReader opens the blob, it must be able to find StructureAliases*.dat,
 # which requires that $(DDR_VM_SRC_ROOT) be on the classpath.
-$(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(BUILD_DDR_TOOLS)
+$(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS)
 	@$(ECHO) Generating DDR pointer and structure class files
 	@$(RM) -rf $(DDR_CLASSES_BIN)
 	@$(JAVA) -cp $(call PathList, $(DDR_TOOLS_BIN) $(DDR_VM_SRC_ROOT)) $(DDR_TOOLS_OPTIONS) \
@@ -108,9 +112,10 @@ $(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(BUILD_DDR_TOOLS)
 			--out=$(DDR_CLASSES_BIN)
 	@$(TOUCH) $@
 
-$(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
+$(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS)
 	@$(ECHO) Generating DDR pointer class source files
 	@$(JAVA) -cp $(DDR_TOOLS_BIN) $(DDR_TOOLS_OPTIONS) com.ibm.j9ddr.tools.PointerGenerator \
+		-a $(DDR_FIELDS_FILE) \
 		-f $(dir $(DDR_SUPERSET_FILE)) \
 		-s $(notdir $(DDR_SUPERSET_FILE)) \
 		-p com.ibm.j9ddr.vm29.pointer.generated \
@@ -171,6 +176,7 @@ DDR_SRC_EXCLUDES := com/ibm/j9ddr/tools/ant
 # Compile DDR code again, to ensure compatibility with class files
 # as they would be dynamically generated from the blob.
 $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
+	DEPENDS := $(DDR_CLASSES_MARKER), \
 	JAVAC_FLAGS := --upgrade-module-path $(JDK_OUTPUTDIR)/modules --system none, \
 	BIN := $(DDR_TEST_BIN), \
 	CLASSPATH := $(DDR_CLASSES_BIN) $(DDR_CLASSPATH), \

--- a/closed/make/modules/openj9.dtfj/Java.gmk
+++ b/closed/make/modules/openj9.dtfj/Java.gmk
@@ -18,5 +18,5 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-COPY     += CompatibilityConstants29.dat StructureAliases29.dat StructureAliases29-edg.dat
+COPY     += .dat
 EXCLUDES += com/ibm/j9ddr/tools/ant


### PR DESCRIPTION
This updates the build steps for DDR code to properly handle optional fields.
This depends on eclipse-openj9/openj9#12676.