### PR TITLE
Fix the compiler flags on AIX for the symbol lookup in FFI

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -27,7 +27,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
 # ===========================================================================
 
 AC_DEFUN([FLAGS_SETUP_LDFLAGS],
@@ -81,7 +81,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
         -fPIC"
 
   elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    BASIC_LDFLAGS="-b64 -brtl -bnolibpath -bnoexpall -bernotok -btextpsize:64K \
+    BASIC_LDFLAGS="-b64 -brtl -bnolibpath -bexpall -bernotok -btextpsize:64K \
         -bdatapsize:64K -bstackpsize:64K"
     # libjvm.so has gotten too large for normal TOC size; compile with qpic=large and link with bigtoc
     BASIC_LDFLAGS_JVM_ONLY="-Wl,-lC_r -bbigtoc"


### PR DESCRIPTION
The change restores the previous flag of XLC on AIX in JDK17
to export all required function symbols in the default library
to ensure they are located via the FFI related code for the
symbol lookup given the code with the default library loading
is directly forthported from JDK17.

Signed-off-by: ChengJin01 [jincheng@ca.ibm.com](mailto:jincheng@ca.ibm.com)
