### PR TITLE
Add null check for virtual thread HoldsLock test

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/HoldsLock.java
+++ b/test/jdk/java/lang/Thread/virtual/HoldsLock.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /**
  * @test
@@ -112,6 +117,11 @@ public class HoldsLock {
         boolean foundCarrier = false;
         for (long tid : tids) {
             ThreadInfo info = bean.getThreadInfo(tid);
+
+            // Skip null ThreadInfo where the thread already exited.
+            if (null == info) {
+                continue;
+            }
             System.out.println(info); // System.out.format("%d\t%s%n", tid, info.getThreadName());
 
             LockInfo lock = info.getLockInfo();


### PR DESCRIPTION
- Ensure only live threads are being checked

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk19/pull/71

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>