### PR TITLE
[JEP424] Enable FFI Upcall on s390x/Aarch64/x86 in JDKnext

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -164,7 +164,7 @@ public abstract class CallArranger {
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, MemorySession session) {
-        throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
+        return UpcallLinker.make(target, mt, cDesc, session);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/CallArranger.java
@@ -55,6 +55,6 @@ public class CallArranger {
 
 	/* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
 	public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, MemorySession session) {
-		throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
+		return UpcallLinker.make(target, mt, cDesc, session);
 	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -133,7 +133,7 @@ public class CallArranger {
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, MemorySession session) {
-        throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
+        return UpcallLinker.make(target, mt, cDesc, session);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -136,7 +136,7 @@ public class CallArranger {
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, MemorySession session) {
-        throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
+        return UpcallLinker.make(target, mt, cDesc, session);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -355,7 +355,12 @@ public final class NativeLibraries {
 
         @Override
         public long find(String name) {
-            return NativeLibraries.findEntryInProcess(name);
+            boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+            if (isAixOS) {
+                return NativeLibraries.findEntryInProcess(name);
+            } else {
+                throw new UnsupportedOperationException("Cannot find on non-AIX platforms");
+            }
         }
 
     };


### PR DESCRIPTION
The changes aim to enable the Linker's upcall handler to
support primitives and struct by replacing UpcallLinker
with the equivalent implemented in OpenJ9 on s390x,
Aarch64 and x86.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>