### PR TITLE
Revert version-numbers.conf

### DIFF
--- a/make/conf/version-numbers.conf
+++ b/make/conf/version-numbers.conf
@@ -23,10 +23,6 @@
 # questions.
 #
 
-# ===========================================================================
-# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
-# ===========================================================================
-
 # Default version, product, and vendor information to use,
 # unless overridden by configure
 
@@ -41,6 +37,6 @@ DEFAULT_VERSION_DATE=2023-09-19
 DEFAULT_VERSION_CLASSFILE_MAJOR=65  # "`$EXPR $DEFAULT_VERSION_FEATURE + 44`"
 DEFAULT_VERSION_CLASSFILE_MINOR=0
 DEFAULT_VERSION_DOCS_API_SINCE=11
-DEFAULT_ACCEPTABLE_BOOT_VERSIONS="18 19 20 21"
+DEFAULT_ACCEPTABLE_BOOT_VERSIONS="20 21"
 DEFAULT_JDK_SOURCE_TARGET_VERSION=21
 DEFAULT_PROMOTED_VERSION_PRE=ea


### PR DESCRIPTION
Neither java 18 nor 19 are acceptable for the boot JDK.

See https://github.com/eclipse-openj9/openj9/issues/17289.