### PR TITLE
Set mainGroup name to incoming vmName

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -3305,13 +3305,13 @@ public class Thread implements Runnable {
         boolean booting = false;
         if (mainGroup == null) {
             // only occurs during bootstrap
+            // vmName must be main at booting
             booting = true;
-            mainGroup = new ThreadGroup(systemThreadGroup, "main");
+            mainGroup = new ThreadGroup(systemThreadGroup, name);
         } else {
             setNameImpl(eetop, name);
         }
         ThreadGroup threadGroup = (vmThreadGroup == null) ? mainGroup : (ThreadGroup)vmThreadGroup;
-
         // If we called setPriority(), it would have to be after setting the ThreadGroup (further down),
         // because of the checkAccess() call (which requires the ThreadGroup set). However, for the main
         // Thread or JNI-C attached Threads we just trust the value the VM is passing us, and just assign.


### PR DESCRIPTION
`vmName` should be `main` at booting.

Related https://github.com/eclipse-openj9/openj9/issues/15205

Cherry-pick https://github.com/ibmruntimes/openj9-openjdk-jdk19/pull/11

Signed-off-by: Jason Feng <fengj@ca.ibm.com>