### PR TITLE
tokenLabel duplicate entry fix

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -515,7 +515,8 @@ final class Config {
             default->
                 {
                     if ("tokenLabel".equalsIgnoreCase(st.sval)) {
-                        tokenLabel = parseStringEntry("tokenLabel");
+                        st.sval = "tokenLabel";
+                        tokenLabel = parseStringEntry(st.sval);
                     } else {
                         throw new ConfigurationException
                                 ("Unknown keyword '" + st.sval + "', line " +


### PR DESCRIPTION
Updating tokenLabel check so keyword is recorded properly.

Signed-off-by: Bob Du bob.du@ibm.com