### PR TITLE
Set OpenJ9PropsExt.java vm.debug test property to false

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -40,6 +40,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.cds", "false");
             map.put("vm.compiler2.enabled", "false");
             map.put("vm.continuations", "false");
+            map.put("vm.debug", "false");
             map.put("vm.flagless", "true");
             map.put("vm.gc.G1", "false");
             map.put("vm.gc.Parallel", "false");


### PR DESCRIPTION
The java/util/concurrent/ConcurrentHashMap/MapLoops.java test requires this property, along with -XX:+UseHeavyMonitors -XX:+VerifyHeavyMonitors options.