### PR TITLE
Add openj9.traceformat to the list of platform modules

### DIFF
--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -28,6 +28,7 @@ PLATFORM_MODULES += \
 	openj9.cuda \
 	openj9.dataaccess \
 	openj9.gpu \
+	openj9.traceformat \
 	openj9.zosconditionhandling \
 	#
 


### PR DESCRIPTION
It is required by ibm.healthcenter: a platform module cannot require non-platform modules.