### PR TITLE
Enable VirtualThread JVMTI natives by default

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
 package java.lang;
 
 import java.security.AccessController;
@@ -1008,6 +1013,7 @@ final class VirtualThread extends BaseVirtualThread {
     private static native void registerNatives();
     static {
         registerNatives();
+        notifyJvmtiEvents = true;
     }
 
     /**


### PR DESCRIPTION
The VirtualThread natives are needed to keep a list of every live virtual
thread for JVMTI. Since JVMTI agents can be attached at any time, enable
these natives by default.

Issue: eclipse-openj9/openj9#15183

Co-authored-by: Babneet Singh <sbabneet@ca.ibm.com>
Signed-off-by: Eric Yang <eric.yang@ibm.com>