### PR TITLE
Add javax.management.Attribute to serialfilter

### DIFF
--- a/src/jdk.management.agent/share/conf/management.properties
+++ b/src/jdk.management.agent/share/conf/management.properties
@@ -302,5 +302,5 @@
 #   If the pattern ends with "*", it matches any class with the pattern as a prefix.
 #   If the pattern is equal to the class name, it matches.
 #   Otherwise, the status is UNDECIDED.
-com.sun.management.jmxremote.serial.filter.pattern=java.lang.*;java.math.BigInteger;java.math.BigDecimal;java.util.*;javax.management.openmbean.*;javax.management.ObjectName;java.rmi.MarshalledObject;javax.security.auth.Subject;!*
+com.sun.management.jmxremote.serial.filter.pattern=java.lang.*;java.math.BigInteger;java.math.BigDecimal;java.util.*;javax.management.openmbean.*;javax.management.Attribute;javax.management.ObjectName;java.rmi.MarshalledObject;javax.security.auth.Subject;!*
 


### PR DESCRIPTION
OpenJ9 uses generic CompositeData, which uses Attribute to transmit data, rather than having custom CompositeData implementations.

Related to https://bugs.openjdk.org/browse/JDK-8283093 - JMX connections use an ObjectInputFilter by default

Closes https://github.com/eclipse-openj9/openj9/issues/16253

Tested the equivalent change via grinders
https://openj9-jenkins.osuosl.org/job/Grinder_testList_0/179/
https://openj9-jenkins.osuosl.org/job/Grinder_testList_0/180/