### PR TITLE
Update OpenJDK Next test case to add module jdk.crypto.cryptoki

### DIFF
--- a/test/jdk/java/lang/Class/GetPackageBootLoaderChildLayer.java
+++ b/test/jdk/java/lang/Class/GetPackageBootLoaderChildLayer.java
@@ -21,12 +21,18 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 /**
  * @test
  * @requires !vm.graal.enabled
  * @modules jdk.attach
- * @run main/othervm --limit-modules jdk.attach -Djdk.attach.allowAttachSelf
- *    GetPackageBootLoaderChildLayer
+ * @run main/othervm --limit-modules jdk.attach,jdk.crypto.cryptoki
+ *    -Djdk.attach.allowAttachSelf GetPackageBootLoaderChildLayer
  * @summary Exercise Class.getPackage on a class defined to the boot loader
  *    but in a module that is in a child layer rather than the boot layer
  */


### PR DESCRIPTION
Port PR https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/557 from OpenJDK11 to OpenJDK Next.

In FIPS mode, the SecureRandom come from the provider SunPKCS11. So, add the module “jdk.crypto.cryptoki” into the test case, so that the test case can initialize the provider SunPKCS11 and get the SecureRandom from it in FIPS mode. This will make the test case works both in the FIPS and non-FIPS mode.

Signed-off-by: Tao Liu <tao.liu@ibm.com>