### PR TITLE
Add copy for openj9.criu module to load j9criu library

### DIFF
--- a/closed/make/modules/openj9.criu/Copy.gmk
+++ b/closed/make/modules/openj9.criu/Copy.gmk
@@ -1,0 +1,23 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include $(TOPDIR)/closed/CopySupport.gmk
+
+$(call openj9_copy_shlibs, j9criu29)


### PR DESCRIPTION
Added j9criu29 as one of the generated libraries to copy over
Depends on: eclipse-openj9/openj9#13245

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>