### PR TITLE
Adapt to rename of GensrcCommonJdk.gmk to GensrcCommon.gmk

### DIFF
--- a/closed/make/modules/openj9.dtfj/Gensrc.gmk
+++ b/closed/make/modules/openj9.dtfj/Gensrc.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -18,7 +18,7 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-include GensrcCommonJdk.gmk
+include GensrcCommon.gmk
 
 all :
 ifeq (true,$(OPENJ9_ENABLE_DDR))


### PR DESCRIPTION
The include file was renamed by
* 8284588: Remove GensrcCommonLangtools.gmk