### PR TITLE
Set default load address for launchers on plinux

### DIFF
--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2021 All Rights Reserved
 # ===========================================================================
 
 include JdkNativeCompilation.gmk
@@ -83,10 +83,11 @@ define SetupBuildLauncherBody
   # Setup default values (unless overridden)
 
   ifeq ($(OPENJDK_TARGET_OS), linux)
-  # Set the image base address for zLinux 64 to 0x60000 for launchers,
-  # allows compressedRefsShift to be 0 when -Xmx is set to 2040m or more.
-  # / RTC PR 100052
-    ifeq ($(OPENJDK_TARGET_CPU), s390x)
+    # Set the image base address for p/zLinux 64 to 0x60000 for launchers,
+    # allows compressedRefsShift to be 0 when -Xmx is set to 2040m or more.
+    # Also maximizes the address space available for the java heap.
+    # / RTC PR 100052
+    ifneq (,$(filter ppc64le s390x, $(OPENJDK_TARGET_CPU)))
       $1_LDFLAGS += -Wl,-Ttext-segment=0x60000
     endif
   endif


### PR DESCRIPTION
On some machines the java launcher is loaded around 0x100000000,
breaking up the address space.

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/518