### PR TITLE
Update the FFI related code intended for JEP434

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/CABI.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/CABI.java
@@ -26,7 +26,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -42,9 +42,9 @@ public enum CABI {
     MAC_OS_AARCH_64,
     WIN_AARCH_64,
     LINUX_RISCV_64,
-    SysVPPC64le,
-    SysVS390x,
-    AIX;
+    SYS_V_PPC_64LE,
+    SYS_V_S390X,
+    AIX_PPC_64;
 
     private static final CABI ABI;
     private static final String ARCH;
@@ -81,12 +81,12 @@ public enum CABI {
             }
         } else if (ARCH.startsWith("ppc64")) {
             if (OS.startsWith("Linux")) {
-                ABI = SysVPPC64le;
+                ABI = SYS_V_PPC_64LE;
             } else {
-                ABI = AIX;
+                ABI = AIX_PPC_64;
             }
         } else if (ARCH.equals("s390x") && OS.startsWith("Linux")) {
-            ABI = SysVS390x;
+            ABI = SYS_V_S390X;
         } else {
             // unsupported
             ABI = null;

--- a/src/java.base/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -26,7 +26,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -325,7 +325,7 @@ public final class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);
+        public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64).asUnbounded();
 
         /**
          * The {@code va_list} native type, as it is passed to a function.
@@ -384,7 +384,7 @@ public final class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);
+        public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64).asUnbounded();
 
         /**
          * The {@code va_list} native type, as it is passed to a function.
@@ -443,7 +443,7 @@ public final class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);
+        public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64).asUnbounded();
 
         /**
          * The {@code va_list} native type, as it is passed to a function.

--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -65,8 +65,8 @@ public final class SystemLookup implements SymbolLookup {
     private static SymbolLookup makeSystemLookup() {
         try {
             return switch (CABI.current()) {
-                case SYS_V, LINUX_AARCH_64, MAC_OS_AARCH_64, LINUX_RISCV_64, SysVPPC64le, SysVS390x -> libLookup(libs -> libs.load(jdkLibraryPath("syslookup")));
-                case AIX -> makeAixLookup();
+                case SYS_V, LINUX_AARCH_64, MAC_OS_AARCH_64, LINUX_RISCV_64, SYS_V_PPC_64LE, SYS_V_S390X -> libLookup(libs -> libs.load(jdkLibraryPath("syslookup")));
+                case AIX_PPC_64 -> makeAixLookup();
                 case WIN_64, WIN_AARCH_64 -> makeWindowsLookup(); // out of line to workaround javac crash
             };
         } catch (Throwable ex) {
@@ -159,7 +159,7 @@ public final class SystemLookup implements SymbolLookup {
     private static Path jdkLibraryPath(String name) {
         Path javahome = Path.of(GetPropertyAction.privilegedGetProperty("java.home"));
         String lib = switch (CABI.current()) {
-            case SYS_V, LINUX_AARCH_64, MAC_OS_AARCH_64, LINUX_RISCV_64, SysVPPC64le, SysVS390x, AIX -> "lib";
+            case SYS_V, LINUX_AARCH_64, MAC_OS_AARCH_64, LINUX_RISCV_64, SYS_V_PPC_64LE, SYS_V_S390X, AIX_PPC_64 -> "lib";
             case WIN_64, WIN_AARCH_64 -> "bin";
         };
         String libname = System.mapLibraryName(name);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -202,9 +202,9 @@ public final class SharedUtils {
             case MAC_OS_AARCH_64 -> MacOsAArch64Linker.getInstance();
             case WIN_AARCH_64 -> WindowsAArch64Linker.getInstance();
             case LINUX_RISCV_64 -> LinuxRISCV64Linker.getInstance();
-            case SysVPPC64le -> SysVPPC64leLinker.getInstance();
-            case SysVS390x -> SysVS390xLinker.getInstance();
-            case AIX -> AixPPC64Linker.getInstance();
+            case SYS_V_PPC_64LE -> SysVPPC64leLinker.getInstance();
+            case SYS_V_S390X -> SysVS390xLinker.getInstance();
+            case AIX_PPC_64 -> AixPPC64Linker.getInstance();
         };
     }
 
@@ -318,9 +318,9 @@ public final class SharedUtils {
             case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaList(actions, scope);
             case LINUX_RISCV_64 -> LinuxRISCV64Linker.newVaList(actions, scope);
             case WIN_AARCH_64 -> WindowsAArch64Linker.newVaList(actions, scope);
-            case SysVPPC64le -> SysVPPC64leLinker.newVaList(actions, scope);
-            case SysVS390x -> SysVS390xLinker.newVaList(actions, scope);
-            case AIX -> AixPPC64Linker.newVaList(actions, scope);
+            case SYS_V_PPC_64LE -> SysVPPC64leLinker.newVaList(actions, scope);
+            case SYS_V_S390X -> SysVS390xLinker.newVaList(actions, scope);
+            case AIX_PPC_64 -> AixPPC64Linker.newVaList(actions, scope);
         };
     }
 
@@ -332,9 +332,9 @@ public final class SharedUtils {
             case MAC_OS_AARCH_64 -> MacOsAArch64Linker.newVaListOfAddress(address, scope);
             case LINUX_RISCV_64 -> LinuxRISCV64Linker.newVaListOfAddress(address, scope);
             case WIN_AARCH_64 -> WindowsAArch64Linker.newVaListOfAddress(address, scope);
-            case SysVPPC64le -> SysVPPC64leLinker.newVaListOfAddress(address, scope);
-            case SysVS390x -> SysVS390xLinker.newVaListOfAddress(address, scope);
-            case AIX -> AixPPC64Linker.newVaListOfAddress(address, scope);
+            case SYS_V_PPC_64LE -> SysVPPC64leLinker.newVaListOfAddress(address, scope);
+            case SYS_V_S390X -> SysVS390xLinker.newVaListOfAddress(address, scope);
+            case AIX_PPC_64 -> AixPPC64Linker.newVaListOfAddress(address, scope);
         };
     }
 
@@ -346,9 +346,9 @@ public final class SharedUtils {
             case MAC_OS_AARCH_64 -> MacOsAArch64Linker.emptyVaList();
             case LINUX_RISCV_64 -> LinuxRISCV64Linker.emptyVaList();
             case WIN_AARCH_64 -> WindowsAArch64Linker.emptyVaList();
-            case SysVPPC64le -> SysVPPC64leLinker.emptyVaList();
-            case SysVS390x -> SysVS390xLinker.emptyVaList();
-            case AIX -> AixPPC64Linker.emptyVaList();
+            case SYS_V_PPC_64LE -> SysVPPC64leLinker.emptyVaList();
+            case SYS_V_S390X -> SysVS390xLinker.emptyVaList();
+            case AIX_PPC_64 -> AixPPC64Linker.emptyVaList();
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -57,6 +57,8 @@ import java.lang.invoke.MethodType;
 import java.util.List;
 import java.util.Optional;
 
+import sun.security.action.GetPropertyAction;
+
 import static jdk.internal.foreign.PlatformLayouts.*;
 import static jdk.internal.foreign.abi.aarch64.AArch64Architecture.*;
 import static jdk.internal.foreign.abi.aarch64.AArch64Architecture.Regs.*;
@@ -77,6 +79,8 @@ public abstract class CallArranger {
     public static final int MAX_REGISTER_ARGUMENTS = 8;
 
     private static final VMStorage INDIRECT_RESULT = r8;
+
+    private static final boolean isWinOS = GetPropertyAction.privilegedGetProperty("os.name").startsWith("Windows");
 
     // This is derived from the AAPCS64 spec, restricted to what's
     // possible when calling to/from C code.
@@ -186,15 +190,18 @@ public abstract class CallArranger {
 
     /* Replace DowncallLinker in OpenJDK with the implementation of DowncallLinker specific to OpenJ9 */
     public MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
-        // MethodHandle handle = DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
-        // return handle;
-        return null;
+        if (isWinOS) {
+            throw new InternalError("arrangeDowncall is not implemented on Windows/Aarch64");
+        }
+        return DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
     }
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
-        // return UpcallLinker.make(target, mt, cDesc, session);
-        return null;
+        if (isWinOS) {
+            throw new InternalError("arrangeUpcall is not implemented on Windows/Aarch64");
+        }
+        return UpcallLinker.make(target, mt, cDesc, session);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/windows/WindowsAArch64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/windows/WindowsAArch64VaList.java
@@ -23,6 +23,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.foreign.abi.aarch64.windows;
 
 import java.lang.foreign.GroupLayout;
@@ -64,6 +71,7 @@ public non-sealed class WindowsAArch64VaList implements VaList {
 
     private WindowsAArch64VaList(MemorySegment segment) {
         this.segment = segment;
+        throw new InternalError("WindowsAArch64VaList()/VaList is not implemented on Windows/Aarch64");
     }
 
     public static VaList empty() {
@@ -103,6 +111,11 @@ public non-sealed class WindowsAArch64VaList implements VaList {
     private Object read(MemoryLayout layout, SegmentAllocator allocator) {
         Objects.requireNonNull(layout);
         Object res;
+
+        if (layout != null) {
+            throw new InternalError("VaList is not implemented on Windows/Aarch64");
+        }
+
         if (layout instanceof GroupLayout) {
             TypeClass typeClass = TypeClass.classifyLayout(layout);
             res = switch (typeClass) {
@@ -189,6 +202,7 @@ public non-sealed class WindowsAArch64VaList implements VaList {
         public Builder(SegmentScope session) {
             ((MemorySessionImpl) session).checkValidState();
             this.session = session;
+            throw new InternalError("VaList is not implemented on Windows/Aarch64");
         }
 
         private Builder arg(MemoryLayout layout, Object value) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64Linker.java
@@ -49,13 +49,17 @@ import java.util.function.Consumer;
  * on AIX/ppc64 and might be updated accordingly in terms of VaList in the future.
  */
 public final class AixPPC64Linker extends AbstractLinker {
-    private static AixPPC64Linker instance;
 
     public static AixPPC64Linker getInstance() {
-        if (instance == null) {
-            instance = new AixPPC64Linker();
+        final class Holder {
+            private static final AixPPC64Linker INSTANCE = new AixPPC64Linker();
         }
-        return instance;
+
+        return Holder.INSTANCE;
+    }
+
+    private AixPPC64Linker() {
+        /* Ensure there is only one instance. */
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64VaList.java
@@ -68,9 +68,9 @@ public non-sealed class AixPPC64VaList implements VaList {
 	private MemorySegment segment;
 	private final SegmentScope session;
 
-	private AixPPC64VaList(MemorySegment segment, SegmentScope session) {
+	private AixPPC64VaList(MemorySegment segment) {
 		this.segment = segment;
-		this.session = session;
+		this.session = segment.scope();
 	}
 
 	public static final VaList empty() {
@@ -132,7 +132,7 @@ public non-sealed class AixPPC64VaList implements VaList {
 			default -> throw new IllegalStateException("Unsupported TypeClass: " + typeClass);
 		}
 
-		/* Move to the next argument in the va_list buffer */
+		/* Move to the next argument in the va_list buffer. */
 		segment = segment.asSlice(argByteSize);
 		return argument;
 	}
@@ -140,7 +140,7 @@ public non-sealed class AixPPC64VaList implements VaList {
 	private static long getAlignedArgSize(MemoryLayout argLayout) {
 		long argLayoutSize = VA_LIST_SLOT_BYTES; // Always aligned with 8 bytes for primitives/pointer by default
 
-		/* As with primitives, a struct should aligned with 8 bytes */
+		/* As with primitives, a struct should aligned with 8 bytes. */
 		if (argLayout instanceof GroupLayout) {
 			argLayoutSize = argLayout.byteSize();
 			if ((argLayoutSize % VA_LIST_SLOT_BYTES) > 0) {
@@ -151,7 +151,7 @@ public non-sealed class AixPPC64VaList implements VaList {
 		return argLayoutSize;
 	}
 
-	/* Check whether the argument to be skipped exceeds the existing memory size in the VaList */
+	/* Check whether the argument to be skipped exceeds the existing memory size in the VaList. */
 	private void checkNextArgument(MemoryLayout argLayout, long argByteSize) {
 		if (argByteSize > segment.byteSize()) {
 			throw SharedUtils.newVaListNSEE(argLayout);
@@ -171,20 +171,19 @@ public non-sealed class AixPPC64VaList implements VaList {
 			Objects.requireNonNull(layout);
 			long argByteSize = getAlignedArgSize(layout);
 			checkNextArgument(layout, argByteSize);
-			/* Skip to the next argument in the va_list buffer */
+			/* Skip to the next argument in the va_list buffer. */
 			segment = segment.asSlice(argByteSize);
 		}
 	}
 
-	public static VaList ofAddress(long addr, SegmentScope session) {
-		MemorySegment segment = MemorySegment.ofAddress(addr, Long.MAX_VALUE, session);
-		return new AixPPC64VaList(segment, session);
+	public static VaList ofAddress(long address, SegmentScope session) {
+		return new AixPPC64VaList(MemorySegment.ofAddress(address, Long.MAX_VALUE, session));
 	}
 
 	@Override
 	public VaList copy() {
 		((MemorySessionImpl)session).checkValidState();
-		return new AixPPC64VaList(segment, session);
+		return new AixPPC64VaList(segment);
 	}
 
 	@Override
@@ -284,7 +283,7 @@ public non-sealed class AixPPC64VaList implements VaList {
 				/* Move to the next argument by the aligned size of the current argument */
 				cursorSegment = cursorSegment.asSlice(argByteSize);
 			}
-			return new AixPPC64VaList(segment, session);
+			return new AixPPC64VaList(segment);
 		}
 	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/CallArranger.java
@@ -50,14 +50,11 @@ public class CallArranger {
 
 	/* Replace DowncallLinker in OpenJDK with the implementation of DowncallLinker specific to OpenJ9 */
 	public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
-		// MethodHandle handle = DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
-		// return handle;
-		return null;
+		return DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
 	}
 
 	/* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
 	public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
-		// return UpcallLinker.make(target, mt, cDesc, session);
-		return null;
+		return UpcallLinker.make(target, mt, cDesc, session);
 	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/sysv/CallArranger.java
@@ -50,14 +50,11 @@ public class CallArranger {
 
 	/* Replace DowncallLinker in OpenJDK with the implementation of DowncallLinker specific to OpenJ9 */
 	public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
-		// MethodHandle handle = DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
-		// return handle;
-		return null;
+		return DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
 	}
 
 	/* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
 	public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
-		// return UpcallLinker.make(target, mt, cDesc, session);
-		return null;
+		return UpcallLinker.make(target, mt, cDesc, session);
 	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/sysv/SysVPPC64leLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/sysv/SysVPPC64leLinker.java
@@ -49,13 +49,17 @@ import java.util.function.Consumer;
  * on Linux/ppc64le and might be updated accordingly in terms of VaList in the future.
  */
 public final class SysVPPC64leLinker extends AbstractLinker {
-    private static SysVPPC64leLinker instance;
 
     public static SysVPPC64leLinker getInstance() {
-        if (instance == null) {
-            instance = new SysVPPC64leLinker();
+        final class Holder {
+            private static final SysVPPC64leLinker INSTANCE = new SysVPPC64leLinker();
         }
-        return instance;
+
+        return Holder.INSTANCE;
+    }
+
+    private SysVPPC64leLinker() {
+        /* Ensure there is only one instance. */
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/CallArranger.java
@@ -50,14 +50,11 @@ public class CallArranger {
 
 	/* Replace DowncallLinker in OpenJDK with the implementation of DowncallLinker specific to OpenJ9 */
 	public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
-		// MethodHandle handle = DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
-		// return handle;
-		return null;
+		return DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
 	}
 
 	/* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
 	public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
-		// return UpcallLinker.make(target, mt, cDesc, session);
-		return null;
+		return UpcallLinker.make(target, mt, cDesc, session);
 	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/SysVS390xLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/SysVS390xLinker.java
@@ -49,13 +49,17 @@ import java.util.function.Consumer;
  * on Linux/s390x and might be updated accordingly in terms of VaList in the future.
  */
 public final class SysVS390xLinker extends AbstractLinker {
-    private static SysVS390xLinker instance;
 
     public static SysVS390xLinker getInstance() {
-        if (instance == null) {
-            instance = new SysVS390xLinker();
+        final class Holder {
+            private static final SysVS390xLinker INSTANCE = new SysVS390xLinker();
         }
-        return instance;
+
+        return Holder.INSTANCE;
+    }
+
+    private SysVS390xLinker() {
+        /* Ensure there is only one instance */
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/SysVS390xVaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/SysVS390xVaList.java
@@ -41,13 +41,11 @@ import java.util.Objects;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
-import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.misc.Unsafe;
 
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
-import static jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
-import static jdk.internal.foreign.abi.SharedUtils.THROWING_ALLOCATOR;
 import static jdk.internal.foreign.PlatformLayouts.SysVS390x;
+import static jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
 
 /**
  * This class implements VaList specific to Linux/s390x based on "ELF Application Binary Interface
@@ -132,9 +130,9 @@ public non-sealed class SysVS390xVaList implements VaList {
 			FP_REG.withName("f6")  /* #3 */
 		);
 
-	/* The starting offset of the general register save area */
+	/* The starting offset of the general register save area. */
 	private static final long GPR_OFFSET = LAYOUT_REG_SAVE_AREA.byteOffset(groupElement("r2"));
-	/* The starting offset of the floating-point register save area */
+	/* The starting offset of the floating-point register save area. */
 	private static final long FPR_OFFSET = LAYOUT_REG_SAVE_AREA.byteOffset(groupElement("f0"));
 
 	private static final long MAX_GPR_NUM = 5; /* 5 8-byte general registers (r2-r6) being used */
@@ -218,12 +216,12 @@ public non-sealed class SysVS390xVaList implements VaList {
 		Objects.requireNonNull(layouts);
 		((MemorySessionImpl)segment.scope()).checkValidState();
 		for (MemoryLayout layout : layouts) {
-			readArg(layout, THROWING_ALLOCATOR, false);
+			readArg(layout, SharedUtils.THROWING_ALLOCATOR, false);
 		}
 	}
 
 	private Object readArg(MemoryLayout layout) {
-		return readArg(layout, THROWING_ALLOCATOR, true);
+		return readArg(layout, SharedUtils.THROWING_ALLOCATOR, true);
 	}
 
 	private Object readArg(MemoryLayout layout, SegmentAllocator allocator, boolean isRead) {
@@ -239,7 +237,7 @@ public non-sealed class SysVS390xVaList implements VaList {
 			if (isRead) {
 				argument = getArgFromMemoryArea(layout, overflowAreaCursor, allocator, true);
 			}
-			/* Move to the next argument by 8 bytes in the overflow area */
+			/* Move to the next argument by 8 bytes in the overflow area. */
 			overflowAreaCursor = overflowAreaCursor.asSlice(VA_LIST_SLOT_BYTES);
 		} else {
 			checkRegSaveAreaElement(layout);
@@ -248,14 +246,14 @@ public non-sealed class SysVS390xVaList implements VaList {
 					if (isRead) {
 						argument = getArgFromMemoryArea(layout, gpRegSaveArea, allocator, false);
 					}
-					/* Move to the next argument in the general register area */
+					/* Move to the next argument in the general register area. */
 					moveToNextArgOfGprArea(nextGprNo);
 				}
 				case FLOAT, STRUCT_ONE_FLOAT -> {
 					if (isRead) {
 						argument = getArgFromMemoryArea(layout, fpRegSaveArea, allocator, false);
 					}
-					/* Move to the next argument in the floating-point register area */
+					/* Move to the next argument in the floating-point register area. */
 					moveToNextArgOfFprArea(nextFprNo);
 				}
 				default -> throw new IllegalStateException("Unsupported TypeClass: " + typeClass);
@@ -293,7 +291,7 @@ public non-sealed class SysVS390xVaList implements VaList {
 		}
 	}
 
-	/* Obtain the argument value from the specified memory area of VaList */
+	/* Obtain the argument value from the specified memory area of VaList. */
 	private Object getArgFromMemoryArea(MemoryLayout layout, MemorySegment argAreaSegment, SegmentAllocator allocator, boolean isOverflowArea) {
 		TypeClass typeClass = TypeClass.classifyLayout(layout);
 		VarHandle argHandle = TypeClass.classifyVarHandle(layout);
@@ -382,18 +380,18 @@ public non-sealed class SysVS390xVaList implements VaList {
 
 	private void moveToNextArgOfGprArea(long nextGprNo) {
 		VH_GPR_NO.set(segment, nextGprNo);
-		/* Move to the next argument by 8 bytes in the general register area */
+		/* Move to the next argument by 8 bytes in the general register area. */
 		gpRegSaveArea = gpRegSaveArea.asSlice(VA_LIST_SLOT_BYTES);
 	}
 
 	private void moveToNextArgOfFprArea(long nextFprNo) {
 		VH_FPR_NO.set(segment, nextFprNo);
-		/* Move to the next argument by 8 bytes in the floating-point register area */
+		/* Move to the next argument by 8 bytes in the floating-point register area. */
 		fpRegSaveArea = fpRegSaveArea.asSlice(VA_LIST_SLOT_BYTES);
 	}
 
-	public static VaList ofAddress(long addr, SegmentScope session) {
-		MemorySegment segment = MemorySegment.ofAddress(addr, LAYOUT_VA_LIST.byteSize(), session);
+	public static VaList ofAddress(long address, SegmentScope session) {
+		MemorySegment segment = MemorySegment.ofAddress(address, LAYOUT_VA_LIST.byteSize(), session);
 		MemorySegment regSaveAreaOfVaList = MemorySegment.ofAddress(((MemorySegment)VH_REG_SAVE_AREA.get(segment)).address(),
 															LAYOUT_REG_SAVE_AREA.byteSize(), session);
 		MemorySegment overflowArgAreaOfVaList = MemorySegment.ofAddress(((MemorySegment)VH_OVERFLOW_ARG_AREA.get(segment)).address(),
@@ -545,7 +543,7 @@ public non-sealed class SysVS390xVaList implements VaList {
 					default -> throw new IllegalStateException("Unsupported TypeClass: " + typeClass);
 				}
 
-				/* Move to the next argument by 8 bytes */
+				/* Move to the next argument by 8 bytes. */
 				argAreaCursor = argAreaCursor.asSlice(VA_LIST_SLOT_BYTES);
 			}
 		}
@@ -571,7 +569,7 @@ public non-sealed class SysVS390xVaList implements VaList {
 			storeArgToMemoryArea(fprArgs, fpRegSaveArea, false);
 			storeArgToMemoryArea(overflowArgs, overflowArgArea, true);
 
-			/* Set va_list with all required information so as to ensure va_list is correctly accessed in native */
+			/* Set va_list with all required information so as to ensure va_list is correctly accessed in native. */
 			VH_GPR_NO.set(vaListSegment, 0);
 			VH_FPR_NO.set(vaListSegment, 0);
 			VH_OVERFLOW_ARG_AREA.set(vaListSegment, overflowArgArea.asSlice(0, 0));

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -128,15 +128,12 @@ public class CallArranger {
 
     /* Replace DowncallLinker in OpenJDK with the implementation of DowncallLinker specific to OpenJ9 */
     public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
-        // MethodHandle handle = DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
-        // return handle;
-        return null;
+        return DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
     }
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
-        // return UpcallLinker.make(target, mt, cDesc, session);
-        return null;
+        return UpcallLinker.make(target, mt, cDesc, session);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -128,15 +128,12 @@ public class CallArranger {
 
     /* Replace DowncallLinker in OpenJDK with the implementation of DowncallLinker specific to OpenJ9 */
     public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc, LinkerOptions options) {
-        // MethodHandle handle = DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
-        // return handle;
-        return null;
+        return DowncallLinker.getBoundMethodHandle(mt, cDesc, options);
     }
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, SegmentScope session) {
-        // return UpcallLinker.make(target, mt, cDesc, session);
-        return null;
+        return UpcallLinker.make(target, mt, cDesc, session);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -23,6 +23,13 @@
  *  questions.
  *
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.foreign.layout;
 
 import jdk.internal.foreign.Utils;
@@ -32,6 +39,7 @@ import jdk.internal.reflect.Reflection;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Stable;
 import sun.invoke.util.Wrapper;
+import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
@@ -64,6 +72,8 @@ public final class ValueLayouts {
     abstract sealed static class AbstractValueLayout<V extends AbstractValueLayout<V> & ValueLayout> extends AbstractLayout<V> {
 
         static final int ADDRESS_SIZE_BITS = Unsafe.ADDRESS_SIZE * 8;
+
+        static final boolean isAixOS = GetPropertyAction.privilegedGetProperty("os.name").equals("AIX");
 
         private final Class<?> carrier;
         private final ByteOrder order;
@@ -399,6 +409,10 @@ public final class ValueLayouts {
             return new OfDoubleImpl(order);
         }
 
+        @Override
+        public boolean hasNaturalAlignment() {
+            return isAixOS ? ((bitAlignment() % 32) == 0) : super.hasNaturalAlignment();
+        }
     }
 
     public static final class OfAddressImpl extends AbstractValueLayout<OfAddressImpl> implements ValueLayout.OfAddress {


### PR DESCRIPTION
The changes update part of our code in the FFI framework
against the latest APIs specified in JDKnext to accommodate
the new features of JEP434.

Note:
This is the part of implementation intended for
#eclipse-openj9/openj9/issues/16329

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
