### PR TITLE
Add preview of AbstractLinker.UpcallStubFactory

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -57,6 +57,10 @@ import java.util.Objects;
 public abstract sealed class AbstractLinker implements Linker permits LinuxAArch64Linker, MacOsAArch64Linker, AixPPC64Linker,
                                                                       SysVPPC64leLinker, SysVS390xLinker, SysVx64Linker, WindowsAArch64Linker, Windowsx64Linker, LinuxRISCV64Linker {
 
+    public interface UpcallStubFactory {
+        MemorySegment makeStub(MethodHandle target, SegmentScope arena);
+    }
+
     private record LinkRequest(FunctionDescriptor descriptor, LinkerOptions options) {}
     private final SoftReferenceCache<LinkRequest, MethodHandle> DOWNCALL_CACHE = new SoftReferenceCache<>();
 


### PR DESCRIPTION
This interface is defined by:
b4a1996aa9df668657832975eb12ef1b9411dfd7 8303684: Lift upcall sharing mechanism to AbstractLinker (mainline)

That change is part of #572 which we cannot merge into the openj9 branch because of https://github.com/eclipse-openj9/openj9/issues/16936, however it will allow https://github.com/eclipse-openj9/openj9/pull/16985 to be merged while allowing the openj9 branch to continue to build with the head of the openj9 repository.