### PR TITLE
CRIU restore clears InetAddress.cache

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -41,10 +41,12 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 	FILES := \
 		src/java.base/share/classes/java/lang/ClassValue.java \
 		src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java \
+		src/java.base/share/classes/java/net/InetAddress.java \
 		src/java.base/share/classes/java/security/Security.java \
 		src/java.base/share/classes/java/util/Timer.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
+		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.net;
 
 import java.net.spi.InetAddressResolver;
@@ -367,6 +373,12 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
                     public byte[] addressBytes(Inet6Address inet6Address) {
                         return inet6Address.addressBytes();
                     }
+
+                    /*[IF CRIU_SUPPORT]*/
+                    public void clearInetAddressCache() {
+                        InetAddress.clearInetAddressCache();
+                    }
+                    /*[ENDIF] CRIU_SUPPORT */
                 }
         );
         init();
@@ -930,6 +942,16 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
     // still being looked-up by NameService(s)) or CachedAddresses when cached
     private static final ConcurrentMap<String, Addresses> cache =
         new ConcurrentHashMap<>();
+
+    /*[IF CRIU_SUPPORT]*/
+    /**
+     * To be invoked by CRIU post-restore hook, clear the cache.
+     */
+    static void clearInetAddressCache() {
+        cache.clear();
+        expirySet.clear();
+    }
+    /*[ENDIF] CRIU_SUPPORT */
 
     // CachedAddresses that have to expire are kept ordered in this NavigableSet
     // which is scanned on each access

--- a/src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.access;
 
 import java.net.Inet4Address;
@@ -45,4 +51,11 @@ public interface JavaNetInetAddressAccess {
      * Returns a reference to the byte[] with the IPv6 address.
      */
     byte[] addressBytes(Inet6Address inet6Address);
+
+    /*[IF CRIU_SUPPORT]*/
+    /**
+     * To be invoked by CRIU post-restore hook, clear the cache.
+     */
+    void clearInetAddressCache();
+    /*[ENDIF] CRIU_SUPPORT */
 }


### PR DESCRIPTION
CRIU restore clears InetAddress.cache

Added `InetAddress.clearInetAddressCache()` to be invoked by CRIU post-restore hook via `JavaNetInetAddressAccess()`.


This change prevents JVM DNS cache before checkpoint which might cause DNS resolution timeout after the CRIU image is restored at a different environment.
Related
* https://github.com/eclipse-openj9/openj9/pull/17448

Related
* https://github.com/eclipse-openj9/openj9/pull/17448

Signed-off-by: Jason Feng <fengj@ca.ibm.com>