### PR TITLE
Update code-signing on macOS

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -131,12 +131,20 @@ endif
 # Usage: $(call CodesignFile, files ...)
 ifeq (,$(CODESIGN))
   CodesignFile =
-else
+else ifeq (debug, $(MACOSX_CODESIGN_MODE))
+  CodesignFile = $(CODESIGN) --sign - \
+	--entitlements $(TOPDIR)/make/data/macosxsigning/default-debug.plist \
+	--force \
+	$1
+else ifeq (hardened, $(MACOSX_CODESIGN_MODE))
   CodesignFile = $(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" \
 	--entitlements $(TOPDIR)/make/data/macosxsigning/default.plist \
+	--force \
 	--options runtime \
 	--timestamp \
 	$1
+else
+  CodesignFile =
 endif
 
 # Archive from which to import Health Center content.


### PR DESCRIPTION
* disabled if codesign is not available or configuring with `CODESIGN=`
* two modes (`MACOSX_CODESIGN_MODE`): `debug`, `hardened`