### PR TITLE
Fix the alignment issue with long & pointer on AIX

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -369,7 +369,7 @@ public class PlatformLayouts {
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG.withBitAlignment(32);
+        public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG.withBitAlignment(64);
 
         /**
          * The {@code float} native type.
@@ -384,7 +384,7 @@ public class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(32);
+        public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);
 
         /**
          * The {@code va_list} native type, as it is passed to a function.

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -77,7 +77,7 @@ public class NativeTestHelper {
     /**
      * The layout for the {@code long long} C type.
      */
-    public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG.withBitAlignment(isAixOS ? 32 : 64);
+    public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG.withBitAlignment(64);
     /**
      * The layout for the {@code float} C type
      */
@@ -89,7 +89,7 @@ public class NativeTestHelper {
     /**
      * The {@code T*} native type.
      */
-    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(isAixOS ? 32 : 64);
+    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);
 
     private static Linker LINKER = Linker.nativeLinker();
 


### PR DESCRIPTION
The changes aim to restore the original alignment setting for long and pointer on AIX given the padding is required in native in the case of struct [int/float,long] and [int/float,pointer].

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>