### PR TITLE
GetCallerClassTest: Accept OpenJ9's InternalError Message

### DIFF
--- a/test/jdk/jdk/internal/reflect/Reflection/GetCallerClassTest.java
+++ b/test/jdk/jdk/internal/reflect/Reflection/GetCallerClassTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8010117
  * @summary Test if the VM enforces Reflection.getCallerClass
@@ -118,7 +124,10 @@ public class GetCallerClassTest {
             gcc.missingCallerSensitiveAnnotation();
             throw new RuntimeException("shouldn't have succeeded");
         } catch (InternalError e) {
-            if (e.getMessage().startsWith("CallerSensitive annotation expected")) {
+            String errorMessage = e.getMessage();
+            if (errorMessage.startsWith("CallerSensitive annotation expected")
+            || errorMessage.startsWith("Caller is not annotated as @sun.reflect.CallerSensitive")
+            ) {
                 System.out.println("Expected error: " + e.getMessage());
             } else {
                 throw e;
@@ -133,7 +142,10 @@ public class GetCallerClassTest {
             Class<?> c = Reflection.getCallerClass();
             throw new RuntimeException("shouldn't have succeeded");
         } catch (InternalError e) {
-            if (e.getMessage().startsWith("CallerSensitive annotation expected")) {
+            String errorMessage = e.getMessage();
+            if (errorMessage.startsWith("CallerSensitive annotation expected")
+            || errorMessage.startsWith("Caller is not annotated as @sun.reflect.CallerSensitive")
+            ) {
                 System.out.println("Expected error: " + e.getMessage());
             } else {
                 throw e;


### PR DESCRIPTION
InternalError message in GetCallerClassTest differs between JVMs:
- OpenJ9: "Caller is not annotated as @sun.reflect.CallerSensitive"
- OpenJDK: "CallerSensitive annotation expected"

GetCallerClassTest has been updated to accept OpenJ9's InternalError message.

Closes: https://github.com/eclipse-openj9/openj9/issues/13998

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>