### PR TITLE
Update dependencies for running Java preprocessor

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -53,7 +53,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 IncludeIfUnsure := -includeIfUnsure -noWarnIncludeIf
 
 $(J9JCL_SOURCES_DONEFILE) : \
-		$(foreach dir, $(JppSourceDirs), $(call RecursiveWildcard,$(dir),*.java)) \
+		$(foreach dir, $(JppSourceDirs), $(call RecursiveWildcard,$(dir),*)) \
 		$(COPY_OVERLAY_FILES)
 	@$(ECHO) Building OpenJ9 Java Preprocessor
 	@$(MKDIR) -p $(J9TOOLS_DIR)


### PR DESCRIPTION
The preprocessor should run if any input files have changed; that is not just `*.java` files, but also, for example, `module-info.java.extra` files. Only Java 8 had this correct (see [OpenJ9.gmk](https://github.com/ibmruntimes/openj9-openjdk-jdk8/blob/openj9/closed/OpenJ9.gmk#L489)).