### PR TITLE
Fix test to check for finalizer thread after object finalized

### DIFF
--- a/test/jdk/java/lang/Object/FinalizationOption.java
+++ b/test/jdk/java/lang/Object/FinalizationOption.java
@@ -119,8 +119,8 @@ public class FinalizationOption {
             }
         };
 
-        boolean threadPass = checkFinalizerThread(finalizationEnabled);
         boolean calledPass = checkFinalizerCalled(finalizationEnabled);
+        boolean threadPass = checkFinalizerThread(finalizationEnabled);
 
         if (!threadPass || !calledPass)
             throw new AssertionError("Test failed.");


### PR DESCRIPTION
In test java/lang/Object/FinalizationOption.java

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk18/pull/18 to the head stream.

Issue https://github.com/eclipse-openj9/openj9/issues/14491