### PR TITLE
Add vm.continuations and vm.openj9 value

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -38,11 +38,13 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
         try {
             map.put("vm.bits", vmBits());
             map.put("vm.compiler2.enabled", "false");
+            map.put("vm.continuations", "false");
             map.put("vm.gc.Z", "false");
             map.put("vm.graal.enabled", "false");
             map.put("vm.hasJFR", "false");
             map.put("vm.jvmti", "true");
             map.put("vm.musl", "false");
+            map.put("vm.openj9", "true");
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -1,5 +1,5 @@
 # ===========================================================================
-# Portions Copyright 2018, 2018 IBM Corporation.
+# Portions Copyright 2018, 2022 IBM Corporation.
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -86,6 +86,7 @@ requires.properties= \
     vm.hasSA \
     vm.hasJFR \
     vm.jvmci \
+    vm.openj9 \
     docker.support \
     release.implementor \
     jdk.containerized

--- a/test/jdk/jdk/internal/vm/Continuation/HumongousStack.java
+++ b/test/jdk/jdk/internal/vm/Continuation/HumongousStack.java
@@ -27,7 +27,7 @@
 * @requires vm.continuations
 * @modules java.base/jdk.internal.vm
 *
-* @requires vm.gc.G1
+* @requires vm.openj9 | vm.gc.G1
 * @run main/othervm --enable-preview -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms2g -Xmx2g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xint HumongousStack 5000
 * @run main/othervm --enable-preview -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms2g -Xmx2g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xcomp -XX:TieredStopAtLevel=3 -XX:CompileOnly=jdk/internal/vm/Continuation,HumongousStack HumongousStack 10000
 * @run main/othervm --enable-preview -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms2g -Xmx2g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xcomp -XX:-TieredCompilation -XX:CompileOnly=jdk/internal/vm/Continuation,HumongousStack HumongousStack 10000


### PR DESCRIPTION
- Add vm.continuations and vm.openj9 value
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/15189  https://github.com/eclipse-openj9/openj9/issues/15247

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>