### PR TITLE
Avoid sign extension when calling adler32() and crc32()

### DIFF
--- a/src/java.base/share/native/libzip/Adler32.c
+++ b/src/java.base/share/native/libzip/Adler32.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * Native method support for java.util.zip.Adler32
@@ -34,13 +39,15 @@
 
 #include "java_util_zip_Adler32.h"
 
+#define unsigned_jint_to_jlong(value) (((jlong)(value)) & 0xffffffffL)
+
 JNIEXPORT jint JNICALL
 Java_java_util_zip_Adler32_update(JNIEnv *env, jclass cls, jint adler, jint b)
 {
     Bytef buf[1];
 
     buf[0] = (Bytef)b;
-    return adler32(adler, buf, 1);
+    return (jint)adler32(unsigned_jint_to_jlong(adler), buf, 1);
 }
 
 JNIEXPORT jint JNICALL
@@ -49,7 +56,7 @@ Java_java_util_zip_Adler32_updateBytes(JNIEnv *env, jclass cls, jint adler,
 {
     Bytef *buf = (*env)->GetPrimitiveArrayCritical(env, b, 0);
     if (buf) {
-        adler = adler32(adler, buf + off, len);
+        adler = (jint)adler32(unsigned_jint_to_jlong(adler), buf + off, len);
         (*env)->ReleasePrimitiveArrayCritical(env, b, buf, 0);
     }
     return adler;
@@ -62,7 +69,7 @@ Java_java_util_zip_Adler32_updateByteBuffer(JNIEnv *env, jclass cls, jint adler,
 {
     Bytef *buf = (Bytef *)jlong_to_ptr(address);
     if (buf) {
-        adler = adler32(adler, buf + off, len);
+        adler = (jint)adler32(unsigned_jint_to_jlong(adler), buf + off, len);
     }
     return adler;
 }

--- a/src/java.base/share/native/libzip/CRC32.c
+++ b/src/java.base/share/native/libzip/CRC32.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * Native method support for java.util.zip.CRC32
@@ -33,13 +38,15 @@
 
 #include "java_util_zip_CRC32.h"
 
+#define unsigned_jint_to_jlong(value) (((jlong)(value)) & 0xffffffffL)
+
 JNIEXPORT jint JNICALL
 Java_java_util_zip_CRC32_update(JNIEnv *env, jclass cls, jint crc, jint b)
 {
     Bytef buf[1];
 
     buf[0] = (Bytef)b;
-    return crc32(crc, buf, 1);
+    return (jint)crc32(unsigned_jint_to_jlong(crc), buf, 1);
 }
 
 JNIEXPORT jint JNICALL
@@ -48,7 +55,7 @@ Java_java_util_zip_CRC32_updateBytes0(JNIEnv *env, jclass cls, jint crc,
 {
     Bytef *buf = (*env)->GetPrimitiveArrayCritical(env, b, 0);
     if (buf) {
-        crc = crc32(crc, buf + off, len);
+        crc = (jint)crc32(unsigned_jint_to_jlong(crc), buf + off, len);
         (*env)->ReleasePrimitiveArrayCritical(env, b, buf, 0);
     }
     return crc;
@@ -57,7 +64,7 @@ Java_java_util_zip_CRC32_updateBytes0(JNIEnv *env, jclass cls, jint crc,
 JNIEXPORT jint
 ZIP_CRC32(jint crc, const jbyte *buf, jint len)
 {
-    return crc32(crc, (Bytef*)buf, len);
+    return (jint)crc32(unsigned_jint_to_jlong(crc), (Bytef*)buf, len);
 }
 
 JNIEXPORT jint JNICALL
@@ -66,7 +73,7 @@ Java_java_util_zip_CRC32_updateByteBuffer0(JNIEnv *env, jclass cls, jint crc,
 {
     Bytef *buf = (Bytef *)jlong_to_ptr(address);
     if (buf) {
-        crc = crc32(crc, buf + off, len);
+        crc = (jint)crc32(unsigned_jint_to_jlong(crc), buf + off, len);
     }
     return crc;
 }


### PR DESCRIPTION
adler32() and crc32() functions take unsigned long parameters. Sign
extending the jint causes a crc32() failure with zlib 1.2.12 although it
works with earlier versions. No problem was discovered using adler32()
with zlib 1.2.12 but it should avoid the sign extension as well.

Issue https://github.com/eclipse-openj9/openj9/issues/14953

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>