### PR TITLE
Set system property vm.jvmti to true

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -40,6 +40,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.bits", vmBits());
             map.put("vm.hasJFR", "false");
             map.put("vm.compiler2.enabled", "false");
+            map.put("vm.jvmti", "true");
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Support eclipse-openj9/openj9#12276

Similar change as ibmruntimes/openj9-openjdk-jdk16#72 https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/13

Signed-off-by: Jason Feng <fengj@ca.ibm.com>