### PR TITLE
JDK17 Copyright issues fixed in script

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2021 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -265,6 +265,9 @@ check () {
       IN_JDK=0;;
     make/hotspot/*)
       trace  "$1 deemed not to be in the built JDK because it matches case parameter expansion make/hotspot/*)"
+      IN_JDK=0;;
+    make/data/hotspot-symbols/*)
+      trace  "$1 deemed not to be in the built JDK because it matches case parameter expansion make/data/hotspot-symbols/*)"
       IN_JDK=0;;
     make/langtools/*)
       trace  "$1 deemed not to be in the built JDK because it matches case parameter expansion make/langtools/*"
@@ -590,6 +593,7 @@ echo "src/jdk.internal.vm.compiler.management/share/classes/org.graalvm.compiler
 
 echo "\n# openj9-openjdk-jdk11 known failures" >>$TEMPFILE
 echo "make/mapfiles/libjsig/mapfile-vers-solaris" >>$TEMPFILE
+echo "make/data/license-templates/gpl-header" >>$TEMPFILE
 echo "make/mapfiles/libjvm_db/mapfile-vers" >>$TEMPFILE
 echo "make/mapfiles/libjvm_dtrace/mapfile-vers" >>$TEMPFILE
 echo "src/java.base/solaris/native/libjvm_db/libjvm_db.c" >>$TEMPFILE


### PR DESCRIPTION
Excluded hotspot and gpl-header template files into copyright script.

https://openj9-jenkins.osuosl.org/view/Infrastructure/job/CopyrightCheck-OpenJDK17/10/
@Peter-Shipton : These seem to be hotspot related which need to add to the script as an excluded. Please if you can confirm that and I can update the script file.

20:59:37  E012: make/data/hotspot-symbols/symbols-aix: GPLv2 is present but Classpath exception is missing
20:59:37  Did not find make/data/hotspot-symbols/symbols-aix in known failures file /home/jenkins/jenkins-agent/workspace/CopyrightCheck-OpenJDK17/workdir/ibmruntimes/openj9-openjdk-jdk17.git/copyrightCheck.known.failures, treating as error
20:59:37  E012: make/data/hotspot-symbols/symbols-aix-debug: GPLv2 is present but Classpath exception is missing
20:59:37  Did not find make/data/hotspot-symbols/symbols-aix-debug in known failures file /home/jenkins/jenkins-agent/workspace/CopyrightCheck-OpenJDK17/workdir/ibmruntimes/openj9-openjdk-jdk17.git/copyrightCheck.known.failures, treating as error
20:59:37  E012: make/data/hotspot-symbols/symbols-linux: GPLv2 is present but Classpath exception is missing
20:59:37  Did not find make/data/hotspot-symbols/symbols-linux in known failures file /home/jenkins/jenkins-agent/workspace/CopyrightCheck-OpenJDK17/workdir/ibmruntimes/openj9-openjdk-jdk17.git/copyrightCheck.known.failures, treating as error
20:59:37  E012: make/data/hotspot-symbols/symbols-macosx: GPLv2 is present but Classpath exception is missing
20:59:37  Did not find make/data/hotspot-symbols/symbols-macosx in known failures file /home/jenkins/jenkins-agent/workspace/CopyrightCheck-OpenJDK17/workdir/ibmruntimes/openj9-openjdk-jdk17.git/copyrightCheck.known.failures, treating as error
20:59:37  E012: make/data/hotspot-symbols/symbols-shared: GPLv2 is present but Classpath exception is missing
20:59:37  Did not find make/data/hotspot-symbols/symbols-shared in known failures file /home/jenkins/jenkins-agent/workspace/CopyrightCheck-OpenJDK17/workdir/ibmruntimes/openj9-openjdk-jdk17.git/copyrightCheck.known.failures, treating as error
20:59:37  E012: make/data/hotspot-symbols/symbols-unix: GPLv2 is present but Classpath exception is missing
20:59:37  Did not find make/data/hotspot-symbols/symbols-unix in known failures file /home/jenkins/jenkins-agent/workspace/CopyrightCheck-OpenJDK17/workdir/ibmruntimes/openj9-openjdk-jdk17.git/copyrightCheck.known.failures, treating as error

@Peter-Shipton : https://github.com/ibmruntimes/openj9-openjdk-jdk17/blob/openj9/make/data/license-templates/gpl-header, looks like just a license header and not the actual file. I think we should be able to also add it to the known failure list?

20:59:37  E012: make/data/license-templates/gpl-header: GPLv2 is present but Classpath exception is missing
20:59:37  Did not find make/data/license-templates/gpl-header in known failures file /home/jenkins/jenkins-agent/workspace/CopyrightCheck-OpenJDK17/workdir/ibmruntimes/openj9-openjdk-jdk17.git/copyrightCheck.known.failures, treating as error

Signed-off-by: Archana Nogriya <archana.nogriya@uk.ibm.com>