### PR TITLE
Restore build progress for OpenJ9 VM

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -608,6 +608,11 @@ AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
   # explicitly disable CDS archive generation (OpenJ9 does not support '-Xshare:dump')
   BUILD_CDS_ARCHIVE=false
 
+  # Override the default for '--with-output-sync' to 'none' for better feedback during VM build.
+  if test "x[$with_output_sync]" = x ; then
+    OUTPUT_SYNC_SUPPORTED=false
+  fi
+
   # explicitly disable classlist generation
   ENABLE_GENERATE_CLASSLIST=false
 


### PR DESCRIPTION
The default for configure option `--with-output-sync` changed to `recurse` with
* 8285093: Introduce UTIL_ARG_WITH

In a nightly build, for example, we see:
```
21:32:39  checking if make --output-sync is supported... no
21:32:39  check msg:for make --output-sync value:
21:32:39  checking for make --output-sync value... <invalid>, not available
```
but with a new version of make, that supports `-O`, the output for building the VM appears as a single chunk of output, giving the appearance that it has stalled.

This changes it back to `none`.