### PR TITLE
OpenJ9 Finalization thread name is "Finalizer thread"

### DIFF
--- a/test/jdk/java/lang/Object/FinalizationOption.java
+++ b/test/jdk/java/lang/Object/FinalizationOption.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8276422
  * @summary add command-line option to disable finalization
@@ -66,7 +72,7 @@ public class FinalizationOption {
 
         Thread ft = null;
         for (int i = 0; i < nt; i++) {
-            if ("Finalizer".equals(threads[i].getName())) {
+            if ("Finalizer thread".equals(threads[i].getName())) {
                 ft = threads[i];
                 break;
             }


### PR DESCRIPTION
`OpenJ9` `Finalization` thread name is `Finalizer thread`.

related to https://github.com/eclipse-openj9/openj9/issues/14049

fyi @dmitripivkine

Signed-off-by: Jason Feng <fengj@ca.ibm.com>