### PR TITLE
Add stub implementation of NativeReferenceQueue

### DIFF
--- a/closed/src/java.base/share/classes/java/lang/ref/NativeReferenceQueue.java
+++ b/closed/src/java.base/share/classes/java/lang/ref/NativeReferenceQueue.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+package java.lang.ref;
+
+/**
+ * An implementation of a ReferenceQueue that uses native monitors.
+ * The use of java.util.concurrent.lock locks interacts with various mechanisms,
+ * such as virtual threads and ForkJoinPool, that might not be appropriate for some
+ * low-level mechanisms, in particular MethodType's weak intern set.
+ */
+final class NativeReferenceQueue<T> extends ReferenceQueue<T> {
+	public NativeReferenceQueue() {
+		super(0);
+	}
+}


### PR DESCRIPTION
Add stub implementation of NativeReferenceQueue

NativeReferenceQueue was added in openjdk to address usage of
j.u.c.locks with virtual threads. OpenJ9 doesn't have that problem as we
only use internal synchronization. As a result we can simply define the
type but make use of the super class methods.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>