### PR TITLE
Show macro definitions generated in openj9_version_info.h

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -351,6 +351,9 @@ OPENJ9_VERSION_SCRIPT := \
 $(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h : $(TOPDIR)/closed/openj9_version_info.h.in
 	@$(MKDIR) -p $(@D)
 	@$(SED) $(OPENJ9_VERSION_SCRIPT) > $@ < $<
+	@$(ECHO) "==== $(@F) ===="
+	@$(GREP) define $@
+	@$(ECHO) "===="
 
 # capture values for use with DependOnVariable
 OPENJ9_VERSION_MAP := $(foreach var,$(sort $(OPENJ9_VERSION_VARS)),$(var)='$(value $(var))')


### PR DESCRIPTION
Provides clarity for things like `OPENJ9_TAG`.