### PR TITLE
CRIU support w/ JPP : add checkpoint/restore environment variables

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,7 +51,29 @@ ifeq (true,$(OPENJ9_ENABLE_OPENJDK_THREAD_SUPPORT))
   JPP_TAGS += OPENJDK_THREAD_SUPPORT
 endif # OPENJ9_ENABLE_OPENJDK_THREAD_SUPPORT
 
-$(J9JCL_SOURCES_DONEFILE) : $(AllJclSource) $(AllDdrSource)
+# OpenJ9 CRIU only supports Linux, so we only need to consider the unix sub-directory.
+OPENJDK_SOURCE_PROCESS_ENVIRONMENT := $(TOPDIR)/src/java.base/unix/classes/java/lang/ProcessEnvironment.java
+OPENJDK_STAGED_PROCESS_ENVIRONMENT := $(patsubst $(TOPDIR)/%,$(SUPPORT_OUTPUTDIR)/overlay/%,$(OPENJDK_SOURCE_PROCESS_ENVIRONMENT))
+
+$(OPENJDK_STAGED_PROCESS_ENVIRONMENT) : $(OPENJDK_SOURCE_PROCESS_ENVIRONMENT)
+	$(call install-file)
+
+# invoke JPP to generate J9JCL sources
+define jpp_generate_sources
+	@$(BOOT_JDK)/bin/java \
+		-cp "$(call FixPath,$(JPP_JAR))" \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-verdict \
+			-baseDir "$(call FixPath,$1)/" \
+			-config JAVA$(VERSION_FEATURE) \
+			-srcRoot $2/ \
+			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)" \
+			-dest "$(call FixPath,$(J9JCL_SOURCES_DIR))" \
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
+endef
+
+$(J9JCL_SOURCES_DONEFILE) : $(AllJclSource) $(AllDdrSource) $(OPENJDK_STAGED_PROCESS_ENVIRONMENT)
 	@$(ECHO) Building OpenJ9 Java Preprocessor
 	@$(MKDIR) -p $(J9TOOLS_DIR)
 	$(MAKE) $(MAKE_ARGS) -C $(OPENJ9_TOPDIR)/sourcetools -f buildj9tools.mk \
@@ -60,17 +82,8 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource) $(AllDdrSource)
 		JAVA_HOME=$(BOOT_JDK) \
 		preprocessor
 	@$(ECHO) Generating J9JCL sources
-	@$(BOOT_JDK)/bin/java \
-		-cp "$(call FixPath,$(JPP_JAR))" \
-		-Dfile.encoding=US-ASCII \
-		com.ibm.jpp.commandline.CommandlineBuilder \
-			-verdict \
-			-baseDir "$(call FixPath,$(OPENJ9_TOPDIR))/" \
-			-config JAVA$(VERSION_FEATURE) \
-			-srcRoot jcl/ \
-			-xml jpp_configuration.xml \
-			-dest "$(call FixPath,$(J9JCL_SOURCES_DIR))" \
-			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
+	$(call jpp_generate_sources,$(call FixPath,$(OPENJ9_TOPDIR)),jcl)
+	$(call jpp_generate_sources,$(call FixPath,$(SUPPORT_OUTPUTDIR)),overlay)
   ifeq (true,$(OPENJ9_ENABLE_DDR))
 	@$(ECHO) Generating DDR_VM sources
 	@$(BOOT_JDK)/bin/java \


### PR DESCRIPTION
Cherry-pick https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/486
CRIU support: add checkpoint/restore environment variables
Added `isCRIUEnabled` via `CRIUProvider.getOpenJ9CRIU()`;
Added `tracePrunedEnvVarsValue` via `org.eclipse.openj9.criu.TracePrunedEnvVars`;
Added `theOriginalUnmodifiableEnvironment` to store original `theUnmodifiableEnvironment`;
Hard-coded immutable list: `LANG`, `LC_ALL` and `LC_CTYPE`;

https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/498
Copy `$(TOPDIR)/src/java.base/unix/classes/java/lang/ProcessEnvironment.java` to `$(SUPPORT_OUTPUTDIR)/overlay/src/java.base/unix/classes/java/lang`;
Decorate `ProcessEnvironment.java` CRIU specific code with `CRIU_SUPPORT` JPP flag.

fyi @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>