### PR TITLE
Support export/import of cryptographic keys in FIPS Mode

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -377,6 +377,7 @@ module java.base {
     exports sun.util.resources to
         jdk.localedata;
     exports openj9.internal.security to
+        jdk.crypto.cryptoki,
         jdk.crypto.ec;
 
     // the service types defined by the APIs in this module

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -157,6 +157,8 @@ grant codeBase "jrt:/jdk.crypto.cryptoki" {
                    "accessClassInPackage.sun.security.*";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
     permission java.lang.RuntimePermission "loadLibrary.j2pkcs11";
+    permission java.lang.RuntimePermission
+                   "accessClassInPackage.openj9.internal.security";
     permission java.util.PropertyPermission "sun.security.pkcs11.allowSingleThreadedModules", "read";
     permission java.util.PropertyPermission "sun.security.pkcs11.disableKeyExtraction", "read";
     permission java.util.PropertyPermission "os.name", "read";

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.pkcs11;
 
 import java.io.*;
@@ -394,6 +400,20 @@ abstract class P11Key implements Key, Length {
         boolean keySensitive = (attrs[0].getBoolean() ||
                 attrs[1].getBoolean() || !attrs[2].getBoolean());
 
+        if (keySensitive && (SunPKCS11.mysunpkcs11 != null) && "RSA".equals(algorithm)) {
+            try {
+                byte[] key = SunPKCS11.mysunpkcs11.exportKey(session.id(), attrs, keyID);
+                RSAPrivateKey rsaPrivKey = RSAPrivateCrtKeyImpl.newKey(KeyType.RSA, "PKCS#8", key);
+                if (rsaPrivKey instanceof RSAPrivateCrtKeyImpl privImpl) {
+                    return new P11RSAPrivateKeyFIPS(session, keyID, algorithm, keyLength, attrs, privImpl);
+                } else {
+                    return new P11RSAPrivateNonCRTKeyFIPS(session, keyID, algorithm, keyLength, attrs, rsaPrivKey);
+                }
+            } catch (PKCS11Exception | InvalidKeyException e) {
+                // Attempt failed, create a P11PrivateKey object.
+            }
+        }
+
         return switch (algorithm) {
             case "RSA" -> P11RSAPrivateKeyInternal.of(session, keyID, algorithm,
                     keyLength, attrs, keySensitive);
@@ -582,6 +602,70 @@ abstract class P11Key implements Key, Length {
         }
     }
 
+    // RSA CRT private key when in FIPS mode
+    private static final class P11RSAPrivateKeyFIPS extends P11Key
+                implements RSAPrivateCrtKey {
+
+        private static final long serialVersionUID = 9215872438913515220L;
+        private final RSAPrivateCrtKeyImpl key;
+
+        P11RSAPrivateKeyFIPS(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs, RSAPrivateCrtKeyImpl key) {
+            super(PRIVATE, session, keyID, algorithm, keyLength, attrs);
+            this.key = key;
+        }
+
+        @Override
+        public String getFormat() {
+            return "PKCS#8";
+        }
+
+        @Override
+        synchronized byte[] getEncodedInternal() {
+            return key.getEncoded();
+        }
+
+        @Override
+        public BigInteger getModulus() {
+            return key.getModulus();
+        }
+
+        @Override
+        public BigInteger getPublicExponent() {
+            return key.getPublicExponent();
+        }
+
+        @Override
+        public BigInteger getPrivateExponent() {
+            return key.getPrivateExponent();
+        }
+
+        @Override
+        public BigInteger getPrimeP() {
+            return key.getPrimeP();
+        }
+
+        @Override
+        public BigInteger getPrimeQ() {
+            return key.getPrimeQ();
+        }
+
+        @Override
+        public BigInteger getPrimeExponentP() {
+            return key.getPrimeExponentP();
+        }
+
+        @Override
+        public BigInteger getPrimeExponentQ() {
+            return key.getPrimeExponentQ();
+        }
+
+        @Override
+        public BigInteger getCrtCoefficient() {
+            return key.getCrtCoefficient();
+        }
+    }
+
     // RSA CRT private key
     private static final class P11RSAPrivateKey extends P11RSAPrivateKeyInternal
             implements RSAPrivateCrtKey {
@@ -657,6 +741,40 @@ abstract class P11Key implements Key, Length {
         }
         public BigInteger getCrtCoefficient() {
             return coeff;
+        }
+    }
+
+    // RSA non-CRT private key in FIPS mode
+    private static final class P11RSAPrivateNonCRTKeyFIPS extends P11Key
+                implements RSAPrivateKey {
+
+        private static final long serialVersionUID = 1137764983777411481L;
+        private final RSAPrivateKey key;
+
+        P11RSAPrivateNonCRTKeyFIPS(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attributes, RSAPrivateKey key) {
+            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+            this.key = key;
+        }
+
+        @Override
+        public String getFormat() {
+            return "PKCS#8";
+        }
+
+        @Override
+        synchronized byte[] getEncodedInternal() {
+            return key.getEncoded();
+        }
+
+        @Override
+        public BigInteger getModulus() {
+            return key.getModulus();
+        }
+
+        @Override
+        public BigInteger getPrivateExponent() {
+            return key.getPrivateExponent();
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -45,11 +45,18 @@
  *  POSSIBILITY  OF SUCH DAMAGE.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.pkcs11.wrapper;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.function.Consumer;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -57,6 +64,7 @@ import java.security.PrivilegedAction;
 import sun.security.util.Debug;
 
 import sun.security.pkcs11.P11Util;
+import sun.security.pkcs11.SunPKCS11;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 import static sun.security.pkcs11.wrapper.PKCS11Exception.RV.*;
 
@@ -140,6 +148,43 @@ public class PKCS11 {
     private static final Map<String,PKCS11> moduleMap =
         new HashMap<String,PKCS11>();
 
+    static boolean isKey(CK_ATTRIBUTE[] attrs) {
+        for (CK_ATTRIBUTE attr : attrs) {
+            if ((attr.type == CKA_CLASS) && (attr.getLong() == CKO_SECRET_KEY)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // This is the SunPKCS11 provider instance
+    // there can only be a single PKCS11 provider in
+    // FIPS mode.
+    private static SunPKCS11 mysunpkcs11;
+
+    private static final class InnerPKCS11 extends PKCS11 implements Consumer<SunPKCS11> {
+        InnerPKCS11(String pkcs11ModulePath, String functionListName) throws IOException {
+            super(pkcs11ModulePath, functionListName);
+        }
+
+        // Set PKCS11 instance to FIPS mode, called by SunPKCS11 provider.
+        @Override
+        public void accept(SunPKCS11 sunpkcs11) {
+            mysunpkcs11 = sunpkcs11;
+        }
+
+        // Overriding the JNI method C_CreateObject so that first check if FIPS mode is on and the object is a
+        // secret key, in which case invoke the importKey method in SunPKCS11 provider to import the secret key
+        // into the PKCS11 device.
+        @Override
+        public synchronized long C_CreateObject(long hSession, CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+            if ((mysunpkcs11 != null) && isKey(pTemplate)) {
+                return mysunpkcs11.importKey(hSession, pTemplate);
+            }
+            return super.C_CreateObject(hSession, pTemplate);
+        }
+    }
+
     /**
      * Connects to the PKCS#11 driver given. The filename must contain the
      * path, if the driver is not in the system's search path.
@@ -183,7 +228,7 @@ public class PKCS11 {
         if (pkcs11 == null) {
             if ((pInitArgs != null)
                     && ((pInitArgs.flags & CKF_OS_LOCKING_OK) != 0)) {
-                pkcs11 = new PKCS11(pkcs11ModulePath, functionList);
+                pkcs11 = new InnerPKCS11(pkcs11ModulePath, functionList);
             } else {
                 pkcs11 = new SynchronizedPKCS11(pkcs11ModulePath, functionList);
             }
@@ -1758,6 +1803,9 @@ static class SynchronizedPKCS11 extends PKCS11 {
 
     public synchronized long C_CreateObject(long hSession,
             CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+        if ((mysunpkcs11 != null) && isKey(pTemplate)) {
+            return mysunpkcs11.importKey(hSession, pTemplate);
+        }
         return super.C_CreateObject(hSession, pTemplate);
     }
 


### PR DESCRIPTION
Signed-off-by: Tao Liu <tao.liu@ibm.com>

This PR is a port from the PR https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/118 into JDKNext. And there are two differences between the JDK17 and JDKNext.

One is for the code about throw the PKCS11Exception, the PKCS11Exception class in JDKNext is changed by removing the “enum values set to variables” code, like below:

public static final long CKR_GENERAL_ERROR = RV.CKR_GENERAL_ERROR.value;

So, there is no way to get the errorCode by using the variable, like CKR_GENERAL_ERROR. Then the “throw new PKCS11Exception(CKR_GENERAL_ERROR);” have to be changed to “throw new PKCS11Exception(0x00000005L, null);”, by using the long errorCode directly.
 
Another one is in the P11Key class, in the method “static PrivateKey privateKey()”. Before JDKnext, only when the below condition is true, then it will go into the FIPS code.

 if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false))

But in the JDKNext, it defined a new variable named “keySensitive”, and added one more “attrs[0].getBoolean()” into this “if” conditions, as below:

boolean keySensitive = (attrs[0].getBoolean() || attrs[1].getBoolean() || !attrs[2].getBoolean());

So, for this one, if the “keySensitive” is true, then it will go into the FIPS code.