### PR TITLE
Update harfbuzz to not use builtin, which doesn't exist, with AIX xlc

### DIFF
--- a/src/java.desktop/share/native/libharfbuzz/hb-algs.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-algs.hh
@@ -875,7 +875,7 @@ hb_in_ranges (T u, T lo1, T hi1, Ts... ds)
 static inline bool
 hb_unsigned_mul_overflows (unsigned int count, unsigned int size, unsigned *result = nullptr)
 {
-#if (defined(__GNUC__) && (__GNUC__ >= 4)) || (defined(__clang__) && (__clang_major__ >= 8))
+#if !defined(__ibmxl__) && ((defined(__GNUC__) && (__GNUC__ >= 4)) || (defined(__clang__) && (__clang_major__ >= 8)))
   unsigned stack_result;
   if (!result)
     result = &stack_result;


### PR DESCRIPTION
Update hb-algs.hh to avoid using __builtin_mul_overflow