### PR TITLE
Restore import needed to support native crypto

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  */
 
@@ -38,6 +38,7 @@ import java.security.*;
 import jdk.crypto.jniprovider.NativeCrypto;
 import jdk.internal.util.StaticProperty;
 import sun.security.action.GetBooleanAction;
+import sun.security.action.GetPropertyAction;
 import sun.security.util.SecurityProviderConstants;
 import static sun.security.util.SecurityProviderConstants.getAliases;
 


### PR DESCRIPTION
The import was replaced by
* 6725221: Standardize obtaining boolean properties with defaults

Note: this targets the openj9-staging branch.