### PR TITLE
Fix @Stable annotation in MethodHandleImpl

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import jdk.internal.access.JavaLangInvokeAccess;
@@ -451,7 +457,7 @@ abstract class MethodHandleImpl {
     static final class AsVarargsCollector extends DelegatingMethodHandle {
         private final MethodHandle target;
         private final Class<?> arrayType;
-        private @Stable MethodHandle asCollectorCache;
+        private MethodHandle asCollectorCache;
 
         AsVarargsCollector(MethodHandle target, Class<?> arrayType) {
             this(target.type(), target, arrayType);


### PR DESCRIPTION
This commit removes a `@Stable` annotation in MethodHandleImpl.
The field `asCollectorCache` can be overwritten after it is first
assigned.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>