### PR TITLE
[FFI/JDK21] Update the code against the changes in OpenJDK

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -202,10 +202,7 @@ public abstract class CallArranger {
         if (isWinOS) {
             throw new InternalError("arrangeUpcall is not implemented on Windows/Aarch64");
         }
-        Bindings bindings = getBindings(mt, cDesc, true);
-        final boolean dropReturn = true; /* drop return, since we don't have bindings for it */
-        return SharedUtils.arrangeUpcallHelper(mt, bindings.isInMemoryReturn, dropReturn, abiDescriptor(),
-                bindings.callingSequence);
+        return UpcallLinker.makeFactory(mt, cDesc);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/CallArranger.java
@@ -56,6 +56,6 @@ public class CallArranger {
 
 	/* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
 	public static UpcallStubFactory arrangeUpcall(MethodType mt, FunctionDescriptor cDesc) {
-		throw new InternalError("arrangeUpcall is not implemented");
+		return UpcallLinker.makeFactory(mt, cDesc);
 	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/sysv/CallArranger.java
@@ -56,6 +56,6 @@ public class CallArranger {
 
 	/* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
 	public static UpcallStubFactory arrangeUpcall(MethodType mt, FunctionDescriptor cDesc) {
-		throw new InternalError("arrangeUpcall is not implemented");
+		return UpcallLinker.makeFactory(mt, cDesc);
 	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/s390x/sysv/CallArranger.java
@@ -56,6 +56,6 @@ public class CallArranger {
 
 	/* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
 	public static UpcallStubFactory arrangeUpcall(MethodType mt, FunctionDescriptor cDesc) {
-		throw new InternalError("arrangeUpcall is not implemented");
+		return UpcallLinker.makeFactory(mt, cDesc);
 	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -134,10 +134,7 @@ public class CallArranger {
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public static UpcallStubFactory arrangeUpcall(MethodType mt, FunctionDescriptor cDesc) {
-        Bindings bindings = getBindings(mt, cDesc, true);
-        final boolean dropReturn = true; /* drop return, since we don't have bindings for it */
-        return SharedUtils.arrangeUpcallHelper(mt, bindings.isInMemoryReturn, dropReturn, CSysV,
-                bindings.callingSequence);
+        return UpcallLinker.makeFactory(mt, cDesc);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -134,10 +134,7 @@ public class CallArranger {
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public static UpcallStubFactory arrangeUpcall(MethodType mt, FunctionDescriptor cDesc) {
-        Bindings bindings = getBindings(mt, cDesc, true);
-        final boolean dropReturn = false; /* need the return value as well */
-        return SharedUtils.arrangeUpcallHelper(mt, bindings.isInMemoryReturn, dropReturn, CWindows,
-                bindings.callingSequence);
+        return UpcallLinker.makeFactory(mt, cDesc);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {


### PR DESCRIPTION
The minor changes wrap up the existing upcall specific code
in `CallArranger.arrangeUpcall()` with `UpcallStubFactory`
introduced in JDK20 by invoking `UpcallLinker.makeFactory()`
implemented in OpenJ9.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>