### PR TITLE
Remove -Xlog:all not supported by OpenJ9

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -2166,12 +2166,10 @@ public class Basic {
                     switch (action & 0x1) {
                         case 0:
                             childArgs.set(1, "-XX:+DisplayVMOutputToStderr");
-                            childArgs.add(2, "-Xlog:all=warning:stderr");
                             pb.redirectError(INHERIT);
                             break;
                         case 1:
                             childArgs.set(1, "-XX:+DisplayVMOutputToStdout");
-                            childArgs.add(2, "-Xlog:all=warning:stdout");
                             pb.redirectOutput(INHERIT);
                             break;
                         default:


### PR DESCRIPTION
Remove `-Xlog:all` not supported by OpenJ9

Cherry-pick from https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/12

Signed-off-by: Jason Feng <fengj@ca.ibm.com>