### PR TITLE
Add OpenJ9PropsExt properties for serviceability_jvmti_j9

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -37,8 +37,10 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
         Map<String, String> map = new HashMap<>();
         try {
             map.put("vm.bits", vmBits());
+            map.put("vm.cds", "false");
             map.put("vm.compiler2.enabled", "false");
             map.put("vm.continuations", "false");
+            map.put("vm.flagless", "true");
             map.put("vm.gc.G1", "false");
             map.put("vm.gc.Parallel", "false");
             map.put("vm.gc.Serial", "false");
@@ -49,6 +51,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.jvmti", "true");
             map.put("vm.musl", "false");
             map.put("vm.openj9", "true");
+            map.put("vm.opt.final.ClassUnloading", "false");
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
`vm.cds` is set to `false` for `serviceability/jvmti/CanGenerateAllClassHook/CanGenerateAllClassHook.java` which is specific to hotspot sharedclass;
`vm.flagless` is set to `true` for `serviceability/jvmti/RedefineClasses/RedefineLeak.java` which OpenJ9 passes;
`vm.opt.final.ClassUnloading` is set to `false` for `serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java` which looks for a hotspot specific `Class unloading: has_previous_versions = false`.

Cherry-pick https://github.com/ibmruntimes/openj9-openjdk-jdk19/pull/34

closes https://github.com/eclipse-openj9/openj9/issues/16074


Signed-off-by: Jason Feng <fengj@ca.ibm.com>