### PR TITLE
Remove unused method ECPublicKeyImpl.isECFieldF2m()

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
@@ -142,14 +142,6 @@ public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
     }
 
     /**
-     * Returns true if this key's EC field is an instance of ECFieldF2m.
-     * @return true if the field is an instance of ECFieldF2m, false otherwise
-     */
-    boolean isECFieldF2m() {
-        return this.params.getCurve().getField() instanceof ECFieldF2m;
-    }
-
-    /**
      * Returns the native EC public key context pointer.
      * @return the native EC public key context pointer or -1 on error
      */


### PR DESCRIPTION
Noticed while reviewing jdk8#671; see https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/671#discussion_r1219946182.