### PR TITLE
Add initCompressionFlag() to String constructors

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -527,6 +527,7 @@ public final class String
                 this.value = val;
                 return;
             }
+            initCompressionFlag();
         }
         this.coder = UTF16;
         this.value = StringUTF16.toBytes(codePoints, offset, count);
@@ -590,6 +591,9 @@ public final class String
             }
             this.value = val;
             this.coder = UTF16;
+            if (COMPACT_STRINGS) {
+                initCompressionFlag();
+            }
         }
     }
 
@@ -836,6 +840,7 @@ public final class String
                         coder = LATIN1;
                         return;
                     }
+                    initCompressionFlag();
                 }
                 coder = UTF16;
                 value = StringUTF16.toBytes(ca, 0, clen);
@@ -870,6 +875,9 @@ public final class String
             }
             coder = UTF16;
             value = StringUTF16.toBytes(ca, 0, caLen);
+        }
+        if (COMPACT_STRINGS && coder == UTF16) {
+            initCompressionFlag();
         }
     }
 
@@ -5277,7 +5285,8 @@ public final class String
                 this.coder = LATIN1;
                 return;
             }
-        }
+            initCompressionFlag();
+		}
         this.coder = UTF16;
         this.value = StringUTF16.toBytes(value, off, len);
     }
@@ -5304,6 +5313,9 @@ public final class String
             }
             this.coder = UTF16;
             this.value = Arrays.copyOfRange(val, 0, length << 1);
+            if (COMPACT_STRINGS) {
+                initCompressionFlag();
+            }
         }
     }
 


### PR DESCRIPTION
Set compression flag in constructors creating uncompressed strings when compact strings is enabled. OpenJ9 uses this flag to check if a string with uncompressed characters has been created, and not having it enabled when there has been leads to errors since the code assumes all strings are still compressed.

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/143

fyi @keithc-ca 