### PR TITLE
Update definition of J9JDK_EXT_VERSION

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -88,7 +88,7 @@ COMPILER_VERSION_STRING := @COMPILER_VERSION_STRING@
 
 include $(TOPDIR)/closed/openjdk-tag.gmk
 
-J9JDK_EXT_VERSION       := HEAD
+J9JDK_EXT_VERSION       := $(VERSION_NUMBER_FOUR_POSITIONS)-ea
 J9JDK_EXT_NAME          := Extensions for OpenJDK for Eclipse OpenJ9
 
 # required by CMake


### PR DESCRIPTION
Updated as discussed: https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/31#pullrequestreview-801271559.