### PR TITLE
Handle thread interrupted status at CRIU single threaded mode

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1744,6 +1744,10 @@ public class Thread implements Runnable {
      * @revised 6.0, 14
      */
     public boolean isInterrupted() {
+        // use fully qualified name to avoid ambiguous class error
+        if (com.ibm.oti.vm.VM.isJVMInSingleThreadedMode()) {
+            return isInterruptedImpl();
+        }
         return interrupted;
     }
 
@@ -1764,6 +1768,10 @@ public class Thread implements Runnable {
     }
 
     boolean getAndClearInterrupt() {
+        // use fully qualified name to avoid ambiguous class error
+        if (com.ibm.oti.vm.VM.isJVMInSingleThreadedMode()) {
+            return interruptedImpl();
+        }
         synchronized (interruptLock) {
             boolean oldValue = interrupted;
             if (oldValue) {
@@ -3064,6 +3072,7 @@ public class Thread implements Runnable {
     private native void setPriorityNoVMAccessImpl(long eetop, int priority);
     private native void interruptImpl();
     private static native boolean interruptedImpl();
+    private native boolean isInterruptedImpl();
     private native void setNameImpl(long threadRef, String threadName);
     private native int getStateImpl(long eetop);
 


### PR DESCRIPTION
At CRIU single threaded mode, returns `isInterruptedImpl()` for `isInterrupted()`, returns `interruptedImpl()` for `interrupted()`.

Cherry-pick https://github.com/ibmruntimes/openj9-openjdk-jdk19/pull/54/commits/c569e9e8668deb5e8a6f5b556c4912c834282611

Signed-off-by: Jason Feng <fengj@ca.ibm.com>