### PR TITLE
Increase clone timeout to 30 minutes

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheck
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheck
@@ -2,10 +2,10 @@
  * ===========================================================================
  * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
- * 
+ *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  
+ * published by the Free Software Foundation.
  *
  * IBM designates this particular file as subject to the "Classpath" exception
  * as provided by IBM in the LICENSE file that accompanied this code.
@@ -18,7 +18,7 @@
  *
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * ===========================================================================
 */
 
@@ -58,7 +58,8 @@ timeout(time: 6, unit: 'HOURS') {
                                                 depth: 0,
                                                 noTags: false,
                                                 reference: "${REPO_CACHE_DIR}",
-                                                shallow: false]],
+                                                shallow: false,
+                                                timeout: 30]],
                                 userRemoteConfigs: [remoteConfigParameters]]
 
                     if (GIT_CREDENTIALS_ID) {


### PR DESCRIPTION
Copyright checking often fails because 10 minutes isn't always enough.