### PR TITLE
Put openj9.criu in the boot modules list 

### DIFF
--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -19,12 +19,12 @@
 # ===========================================================================
 
 BOOT_MODULES += \
+	$(if $(call equals, $(OPENJ9_ENABLE_CRIU_SUPPORT), true), openj9.criu) \
 	openj9.jvm \
 	openj9.sharedclasses \
 	#
 
 PLATFORM_MODULES += \
-	$(if $(call equals, $(OPENJ9_ENABLE_CRIU_SUPPORT), true), openj9.criu) \
 	openj9.cuda \
 	openj9.dataaccess \
 	openj9.gpu \


### PR DESCRIPTION
Put openj9.criu in the boot modules list

The openj9.criu natives are located in the jclse29 dll. The jclse29
library is loaded by the system loader, this means that only classes
that are loaded by the system loader can access natives in this library.

Currently the openj9.criu module is in the platform modules list, as a
result it is loaded by the platform loader and not the system loader.
Therefore it is unable to access the natives in jclse29. This PR puts
openj9.criu in the bootmodule list so it can access the jclse29 natives.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>