### PR TITLE
PKCS#12 file-based keystore

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -400,4 +400,15 @@ public class NativeCrypto {
                                       int id,
                                       int hashAlgorithm);
 
+    public final native int PBES2Derive(byte[] password,
+                                      int passwordLength,
+                                      byte[] salt,
+                                      int saltLength,
+                                      int iterations,
+                                      int hashAlgorithm,
+                                      int keyLength,
+                                      byte[] key);
+
+    /* Native FIPS interfaces */
+    public final native int FIPSMode();
 }

--- a/closed/src/java.base/share/classes/openj9/internal/security/FIPSConfigurator.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/FIPSConfigurator.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,6 +111,7 @@ public final class FIPSConfigurator {
                 props.put("security.provider.2", "SUN");
                 props.put("security.provider.3", "SunEC");
                 props.put("security.provider.4", "SunJSSE");
+                props.put("security.provider.5", "SunJCE");
 
                 // Add FIPS security properties.
                 props.put("keystore.type", "PKCS11");

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -28,6 +28,7 @@
 #include <openssl/rsa.h>
 #include <openssl/ecdh.h>
 #include <openssl/pkcs12.h>
+#include <openssl/crypto.h>
 
 #include <ctype.h>
 #include <jni.h>
@@ -119,6 +120,9 @@ typedef BIGNUM* OSSL_BN_bin2bn_t (const unsigned char *, int, BIGNUM *);
 typedef void OSSL_BN_set_negative_t (BIGNUM *, int);
 typedef void OSSL_BN_free_t (BIGNUM *);
 
+typedef int OSSL_FIPS_mode_t(void);
+typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
+typedef int OSSL_EVP_default_properties_is_fips_enabled_t(OSSL_LIB_CTX *);
 typedef void OSSL_EC_KEY_free_t(EC_KEY *);
 typedef int OSSL_ECDH_compute_key_t(void *, size_t, const EC_POINT *, EC_KEY *, void *(*KDF)(const void *, size_t, void *, size_t *));
 typedef const EC_POINT* OSSL_EC_KEY_get0_public_key_t(const EC_KEY *);
@@ -142,6 +146,7 @@ typedef int OSSL_EC_KEY_check_key_t(const EC_KEY *);
 typedef int EC_set_public_key_t(EC_KEY *, BIGNUM *, BIGNUM *, int);
 
 typedef int OSSL_PKCS12_key_gen_t(const char *, int, unsigned char *, int, int, int, int, unsigned char *, const EVP_MD *);
+typedef int OSSL_PKCS5_PBKDF2_HMAC_t(const char *, int, const unsigned char *, int, int, const EVP_MD *, int, unsigned char *);
 
 typedef int OSSL_CRYPTO_num_locks_t();
 typedef void OSSL_CRYPTO_THREADID_set_numeric_t(CRYPTO_THREADID *id, unsigned long val);
@@ -157,6 +162,10 @@ static void win32_locking_callback(int mode, int type, const char *file, int lin
 static void pthreads_thread_id(CRYPTO_THREADID *tid);
 static void pthreads_locking_callback(int mode, int type, const char *file, int line);
 #endif /* defined(WINDOWS) */
+
+/* Define pointers for OpenSSL functions to check if FIPS module is enabled in OpenSSL. */
+OSSL_FIPS_mode_t* OSSL_FIPS_mode;
+OSSL_EVP_default_properties_is_fips_enabled_t* OSSL_EVP_default_properties_is_fips_enabled;
 
 /* Define pointers for OpenSSL functions to handle Errors. */
 OSSL_error_string_n_t* OSSL_error_string_n;
@@ -247,6 +256,9 @@ EC_set_public_key_t* EC_set_public_key;
 /* Define pointers for OpenSSL functions to handle PBE algorithm. */
 OSSL_PKCS12_key_gen_t* OSSL_PKCS12_key_gen;
 
+/* Define pointers for OpenSSL functions to handle PBES2 algorithm. */
+OSSL_PKCS5_PBKDF2_HMAC_t* OSSL_PKCS5_PBKDF2_HMAC;
+
 /* Structure for OpenSSL Digest context. */
 typedef struct OpenSSLMDContext {
     EVP_MD_CTX *ctx;
@@ -294,6 +306,7 @@ static jlong extractVersionToJlong(const char *astring)
 }
 
 static void *crypto_library = NULL;
+jlong ossl_ver = 0;
 /*
  * Class:     jdk_crypto_jniprovider_NativeCrypto
  * Method:    loadCrypto
@@ -308,7 +321,6 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
     /* Determine the version of OpenSSL. */
     OSSL_version_t* OSSL_version;
     const char * openssl_version;
-    jlong ossl_ver = 0;
 
     /* Load OpenSSL Crypto library */
     crypto_library = load_crypto_library(trace);
@@ -367,6 +379,41 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
             unload_crypto_library(crypto_library);
             crypto_library = NULL;
             return -1;
+        }
+    }
+
+    /* Load the FIPS_mode() function for OpenSSL 1.x version. */
+    OSSL_FIPS_mode = (OSSL_FIPS_mode_t*)find_crypto_symbol(crypto_library, "FIPS_mode");
+
+    if(ossl_ver < OPENSSL_VERSION_2_0_0) {
+        /* Check if OpenSSL is FIPS compliant. */
+        int fips_compatible_build = -1;
+
+        /*
+        * The return value is either 0 to indicate that the FIPS mode of operation is not enabled,
+        * or the value used for the ONOFF parameter passed to an earlier successful call to FIPS_mode_set().
+        */
+        if ((fips_compatible_build = (*OSSL_FIPS_mode)()) == 0) {
+            if (trace) {
+                fprintf(stderr, "The current version of OpenSSL 1.x is not FIPS-capable.\n");
+                fflush(stderr);
+            }
+        }
+    }
+
+    /* Load the EVP_default_properties_is_fips_enabled() function for OpenSSL 3.x version. */
+    OSSL_EVP_default_properties_is_fips_enabled = (OSSL_EVP_default_properties_is_fips_enabled_t*)find_crypto_symbol(crypto_library, "EVP_default_properties_is_fips_enabled");
+
+    if(ossl_ver >= OPENSSL_VERSION_3_0_0) {
+        /*
+        * EVP_default_properties_is_fips_enabled() returns 1 if the 'fips=yes' default property is set for the given libctx.
+        * Otherwise it returns 0.
+        */
+        if ((*OSSL_EVP_default_properties_is_fips_enabled)(NULL) == 0) {
+            if (trace) {
+                fprintf(stderr, "The current version of OpenSSL 3.x is not FIPS-capable.\n");
+                fflush(stderr);
+            }
         }
     }
 
@@ -496,6 +543,9 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
     /* Load the functions symbols for OpenSSL PBE algorithm. */
     OSSL_PKCS12_key_gen = (OSSL_PKCS12_key_gen_t*)find_crypto_symbol(crypto_library, "PKCS12_key_gen_uni");
 
+    /* Load the functions symbols for OpenSSL PBES2 algorithm. */
+    OSSL_PKCS5_PBKDF2_HMAC = (OSSL_PKCS5_PBKDF2_HMAC_t*)find_crypto_symbol(crypto_library, "PKCS5_PBKDF2_HMAC");
+
     if ((NULL == OSSL_error_string) ||
         (NULL == OSSL_error_string_n) ||
         (NULL == OSSL_get_error) ||
@@ -555,6 +605,7 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         (NULL == OSSL_EC_KEY_set_public_key) ||
         (NULL == OSSL_EC_KEY_check_key) ||
         (NULL == OSSL_PKCS12_key_gen) ||
+        (NULL == OSSL_PKCS5_PBKDF2_HMAC) ||
         /* Check symbols that are only available in OpenSSL 1.1.x and above */
         ((ossl_ver >= OPENSSL_VERSION_1_1_0) && ((NULL == OSSL_chacha20) || (NULL == OSSL_chacha20_poly1305))) ||
         /* Check symbols that are only available in OpenSSL 1.0.x and above */
@@ -2987,4 +3038,90 @@ cleanup:
     }
 
     return ret;
+}
+
+/* Password-Based Encryption Standard v2.0
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    PBES2Derive
+ * Signature: (J[BI[BI[BIIII)I
+ */
+JNIEXPORT jint JNICALL
+Java_jdk_crypto_jniprovider_NativeCrypto_PBES2Derive
+    (JNIEnv *env, jclass obj, jbyteArray password, jint passwordLength, jbyteArray salt, jint saltLength, jint iterations, jint hashAlgorithm, jint keyLength, jbyteArray key)
+{
+    const EVP_MD *digestAlgorithm = NULL;
+    char *nativePassword = NULL;
+    unsigned char *nativeSalt = NULL;
+    unsigned char *nativeKey = NULL;
+    jint ret = -1;
+
+    switch (hashAlgorithm) {
+        case jdk_crypto_jniprovider_NativeCrypto_SHA1_160:
+            digestAlgorithm = (*OSSL_sha1)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA2_224:
+            digestAlgorithm = (*OSSL_sha224)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA2_256:
+            digestAlgorithm = (*OSSL_sha256)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA5_384:
+            digestAlgorithm = (*OSSL_sha384)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA5_512:
+            digestAlgorithm = (*OSSL_sha512)();
+            break;
+        default:
+            goto cleanup;
+    }
+
+    nativePassword = (char*)((*env)->GetPrimitiveArrayCritical(env, password, 0));
+    if (NULL == nativePassword) {
+        goto cleanup;
+    }
+    nativeSalt = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, salt, 0));
+    if (NULL == nativeSalt) {
+        goto cleanup;
+    }
+    nativeKey = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, key, 0));
+    if (NULL == nativeKey) {
+        goto cleanup;
+    }
+
+    if (1 == (*OSSL_PKCS5_PBKDF2_HMAC)(nativePassword, passwordLength, nativeSalt, saltLength, iterations, digestAlgorithm, keyLength, nativeKey)) {
+        ret = 0;
+    }
+
+cleanup:
+    if (NULL != nativePassword) {
+        (*env)->ReleasePrimitiveArrayCritical(env, password, nativePassword, JNI_ABORT);
+    }
+    if (NULL != nativeSalt) {
+        (*env)->ReleasePrimitiveArrayCritical(env, salt, nativeSalt, JNI_ABORT);
+    }
+    if (NULL != nativeKey) {
+        (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, JNI_ABORT);
+    }
+
+    return ret;
+}
+
+/* Check if the FIPS mode is enabled in OpenSSL.
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    FIPSMode
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL
+Java_jdk_crypto_jniprovider_NativeCrypto_FIPSMode
+  (JNIEnv *env, jclass obj)
+{
+    if(ossl_ver >= OPENSSL_VERSION_3_0_0) {
+        return (*OSSL_EVP_default_properties_is_fips_enabled)(NULL);
+    } else if(ossl_ver >= OPENSSL_VERSION_1_0_0) {
+        return (*OSSL_FIPS_mode)();
+    } else {
+        return 0;
+    }
 }

--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -43,6 +43,8 @@ import jdk.crypto.jniprovider.NativeCrypto;
 import jdk.internal.util.StaticProperty;
 import sun.security.action.GetPropertyAction;
 
+import openj9.internal.security.FIPSConfigurator;
+
 /**
  * The "SunJCE" Cryptographic Service Provider.
  *
@@ -160,658 +162,802 @@ public final class SunJCE extends Provider {
     }
 
     void putEntries() {
-        // reuse attribute map and reset before each reuse
-        HashMap<String, String> attrs = new HashMap<>(3);
-        attrs.put("SupportedModes", "ECB");
-        attrs.put("SupportedPaddings", "NOPADDING|PKCS1PADDING|OAEPPADDING"
-                + "|OAEPWITHMD5ANDMGF1PADDING"
-                + "|OAEPWITHSHA1ANDMGF1PADDING"
-                + "|OAEPWITHSHA-1ANDMGF1PADDING"
-                + "|OAEPWITHSHA-224ANDMGF1PADDING"
-                + "|OAEPWITHSHA-256ANDMGF1PADDING"
-                + "|OAEPWITHSHA-384ANDMGF1PADDING"
-                + "|OAEPWITHSHA-512ANDMGF1PADDING"
-                + "|OAEPWITHSHA-512/224ANDMGF1PADDING"
-                + "|OAEPWITHSHA-512/256ANDMGF1PADDING");
-        attrs.put("SupportedKeyClasses",
-                "java.security.interfaces.RSAPublicKey" +
-                "|java.security.interfaces.RSAPrivateKey");
-        ps("Cipher", "RSA",
-                "com.sun.crypto.provider.RSACipher", null, attrs);
-
-        // common block cipher modes, pads
-        final String BLOCK_MODES = "ECB|CBC|PCBC|CTR|CTS|CFB|OFB" +
-            "|CFB8|CFB16|CFB24|CFB32|CFB40|CFB48|CFB56|CFB64" +
-            "|OFB8|OFB16|OFB24|OFB32|OFB40|OFB48|OFB56|OFB64";
-        final String BLOCK_MODES128 = BLOCK_MODES +
-            "|CFB72|CFB80|CFB88|CFB96|CFB104|CFB112|CFB120|CFB128" +
-            "|OFB72|OFB80|OFB88|OFB96|OFB104|OFB112|OFB120|OFB128";
-        final String BLOCK_PADS = "NOPADDING|PKCS5PADDING|ISO10126PADDING";
-
-        attrs.clear();
-        attrs.put("SupportedModes", BLOCK_MODES);
-        attrs.put("SupportedPaddings", BLOCK_PADS);
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Cipher", "DES",
-                "com.sun.crypto.provider.DESCipher", null, attrs);
-        psA("Cipher", "DESede", "com.sun.crypto.provider.DESedeCipher",
-                attrs);
-        ps("Cipher", "Blowfish",
-                "com.sun.crypto.provider.BlowfishCipher", null, attrs);
-
-        ps("Cipher", "RC2",
-                "com.sun.crypto.provider.RC2Cipher", null, attrs);
-
-        attrs.clear();
-        attrs.put("SupportedModes", BLOCK_MODES128);
-        attrs.put("SupportedPaddings", BLOCK_PADS);
-        attrs.put("SupportedKeyFormats", "RAW");
-        psA("Cipher", "AES",
-                "com.sun.crypto.provider.AESCipher$General", attrs);
-
-        attrs.clear();
-        attrs.put("SupportedKeyFormats", "RAW");
-        psA("Cipher", "AES/KW/NoPadding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES_KW_NoPadding",
-                attrs);
-        ps("Cipher", "AES/KW/PKCS5Padding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES_KW_PKCS5Padding",
-                null, attrs);
-        psA("Cipher", "AES/KWP/NoPadding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES_KWP_NoPadding",
-                attrs);
-
-        psA("Cipher", "AES_128/ECB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_ECB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_128/CBC/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_CBC_NoPadding",
-                attrs);
-        psA("Cipher", "AES_128/OFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_OFB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_128/CFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES128_CFB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_128/KW/NoPadding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES128_KW_NoPadding",
-                attrs);
-        ps("Cipher", "AES_128/KW/PKCS5Padding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES128_KW_PKCS5Padding",
-                null, attrs);
-        psA("Cipher", "AES_128/KWP/NoPadding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES128_KWP_NoPadding",
-                attrs);
-
-        psA("Cipher", "AES_192/ECB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_ECB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_192/CBC/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_CBC_NoPadding",
-                attrs);
-        psA("Cipher", "AES_192/OFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_OFB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_192/CFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES192_CFB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_192/KW/NoPadding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES192_KW_NoPadding",
-                attrs);
-        ps("Cipher", "AES_192/KW/PKCS5Padding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES192_KW_PKCS5Padding",
-                null, attrs);
-        psA("Cipher", "AES_192/KWP/NoPadding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES192_KWP_NoPadding",
-                attrs);
-
-        psA("Cipher", "AES_256/ECB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_ECB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_256/CBC/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_CBC_NoPadding",
-                attrs);
-        psA("Cipher", "AES_256/OFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_OFB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_256/CFB/NoPadding",
-                "com.sun.crypto.provider.AESCipher$AES256_CFB_NoPadding",
-                attrs);
-        psA("Cipher", "AES_256/KW/NoPadding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES256_KW_NoPadding",
-                attrs);
-        ps("Cipher", "AES_256/KW/PKCS5Padding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES256_KW_PKCS5Padding",
-                null, attrs);
-        psA("Cipher", "AES_256/KWP/NoPadding",
-                "com.sun.crypto.provider.KeyWrapCipher$AES256_KWP_NoPadding",
-                attrs);
-
-        attrs.clear();
-        attrs.put("SupportedModes", "GCM");
-        attrs.put("SupportedKeyFormats", "RAW");
-
-        if (useNativeGaloisCounterMode && NativeCrypto.isAllowedAndLoaded()) {
-            ps("Cipher", "AES/GCM/NoPadding",
-                    "com.sun.crypto.provider.NativeGaloisCounterMode$AESGCM", null,
-                    attrs);
-            psA("Cipher", "AES_128/GCM/NoPadding",
-                    "com.sun.crypto.provider.NativeGaloisCounterMode$AES128",
-                    attrs);
-            psA("Cipher", "AES_192/GCM/NoPadding",
-                    "com.sun.crypto.provider.NativeGaloisCounterMode$AES192",
-                    attrs);
-            psA("Cipher", "AES_256/GCM/NoPadding",
-                    "com.sun.crypto.provider.NativeGaloisCounterMode$AES256",
-                    attrs);
-        } else {
-            ps("Cipher", "AES/GCM/NoPadding",
-                    "com.sun.crypto.provider.GaloisCounterMode$AESGCM", null,
-                    attrs);
-            psA("Cipher", "AES_128/GCM/NoPadding",
-                    "com.sun.crypto.provider.GaloisCounterMode$AES128",
-                    attrs);
-            psA("Cipher", "AES_192/GCM/NoPadding",
-                    "com.sun.crypto.provider.GaloisCounterMode$AES192",
-                    attrs);
-            psA("Cipher", "AES_256/GCM/NoPadding",
-                    "com.sun.crypto.provider.GaloisCounterMode$AES256",
-                    attrs);
-        }
-
-        attrs.clear();
-        attrs.put("SupportedModes", "CBC");
-        attrs.put("SupportedPaddings", "NOPADDING");
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Cipher", "DESedeWrap",
-                "com.sun.crypto.provider.DESedeWrapCipher", null, attrs);
-
-        attrs.clear();
-        attrs.put("SupportedModes", "ECB");
-        attrs.put("SupportedPaddings", "NOPADDING");
-        attrs.put("SupportedKeyFormats", "RAW");
-        psA("Cipher", "ARCFOUR",
-                "com.sun.crypto.provider.ARCFOURCipher", attrs);
-
-        attrs.clear();
-        attrs.put("SupportedKeyFormats", "RAW");
-
-        if (useNativeChaCha20Cipher && (NativeCrypto.getVersionIfAvailable() >= NativeCrypto.OPENSSL_VERSION_1_1_0)) {
-            ps("Cipher", "ChaCha20",
-                    "com.sun.crypto.provider.NativeChaCha20Cipher$ChaCha20Only",
-                    null, attrs);
-            psA("Cipher", "ChaCha20-Poly1305",
-                    "com.sun.crypto.provider.NativeChaCha20Cipher$ChaCha20Poly1305",
-                    attrs);
-        } else {
-            ps("Cipher",  "ChaCha20",
-                    "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Only",
-                    null, attrs);
-            psA("Cipher",  "ChaCha20-Poly1305",
-                    "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
-                    attrs);
-        }
-
-        // PBES1
-        psA("Cipher", "PBEWithMD5AndDES",
-                "com.sun.crypto.provider.PBEWithMD5AndDESCipher",
-                null);
-        ps("Cipher", "PBEWithMD5AndTripleDES",
-                "com.sun.crypto.provider.PBEWithMD5AndTripleDESCipher");
-        psA("Cipher", "PBEWithSHA1AndDESede",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndDESede",
-                null);
-        psA("Cipher", "PBEWithSHA1AndRC2_40",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC2_40",
-                null);
-        psA("Cipher", "PBEWithSHA1AndRC2_128",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC2_128",
-                null);
-        psA("Cipher", "PBEWithSHA1AndRC4_40",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC4_40",
-                null);
-
-        psA("Cipher", "PBEWithSHA1AndRC4_128",
-                "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC4_128",
-                null);
-
-        // PBES2
-        ps("Cipher", "PBEWithHmacSHA1AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_128");
-
-        ps("Cipher", "PBEWithHmacSHA224AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_128");
-
-        ps("Cipher", "PBEWithHmacSHA256AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_128");
-
-        ps("Cipher", "PBEWithHmacSHA384AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_128");
-
-        ps("Cipher", "PBEWithHmacSHA512AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_128");
-
-        ps("Cipher", "PBEWithHmacSHA512/224AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA512_224AndAES_128");
-
-        ps("Cipher", "PBEWithHmacSHA512/256AndAES_128",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA512_256AndAES_128");
-
-
-        ps("Cipher", "PBEWithHmacSHA1AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_256");
-
-        ps("Cipher", "PBEWithHmacSHA224AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_256");
-
-        ps("Cipher", "PBEWithHmacSHA256AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_256");
-
-        ps("Cipher", "PBEWithHmacSHA384AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_256");
-
-        ps("Cipher", "PBEWithHmacSHA512AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_256");
-
-        ps("Cipher", "PBEWithHmacSHA512/224AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA512_224AndAES_256");
-
-        ps("Cipher", "PBEWithHmacSHA512/256AndAES_256",
-                "com.sun.crypto.provider.PBES2Core$HmacSHA512_256AndAES_256");
-
-        /*
-         * Key(pair) Generator engines
-         */
-        ps("KeyGenerator", "DES",
-                "com.sun.crypto.provider.DESKeyGenerator");
-        psA("KeyGenerator", "DESede",
-                "com.sun.crypto.provider.DESedeKeyGenerator",
-                null);
-        ps("KeyGenerator", "Blowfish",
-                "com.sun.crypto.provider.BlowfishKeyGenerator");
-        psA("KeyGenerator", "AES",
-                "com.sun.crypto.provider.AESKeyGenerator",
-                null);
-        ps("KeyGenerator", "RC2",
-                "com.sun.crypto.provider.KeyGeneratorCore$RC2KeyGenerator");
-        psA("KeyGenerator", "ARCFOUR",
-                "com.sun.crypto.provider.KeyGeneratorCore$ARCFOURKeyGenerator",
-                null);
-        ps("KeyGenerator", "ChaCha20",
-                "com.sun.crypto.provider.KeyGeneratorCore$ChaCha20KeyGenerator");
-        ps("KeyGenerator", "HmacMD5",
-                "com.sun.crypto.provider.HmacMD5KeyGenerator");
-
-        psA("KeyGenerator", "HmacSHA1",
-                "com.sun.crypto.provider.HmacSHA1KeyGenerator", null);
-        psA("KeyGenerator", "HmacSHA224",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA224",
-                null);
-        psA("KeyGenerator", "HmacSHA256",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA256",
-                null);
-        psA("KeyGenerator", "HmacSHA384",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA384",
-                null);
-        psA("KeyGenerator", "HmacSHA512",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512",
-                null);
-        psA("KeyGenerator", "HmacSHA512/224",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512_224",
-                null);
-        psA("KeyGenerator", "HmacSHA512/256",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512_256",
-                null);
-
-        psA("KeyGenerator", "HmacSHA3-224",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA3_224",
-                null);
-        psA("KeyGenerator", "HmacSHA3-256",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA3_256",
-                null);
-        psA("KeyGenerator", "HmacSHA3-384",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA3_384",
-                null);
-        psA("KeyGenerator", "HmacSHA3-512",
-                "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA3_512",
-                null);
-
-        psA("KeyPairGenerator", "DiffieHellman",
-                "com.sun.crypto.provider.DHKeyPairGenerator",
-                null);
-
-        /*
-         * Algorithm parameter generation engines
-         */
-        psA("AlgorithmParameterGenerator",
-                "DiffieHellman", "com.sun.crypto.provider.DHParameterGenerator",
-                null);
-
-        /*
-         * Key Agreement engines
-         */
-        attrs.clear();
-        attrs.put("SupportedKeyClasses", "javax.crypto.interfaces.DHPublicKey" +
-                        "|javax.crypto.interfaces.DHPrivateKey");
-        psA("KeyAgreement", "DiffieHellman",
-                "com.sun.crypto.provider.DHKeyAgreement",
-                attrs);
-
-        /*
-         * Algorithm Parameter engines
-         */
-        psA("AlgorithmParameters", "DiffieHellman",
-                "com.sun.crypto.provider.DHParameters", null);
-
-        ps("AlgorithmParameters", "DES",
-                "com.sun.crypto.provider.DESParameters");
-
-        psA("AlgorithmParameters", "DESede",
-                "com.sun.crypto.provider.DESedeParameters", null);
-
-        psA("AlgorithmParameters", "PBEWithMD5AndDES",
-                "com.sun.crypto.provider.PBEParameters",
-                null);
-
-        ps("AlgorithmParameters", "PBEWithMD5AndTripleDES",
-                "com.sun.crypto.provider.PBEParameters");
-
-        psA("AlgorithmParameters", "PBEWithSHA1AndDESede",
-                "com.sun.crypto.provider.PBEParameters",
-                null);
-
-        psA("AlgorithmParameters", "PBEWithSHA1AndRC2_40",
-                "com.sun.crypto.provider.PBEParameters",
-                null);
-
-        psA("AlgorithmParameters", "PBEWithSHA1AndRC2_128",
-                "com.sun.crypto.provider.PBEParameters",
-                null);
-
-        psA("AlgorithmParameters", "PBEWithSHA1AndRC4_40",
-                "com.sun.crypto.provider.PBEParameters",
-                null);
-
-        psA("AlgorithmParameters", "PBEWithSHA1AndRC4_128",
-                "com.sun.crypto.provider.PBEParameters",
-                null);
-
-        psA("AlgorithmParameters", "PBES2",
-                "com.sun.crypto.provider.PBES2Parameters$General",
-                null);
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA1AndAES_128",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA1AndAES_128");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA224AndAES_128",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA224AndAES_128");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA256AndAES_128",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA256AndAES_128");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA384AndAES_128",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA384AndAES_128");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA512AndAES_128",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA512AndAES_128");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA512/224AndAES_128",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA512_224AndAES_128");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA512/256AndAES_128",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA512_256AndAES_128");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA1AndAES_256",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA1AndAES_256");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA224AndAES_256",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA224AndAES_256");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA256AndAES_256",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA256AndAES_256");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA384AndAES_256",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA384AndAES_256");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA512AndAES_256",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA512AndAES_256");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA512/224AndAES_256",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA512_224AndAES_256");
-
-        ps("AlgorithmParameters", "PBEWithHmacSHA512/256AndAES_256",
-                "com.sun.crypto.provider.PBES2Parameters$HmacSHA512_256AndAES_256");
-
-        ps("AlgorithmParameters", "Blowfish",
-                "com.sun.crypto.provider.BlowfishParameters");
-
-        psA("AlgorithmParameters", "AES",
-                "com.sun.crypto.provider.AESParameters", null);
-
-        ps("AlgorithmParameters", "GCM",
-                "com.sun.crypto.provider.GCMParameters");
-
-        ps("AlgorithmParameters", "RC2",
-                "com.sun.crypto.provider.RC2Parameters");
-
-        psA("AlgorithmParameters", "OAEP",
-                "com.sun.crypto.provider.OAEPParameters", null);
-
-        psA("AlgorithmParameters", "ChaCha20-Poly1305",
-                "com.sun.crypto.provider.ChaCha20Poly1305Parameters", null);
-
-        /*
-         * Key factories
-         */
-        psA("KeyFactory", "DiffieHellman",
-                "com.sun.crypto.provider.DHKeyFactory",
-                null);
-
-        /*
-         * Secret-key factories
-         */
-        ps("SecretKeyFactory", "DES",
-                "com.sun.crypto.provider.DESKeyFactory");
-
-        psA("SecretKeyFactory", "DESede",
-                "com.sun.crypto.provider.DESedeKeyFactory", null);
-
-        psA("SecretKeyFactory", "PBEWithMD5AndDES",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndDES",
-                null);
-
-        /*
-         * Internal in-house crypto algorithm used for
-         * the JCEKS keystore type.  Since this was developed
-         * internally, there isn't an OID corresponding to this
-         * algorithm.
-         */
-        ps("SecretKeyFactory", "PBEWithMD5AndTripleDES",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndTripleDES");
-
-        psA("SecretKeyFactory", "PBEWithSHA1AndDESede",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndDESede",
-                null);
-
-        psA("SecretKeyFactory", "PBEWithSHA1AndRC2_40",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_40",
-                null);
-
-        psA("SecretKeyFactory", "PBEWithSHA1AndRC2_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_128",
-                null);
-
-        psA("SecretKeyFactory", "PBEWithSHA1AndRC4_40",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_40",
-                null);
-
-        psA("SecretKeyFactory", "PBEWithSHA1AndRC4_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_128",
-                null);
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_128");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_128");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_128");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_128");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_128");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA512/224AndAES_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_224AndAES_128");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA512/256AndAES_128",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_256AndAES_128");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_256",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_256");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_256",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_256");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_256",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_256");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_256",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_256");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_256",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_256");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA512/224AndAES_256",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_224AndAES_256");
-
-        ps("SecretKeyFactory", "PBEWithHmacSHA512/256AndAES_256",
-                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_256AndAES_256");
-
-        // PBKDF2
-        psA("SecretKeyFactory", "PBKDF2WithHmacSHA1",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",
-                null);
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA224",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA224");
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA256",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA256");
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA384",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA384");
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA512",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA512");
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA512/224",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA512_224");
-        ps("SecretKeyFactory", "PBKDF2WithHmacSHA512/256",
-                "com.sun.crypto.provider.PBKDF2Core$HmacSHA512_256");
-
-        /*
-         * MAC
-         */
-        attrs.clear();
-        attrs.put("SupportedKeyFormats", "RAW");
-        ps("Mac", "HmacMD5", "com.sun.crypto.provider.HmacMD5", null, attrs);
-        psA("Mac", "HmacSHA1", "com.sun.crypto.provider.HmacSHA1",
-                attrs);
-        psA("Mac", "HmacSHA224",
-                "com.sun.crypto.provider.HmacCore$HmacSHA224", attrs);
-        psA("Mac", "HmacSHA256",
-                "com.sun.crypto.provider.HmacCore$HmacSHA256", attrs);
-        psA("Mac", "HmacSHA384",
-                "com.sun.crypto.provider.HmacCore$HmacSHA384", attrs);
-        psA("Mac", "HmacSHA512",
-                "com.sun.crypto.provider.HmacCore$HmacSHA512", attrs);
-        psA("Mac", "HmacSHA512/224",
-                "com.sun.crypto.provider.HmacCore$HmacSHA512_224", attrs);
-        psA("Mac", "HmacSHA512/256",
-                "com.sun.crypto.provider.HmacCore$HmacSHA512_256", attrs);
-        psA("Mac", "HmacSHA3-224",
-                "com.sun.crypto.provider.HmacCore$HmacSHA3_224", attrs);
-        psA("Mac", "HmacSHA3-256",
-                "com.sun.crypto.provider.HmacCore$HmacSHA3_256", attrs);
-        psA("Mac", "HmacSHA3-384",
-                "com.sun.crypto.provider.HmacCore$HmacSHA3_384", attrs);
-        psA("Mac", "HmacSHA3-512",
-                "com.sun.crypto.provider.HmacCore$HmacSHA3_512", attrs);
-
-        ps("Mac", "HmacPBESHA1",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA1",
-                null, attrs);
-        ps("Mac", "HmacPBESHA224",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA224",
-                null, attrs);
-        ps("Mac", "HmacPBESHA256",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA256",
-                null, attrs);
-        ps("Mac", "HmacPBESHA384",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA384",
-                null, attrs);
-        ps("Mac", "HmacPBESHA512",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512",
-                null, attrs);
-        ps("Mac", "HmacPBESHA512/224",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512_224",
-                null, attrs);
-        ps("Mac", "HmacPBESHA512/256",
-                "com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512_256",
-                null, attrs);
-
-
-        // PBMAC1
-        ps("Mac", "PBEWithHmacSHA1",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA1", null, attrs);
-        ps("Mac", "PBEWithHmacSHA224",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA224", null, attrs);
-        ps("Mac", "PBEWithHmacSHA256",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA256", null, attrs);
-        ps("Mac", "PBEWithHmacSHA384",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA384", null, attrs);
-        ps("Mac", "PBEWithHmacSHA512",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA512", null, attrs);
-        ps("Mac", "PBEWithHmacSHA512/224",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA512_224", null, attrs);
-        ps("Mac", "PBEWithHmacSHA512/256",
-                "com.sun.crypto.provider.PBMAC1Core$HmacSHA512_256", null, attrs);
-
-        ps("Mac", "SslMacMD5",
-                "com.sun.crypto.provider.SslMacCore$SslMacMD5", null, attrs);
-        ps("Mac", "SslMacSHA1",
-                "com.sun.crypto.provider.SslMacCore$SslMacSHA1", null, attrs);
-
-        /*
-         * KeyStore
-         */
-        ps("KeyStore", "JCEKS",
-                "com.sun.crypto.provider.JceKeyStore");
-
-        /*
-         * SSL/TLS mechanisms
-         *
-         * These are strictly internal implementations and may
-         * be changed at any time.  These names were chosen
-         * because PKCS11/SunPKCS11 does not yet have TLS1.2
-         * mechanisms, and it will cause calls to come here.
-         */
-        ps("KeyGenerator", "SunTlsPrf",
-                "com.sun.crypto.provider.TlsPrfGenerator$V10");
-        ps("KeyGenerator", "SunTls12Prf",
-                "com.sun.crypto.provider.TlsPrfGenerator$V12");
-
-        ps("KeyGenerator", "SunTlsMasterSecret",
-                "com.sun.crypto.provider.TlsMasterSecretGenerator",
-                List.of("SunTls12MasterSecret", "SunTlsExtendedMasterSecret"),
-                null);
-
-        ps("KeyGenerator", "SunTlsKeyMaterial",
-                "com.sun.crypto.provider.TlsKeyMaterialGenerator",
-                List.of("SunTls12KeyMaterial"), null);
-
-        ps("KeyGenerator", "SunTlsRsaPremasterSecret",
-                "com.sun.crypto.provider.TlsRsaPremasterSecretGenerator",
-                List.of("SunTls12RsaPremasterSecret"), null);
+		if (FIPSConfigurator.enableFIPS()) {
+			// PBES2
+			ps("Cipher", "PBEWithHmacSHA1AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA224AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA256AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA384AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA512AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA512/224AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512_224AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA512/256AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512_256AndAES_128");
+
+
+			ps("Cipher", "PBEWithHmacSHA1AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA224AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA256AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA384AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA512AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA512/224AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512_224AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA512/256AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512_256AndAES_256");
+
+					psA("AlgorithmParameters", "PBES2",
+					"com.sun.crypto.provider.PBES2Parameters$General",
+					null);
+
+			/*
+			* Algorithm Parameter engines
+			*/
+			ps("AlgorithmParameters", "PBEWithHmacSHA1AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA1AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA224AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA224AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA256AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA256AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA384AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA384AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512/224AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512_224AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512/256AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512_256AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA1AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA1AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA224AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA224AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA256AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA256AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA384AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA384AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512/224AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512_224AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512/256AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512_256AndAES_256");
+
+					ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_128");
+
+			/*
+			* Secret-key factories
+			*/
+			psA("SecretKeyFactory", "PBEWithMD5AndDES",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndDES",
+					null);
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512/224AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_224AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512/256AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_256AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512/224AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_224AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512/256AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_256AndAES_256");
+		} else {
+			// reuse attribute map and reset before each reuse
+			HashMap<String, String> attrs = new HashMap<>(3);
+			attrs.put("SupportedModes", "ECB");
+			attrs.put("SupportedPaddings", "NOPADDING|PKCS1PADDING|OAEPPADDING"
+					+ "|OAEPWITHMD5ANDMGF1PADDING"
+					+ "|OAEPWITHSHA1ANDMGF1PADDING"
+					+ "|OAEPWITHSHA-1ANDMGF1PADDING"
+					+ "|OAEPWITHSHA-224ANDMGF1PADDING"
+					+ "|OAEPWITHSHA-256ANDMGF1PADDING"
+					+ "|OAEPWITHSHA-384ANDMGF1PADDING"
+					+ "|OAEPWITHSHA-512ANDMGF1PADDING"
+					+ "|OAEPWITHSHA-512/224ANDMGF1PADDING"
+					+ "|OAEPWITHSHA-512/256ANDMGF1PADDING");
+			attrs.put("SupportedKeyClasses",
+					"java.security.interfaces.RSAPublicKey" +
+					"|java.security.interfaces.RSAPrivateKey");
+			ps("Cipher", "RSA",
+					"com.sun.crypto.provider.RSACipher", null, attrs);
+
+			// common block cipher modes, pads
+			final String BLOCK_MODES = "ECB|CBC|PCBC|CTR|CTS|CFB|OFB" +
+				"|CFB8|CFB16|CFB24|CFB32|CFB40|CFB48|CFB56|CFB64" +
+				"|OFB8|OFB16|OFB24|OFB32|OFB40|OFB48|OFB56|OFB64";
+			final String BLOCK_MODES128 = BLOCK_MODES +
+				"|CFB72|CFB80|CFB88|CFB96|CFB104|CFB112|CFB120|CFB128" +
+				"|OFB72|OFB80|OFB88|OFB96|OFB104|OFB112|OFB120|OFB128";
+			final String BLOCK_PADS = "NOPADDING|PKCS5PADDING|ISO10126PADDING";
+
+			attrs.clear();
+			attrs.put("SupportedModes", BLOCK_MODES);
+			attrs.put("SupportedPaddings", BLOCK_PADS);
+			attrs.put("SupportedKeyFormats", "RAW");
+			ps("Cipher", "DES",
+					"com.sun.crypto.provider.DESCipher", null, attrs);
+			psA("Cipher", "DESede", "com.sun.crypto.provider.DESedeCipher",
+					attrs);
+			ps("Cipher", "Blowfish",
+					"com.sun.crypto.provider.BlowfishCipher", null, attrs);
+
+			ps("Cipher", "RC2",
+					"com.sun.crypto.provider.RC2Cipher", null, attrs);
+
+			attrs.clear();
+			attrs.put("SupportedModes", BLOCK_MODES128);
+			attrs.put("SupportedPaddings", BLOCK_PADS);
+			attrs.put("SupportedKeyFormats", "RAW");
+			psA("Cipher", "AES",
+					"com.sun.crypto.provider.AESCipher$General", attrs);
+
+			attrs.clear();
+			attrs.put("SupportedKeyFormats", "RAW");
+			psA("Cipher", "AES/KW/NoPadding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES_KW_NoPadding",
+					attrs);
+			ps("Cipher", "AES/KW/PKCS5Padding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES_KW_PKCS5Padding",
+					null, attrs);
+			psA("Cipher", "AES/KWP/NoPadding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES_KWP_NoPadding",
+					attrs);
+
+			psA("Cipher", "AES_128/ECB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES128_ECB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_128/CBC/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES128_CBC_NoPadding",
+					attrs);
+			psA("Cipher", "AES_128/OFB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES128_OFB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_128/CFB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES128_CFB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_128/KW/NoPadding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES128_KW_NoPadding",
+					attrs);
+			ps("Cipher", "AES_128/KW/PKCS5Padding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES128_KW_PKCS5Padding",
+					null, attrs);
+			psA("Cipher", "AES_128/KWP/NoPadding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES128_KWP_NoPadding",
+					attrs);
+
+			psA("Cipher", "AES_192/ECB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES192_ECB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_192/CBC/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES192_CBC_NoPadding",
+					attrs);
+			psA("Cipher", "AES_192/OFB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES192_OFB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_192/CFB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES192_CFB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_192/KW/NoPadding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES192_KW_NoPadding",
+					attrs);
+			ps("Cipher", "AES_192/KW/PKCS5Padding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES192_KW_PKCS5Padding",
+					null, attrs);
+			psA("Cipher", "AES_192/KWP/NoPadding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES192_KWP_NoPadding",
+					attrs);
+
+			psA("Cipher", "AES_256/ECB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES256_ECB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_256/CBC/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES256_CBC_NoPadding",
+					attrs);
+			psA("Cipher", "AES_256/OFB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES256_OFB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_256/CFB/NoPadding",
+					"com.sun.crypto.provider.AESCipher$AES256_CFB_NoPadding",
+					attrs);
+			psA("Cipher", "AES_256/KW/NoPadding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES256_KW_NoPadding",
+					attrs);
+			ps("Cipher", "AES_256/KW/PKCS5Padding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES256_KW_PKCS5Padding",
+					null, attrs);
+			psA("Cipher", "AES_256/KWP/NoPadding",
+					"com.sun.crypto.provider.KeyWrapCipher$AES256_KWP_NoPadding",
+					attrs);
+
+			attrs.clear();
+			attrs.put("SupportedModes", "GCM");
+			attrs.put("SupportedKeyFormats", "RAW");
+
+			if (useNativeGaloisCounterMode && NativeCrypto.isAllowedAndLoaded()) {
+				ps("Cipher", "AES/GCM/NoPadding",
+						"com.sun.crypto.provider.NativeGaloisCounterMode$AESGCM", null,
+						attrs);
+				psA("Cipher", "AES_128/GCM/NoPadding",
+						"com.sun.crypto.provider.NativeGaloisCounterMode$AES128",
+						attrs);
+				psA("Cipher", "AES_192/GCM/NoPadding",
+						"com.sun.crypto.provider.NativeGaloisCounterMode$AES192",
+						attrs);
+				psA("Cipher", "AES_256/GCM/NoPadding",
+						"com.sun.crypto.provider.NativeGaloisCounterMode$AES256",
+						attrs);
+			} else {
+				ps("Cipher", "AES/GCM/NoPadding",
+						"com.sun.crypto.provider.GaloisCounterMode$AESGCM", null,
+						attrs);
+				psA("Cipher", "AES_128/GCM/NoPadding",
+						"com.sun.crypto.provider.GaloisCounterMode$AES128",
+						attrs);
+				psA("Cipher", "AES_192/GCM/NoPadding",
+						"com.sun.crypto.provider.GaloisCounterMode$AES192",
+						attrs);
+				psA("Cipher", "AES_256/GCM/NoPadding",
+						"com.sun.crypto.provider.GaloisCounterMode$AES256",
+						attrs);
+			}
+
+			attrs.clear();
+			attrs.put("SupportedModes", "CBC");
+			attrs.put("SupportedPaddings", "NOPADDING");
+			attrs.put("SupportedKeyFormats", "RAW");
+			ps("Cipher", "DESedeWrap",
+					"com.sun.crypto.provider.DESedeWrapCipher", null, attrs);
+
+			attrs.clear();
+			attrs.put("SupportedModes", "ECB");
+			attrs.put("SupportedPaddings", "NOPADDING");
+			attrs.put("SupportedKeyFormats", "RAW");
+			psA("Cipher", "ARCFOUR",
+					"com.sun.crypto.provider.ARCFOURCipher", attrs);
+
+			attrs.clear();
+			attrs.put("SupportedKeyFormats", "RAW");
+
+			if (useNativeChaCha20Cipher && (NativeCrypto.getVersionIfAvailable() >= NativeCrypto.OPENSSL_VERSION_1_1_0)) {
+				ps("Cipher", "ChaCha20",
+						"com.sun.crypto.provider.NativeChaCha20Cipher$ChaCha20Only",
+						null, attrs);
+				psA("Cipher", "ChaCha20-Poly1305",
+						"com.sun.crypto.provider.NativeChaCha20Cipher$ChaCha20Poly1305",
+						attrs);
+			} else {
+				ps("Cipher",  "ChaCha20",
+						"com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Only",
+						null, attrs);
+				psA("Cipher",  "ChaCha20-Poly1305",
+						"com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+						attrs);
+			}
+
+			// PBES1
+			psA("Cipher", "PBEWithMD5AndDES",
+					"com.sun.crypto.provider.PBEWithMD5AndDESCipher",
+					null);
+			ps("Cipher", "PBEWithMD5AndTripleDES",
+					"com.sun.crypto.provider.PBEWithMD5AndTripleDESCipher");
+			psA("Cipher", "PBEWithSHA1AndDESede",
+					"com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndDESede",
+					null);
+			psA("Cipher", "PBEWithSHA1AndRC2_40",
+					"com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC2_40",
+					null);
+			psA("Cipher", "PBEWithSHA1AndRC2_128",
+					"com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC2_128",
+					null);
+			psA("Cipher", "PBEWithSHA1AndRC4_40",
+					"com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC4_40",
+					null);
+
+			psA("Cipher", "PBEWithSHA1AndRC4_128",
+					"com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndRC4_128",
+					null);
+
+			// PBES2
+			ps("Cipher", "PBEWithHmacSHA1AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA224AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA256AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA384AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA512AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA512/224AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512_224AndAES_128");
+
+			ps("Cipher", "PBEWithHmacSHA512/256AndAES_128",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512_256AndAES_128");
+
+
+			ps("Cipher", "PBEWithHmacSHA1AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA1AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA224AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA224AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA256AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA256AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA384AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA384AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA512AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA512/224AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512_224AndAES_256");
+
+			ps("Cipher", "PBEWithHmacSHA512/256AndAES_256",
+					"com.sun.crypto.provider.PBES2Core$HmacSHA512_256AndAES_256");
+
+			/*
+			* Key(pair) Generator engines
+			*/
+			ps("KeyGenerator", "DES",
+					"com.sun.crypto.provider.DESKeyGenerator");
+			psA("KeyGenerator", "DESede",
+					"com.sun.crypto.provider.DESedeKeyGenerator",
+					null);
+			ps("KeyGenerator", "Blowfish",
+					"com.sun.crypto.provider.BlowfishKeyGenerator");
+			psA("KeyGenerator", "AES",
+					"com.sun.crypto.provider.AESKeyGenerator",
+					null);
+			ps("KeyGenerator", "RC2",
+					"com.sun.crypto.provider.KeyGeneratorCore$RC2KeyGenerator");
+			psA("KeyGenerator", "ARCFOUR",
+					"com.sun.crypto.provider.KeyGeneratorCore$ARCFOURKeyGenerator",
+					null);
+			ps("KeyGenerator", "ChaCha20",
+					"com.sun.crypto.provider.KeyGeneratorCore$ChaCha20KeyGenerator");
+			ps("KeyGenerator", "HmacMD5",
+					"com.sun.crypto.provider.HmacMD5KeyGenerator");
+
+			psA("KeyGenerator", "HmacSHA1",
+					"com.sun.crypto.provider.HmacSHA1KeyGenerator", null);
+			psA("KeyGenerator", "HmacSHA224",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA224",
+					null);
+			psA("KeyGenerator", "HmacSHA256",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA256",
+					null);
+			psA("KeyGenerator", "HmacSHA384",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA384",
+					null);
+			psA("KeyGenerator", "HmacSHA512",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512",
+					null);
+			psA("KeyGenerator", "HmacSHA512/224",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512_224",
+					null);
+			psA("KeyGenerator", "HmacSHA512/256",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512_256",
+					null);
+
+			psA("KeyGenerator", "HmacSHA3-224",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA3_224",
+					null);
+			psA("KeyGenerator", "HmacSHA3-256",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA3_256",
+					null);
+			psA("KeyGenerator", "HmacSHA3-384",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA3_384",
+					null);
+			psA("KeyGenerator", "HmacSHA3-512",
+					"com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA3_512",
+					null);
+
+			psA("KeyPairGenerator", "DiffieHellman",
+					"com.sun.crypto.provider.DHKeyPairGenerator",
+					null);
+
+			/*
+			* Algorithm parameter generation engines
+			*/
+			psA("AlgorithmParameterGenerator",
+					"DiffieHellman", "com.sun.crypto.provider.DHParameterGenerator",
+					null);
+
+			/*
+			* Key Agreement engines
+			*/
+			attrs.clear();
+			attrs.put("SupportedKeyClasses", "javax.crypto.interfaces.DHPublicKey" +
+							"|javax.crypto.interfaces.DHPrivateKey");
+			psA("KeyAgreement", "DiffieHellman",
+					"com.sun.crypto.provider.DHKeyAgreement",
+					attrs);
+
+			/*
+			* Algorithm Parameter engines
+			*/
+			psA("AlgorithmParameters", "DiffieHellman",
+					"com.sun.crypto.provider.DHParameters", null);
+
+			ps("AlgorithmParameters", "DES",
+					"com.sun.crypto.provider.DESParameters");
+
+			psA("AlgorithmParameters", "DESede",
+					"com.sun.crypto.provider.DESedeParameters", null);
+
+			psA("AlgorithmParameters", "PBEWithMD5AndDES",
+					"com.sun.crypto.provider.PBEParameters",
+					null);
+
+			ps("AlgorithmParameters", "PBEWithMD5AndTripleDES",
+					"com.sun.crypto.provider.PBEParameters");
+
+			psA("AlgorithmParameters", "PBEWithSHA1AndDESede",
+					"com.sun.crypto.provider.PBEParameters",
+					null);
+
+			psA("AlgorithmParameters", "PBEWithSHA1AndRC2_40",
+					"com.sun.crypto.provider.PBEParameters",
+					null);
+
+			psA("AlgorithmParameters", "PBEWithSHA1AndRC2_128",
+					"com.sun.crypto.provider.PBEParameters",
+					null);
+
+			psA("AlgorithmParameters", "PBEWithSHA1AndRC4_40",
+					"com.sun.crypto.provider.PBEParameters",
+					null);
+
+			psA("AlgorithmParameters", "PBEWithSHA1AndRC4_128",
+					"com.sun.crypto.provider.PBEParameters",
+					null);
+
+			psA("AlgorithmParameters", "PBES2",
+					"com.sun.crypto.provider.PBES2Parameters$General",
+					null);
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA1AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA1AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA224AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA224AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA256AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA256AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA384AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA384AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512/224AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512_224AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512/256AndAES_128",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512_256AndAES_128");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA1AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA1AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA224AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA224AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA256AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA256AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA384AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA384AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512/224AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512_224AndAES_256");
+
+			ps("AlgorithmParameters", "PBEWithHmacSHA512/256AndAES_256",
+					"com.sun.crypto.provider.PBES2Parameters$HmacSHA512_256AndAES_256");
+
+			ps("AlgorithmParameters", "Blowfish",
+					"com.sun.crypto.provider.BlowfishParameters");
+
+			psA("AlgorithmParameters", "AES",
+					"com.sun.crypto.provider.AESParameters", null);
+
+			ps("AlgorithmParameters", "GCM",
+					"com.sun.crypto.provider.GCMParameters");
+
+			ps("AlgorithmParameters", "RC2",
+					"com.sun.crypto.provider.RC2Parameters");
+
+			psA("AlgorithmParameters", "OAEP",
+					"com.sun.crypto.provider.OAEPParameters", null);
+
+			psA("AlgorithmParameters", "ChaCha20-Poly1305",
+					"com.sun.crypto.provider.ChaCha20Poly1305Parameters", null);
+
+			/*
+			* Key factories
+			*/
+			psA("KeyFactory", "DiffieHellman",
+					"com.sun.crypto.provider.DHKeyFactory",
+					null);
+
+			/*
+			* Secret-key factories
+			*/
+			ps("SecretKeyFactory", "DES",
+					"com.sun.crypto.provider.DESKeyFactory");
+
+			psA("SecretKeyFactory", "DESede",
+					"com.sun.crypto.provider.DESedeKeyFactory", null);
+
+			psA("SecretKeyFactory", "PBEWithMD5AndDES",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndDES",
+					null);
+
+			/*
+			* Internal in-house crypto algorithm used for
+			* the JCEKS keystore type.  Since this was developed
+			* internally, there isn't an OID corresponding to this
+			* algorithm.
+			*/
+			ps("SecretKeyFactory", "PBEWithMD5AndTripleDES",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndTripleDES");
+
+			psA("SecretKeyFactory", "PBEWithSHA1AndDESede",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndDESede",
+					null);
+
+			psA("SecretKeyFactory", "PBEWithSHA1AndRC2_40",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_40",
+					null);
+
+			psA("SecretKeyFactory", "PBEWithSHA1AndRC2_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_128",
+					null);
+
+			psA("SecretKeyFactory", "PBEWithSHA1AndRC4_40",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_40",
+					null);
+
+			psA("SecretKeyFactory", "PBEWithSHA1AndRC4_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_128",
+					null);
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512/224AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_224AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512/256AndAES_128",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_256AndAES_128");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512/224AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_224AndAES_256");
+
+			ps("SecretKeyFactory", "PBEWithHmacSHA512/256AndAES_256",
+					"com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512_256AndAES_256");
+
+			// PBKDF2
+			psA("SecretKeyFactory", "PBKDF2WithHmacSHA1",
+					"com.sun.crypto.provider.PBKDF2Core$HmacSHA1",
+					null);
+			ps("SecretKeyFactory", "PBKDF2WithHmacSHA224",
+					"com.sun.crypto.provider.PBKDF2Core$HmacSHA224");
+			ps("SecretKeyFactory", "PBKDF2WithHmacSHA256",
+					"com.sun.crypto.provider.PBKDF2Core$HmacSHA256");
+			ps("SecretKeyFactory", "PBKDF2WithHmacSHA384",
+					"com.sun.crypto.provider.PBKDF2Core$HmacSHA384");
+			ps("SecretKeyFactory", "PBKDF2WithHmacSHA512",
+					"com.sun.crypto.provider.PBKDF2Core$HmacSHA512");
+			ps("SecretKeyFactory", "PBKDF2WithHmacSHA512/224",
+					"com.sun.crypto.provider.PBKDF2Core$HmacSHA512_224");
+			ps("SecretKeyFactory", "PBKDF2WithHmacSHA512/256",
+					"com.sun.crypto.provider.PBKDF2Core$HmacSHA512_256");
+
+			/*
+			* MAC
+			*/
+			attrs.clear();
+			attrs.put("SupportedKeyFormats", "RAW");
+			ps("Mac", "HmacMD5", "com.sun.crypto.provider.HmacMD5", null, attrs);
+			psA("Mac", "HmacSHA1", "com.sun.crypto.provider.HmacSHA1",
+					attrs);
+			psA("Mac", "HmacSHA224",
+					"com.sun.crypto.provider.HmacCore$HmacSHA224", attrs);
+			psA("Mac", "HmacSHA256",
+					"com.sun.crypto.provider.HmacCore$HmacSHA256", attrs);
+			psA("Mac", "HmacSHA384",
+					"com.sun.crypto.provider.HmacCore$HmacSHA384", attrs);
+			psA("Mac", "HmacSHA512",
+					"com.sun.crypto.provider.HmacCore$HmacSHA512", attrs);
+			psA("Mac", "HmacSHA512/224",
+					"com.sun.crypto.provider.HmacCore$HmacSHA512_224", attrs);
+			psA("Mac", "HmacSHA512/256",
+					"com.sun.crypto.provider.HmacCore$HmacSHA512_256", attrs);
+			psA("Mac", "HmacSHA3-224",
+					"com.sun.crypto.provider.HmacCore$HmacSHA3_224", attrs);
+			psA("Mac", "HmacSHA3-256",
+					"com.sun.crypto.provider.HmacCore$HmacSHA3_256", attrs);
+			psA("Mac", "HmacSHA3-384",
+					"com.sun.crypto.provider.HmacCore$HmacSHA3_384", attrs);
+			psA("Mac", "HmacSHA3-512",
+					"com.sun.crypto.provider.HmacCore$HmacSHA3_512", attrs);
+
+			ps("Mac", "HmacPBESHA1",
+					"com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA1",
+					null, attrs);
+			ps("Mac", "HmacPBESHA224",
+					"com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA224",
+					null, attrs);
+			ps("Mac", "HmacPBESHA256",
+					"com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA256",
+					null, attrs);
+			ps("Mac", "HmacPBESHA384",
+					"com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA384",
+					null, attrs);
+			ps("Mac", "HmacPBESHA512",
+					"com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512",
+					null, attrs);
+			ps("Mac", "HmacPBESHA512/224",
+					"com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512_224",
+					null, attrs);
+			ps("Mac", "HmacPBESHA512/256",
+					"com.sun.crypto.provider.HmacPKCS12PBECore$HmacPKCS12PBE_SHA512_256",
+					null, attrs);
+
+
+			// PBMAC1
+			ps("Mac", "PBEWithHmacSHA1",
+					"com.sun.crypto.provider.PBMAC1Core$HmacSHA1", null, attrs);
+			ps("Mac", "PBEWithHmacSHA224",
+					"com.sun.crypto.provider.PBMAC1Core$HmacSHA224", null, attrs);
+			ps("Mac", "PBEWithHmacSHA256",
+					"com.sun.crypto.provider.PBMAC1Core$HmacSHA256", null, attrs);
+			ps("Mac", "PBEWithHmacSHA384",
+					"com.sun.crypto.provider.PBMAC1Core$HmacSHA384", null, attrs);
+			ps("Mac", "PBEWithHmacSHA512",
+					"com.sun.crypto.provider.PBMAC1Core$HmacSHA512", null, attrs);
+			ps("Mac", "PBEWithHmacSHA512/224",
+					"com.sun.crypto.provider.PBMAC1Core$HmacSHA512_224", null, attrs);
+			ps("Mac", "PBEWithHmacSHA512/256",
+					"com.sun.crypto.provider.PBMAC1Core$HmacSHA512_256", null, attrs);
+
+			ps("Mac", "SslMacMD5",
+					"com.sun.crypto.provider.SslMacCore$SslMacMD5", null, attrs);
+			ps("Mac", "SslMacSHA1",
+					"com.sun.crypto.provider.SslMacCore$SslMacSHA1", null, attrs);
+
+			/*
+			* KeyStore
+			*/
+			ps("KeyStore", "JCEKS",
+					"com.sun.crypto.provider.JceKeyStore");
+
+			/*
+			* SSL/TLS mechanisms
+			*
+			* These are strictly internal implementations and may
+			* be changed at any time.  These names were chosen
+			* because PKCS11/SunPKCS11 does not yet have TLS1.2
+			* mechanisms, and it will cause calls to come here.
+			*/
+			ps("KeyGenerator", "SunTlsPrf",
+					"com.sun.crypto.provider.TlsPrfGenerator$V10");
+			ps("KeyGenerator", "SunTls12Prf",
+					"com.sun.crypto.provider.TlsPrfGenerator$V12");
+
+			ps("KeyGenerator", "SunTlsMasterSecret",
+					"com.sun.crypto.provider.TlsMasterSecretGenerator",
+					List.of("SunTls12MasterSecret", "SunTlsExtendedMasterSecret"),
+					null);
+
+			ps("KeyGenerator", "SunTlsKeyMaterial",
+					"com.sun.crypto.provider.TlsKeyMaterialGenerator",
+					List.of("SunTls12KeyMaterial"), null);
+
+			ps("KeyGenerator", "SunTlsRsaPremasterSecret",
+					"com.sun.crypto.provider.TlsRsaPremasterSecretGenerator",
+					List.of("SunTls12RsaPremasterSecret"), null);
+		}
     }
 
     // Return the instance of this class or create one if needed.

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -157,6 +157,12 @@ public final class SunEntries {
                 "sun.security.provider.certpath.PKIXCertPathValidator",
                 attrs);
 
+        /*
+         * KeyStore
+         */
+        add(p, "KeyStore", "PKCS12",
+                "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12");
+
         if (FIPSConfigurator.enableFIPS()) {
             return;
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -55,6 +55,8 @@ package sun.security.pkcs11.wrapper;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -149,9 +151,21 @@ public class PKCS11 {
         new HashMap<String,PKCS11>();
 
     static boolean isKey(CK_ATTRIBUTE[] attrs) {
+        long keyClass = 0, keyType = 0;
         for (CK_ATTRIBUTE attr : attrs) {
+            if (attr.type == CKA_CLASS) {
+                keyClass = attr.getLong();
+            }
+            if (attr.type == CKA_KEY_TYPE) {
+                keyType = attr.getLong();
+            }
             if ((attr.type == CKA_CLASS) && (attr.getLong() == CKO_SECRET_KEY)) {
                 return true;
+            }
+            if ((attr.type == CKA_CLASS) && (attr.getLong() == CKO_PRIVATE_KEY)) {
+                if(keyType == CKK_RSA || keyType == CKK_EC) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
This PR aims to provide the PKCS#12 file-based keystore support.

The algorithm that used for keystore operations is called PBE(Password-Based Encryption), this PBE algorithm need to be fips certified. There are two sources of FIPS certified croptography that accepted to Java right now, one is NSS and the other one is openssl. We are providing the support by using a FIPS openssl version, it has the PBE algorithms named PBES2 which is FIPS compliance.

While loading a keystore file and use a fips certified PBE algorithm and now you will have a key in memory. This key will be loaded to do various operations for example TLS handshake. There is one problem that the way NSS works in FIPS mode is they keep their own keys in their own memory. Those keys are not accessable, you cannot read or write those keys from or to NSS. Therefore, we need to import/export the keys to/from NSS.