### PR TITLE
Avoid warnings during code-signing on macOS

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -132,17 +132,23 @@ endif
 ifeq (,$(CODESIGN))
   CodesignFile =
 else ifeq (debug, $(MACOSX_CODESIGN_MODE))
-  CodesignFile = $(CODESIGN) --sign - \
-	--entitlements $(TOPDIR)/make/data/macosxsigning/default-debug.plist \
-	--force \
-	$1
+  define CodesignFile
+	$(CODESIGN) --remove-signature $1
+	$(CODESIGN) --sign - \
+		--entitlements $(TOPDIR)/make/data/macosxsigning/default-debug.plist \
+		--force \
+		$1
+  endef
 else ifeq (hardened, $(MACOSX_CODESIGN_MODE))
-  CodesignFile = $(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" \
-	--entitlements $(TOPDIR)/make/data/macosxsigning/default.plist \
-	--force \
-	--options runtime \
-	--timestamp \
-	$1
+  define CodesignFile
+	$(CODESIGN) --remove-signature $1
+	$(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" \
+		--entitlements $(TOPDIR)/make/data/macosxsigning/default.plist \
+		--force \
+		--options runtime \
+		--timestamp \
+		$1
+  endef
 else
   CodesignFile =
 endif


### PR DESCRIPTION
See also
* 8293965: Code signing warnings after JDK-8293550