### PR TITLE
Add loadLibraryOnlyIfPresent to adopt NativeLibraries changes

### DIFF
--- a/src/java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java
+++ b/src/java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
  * ===========================================================================
  */
 
@@ -37,6 +37,14 @@ import java.util.ArrayList;
 class ClassLoaderHelper {
 
     private ClassLoaderHelper() {}
+
+    /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return true;
+    }
 
     /**
      * Returns an alternate path name for the given file


### PR DESCRIPTION
Required by `NativeLibraries.loadLibraryOnlyIfPresent = ClassLoaderHelper.loadLibraryOnlyIfPresent()` which is introduced by `8275703: System.loadLibrary fails on Big Sur for libraries hidden from filesystem`.

fixes https://github.com/eclipse-openj9/openj9/issues/13827 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>