### PR TITLE
Improve speed of cipher operations for large inputs

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -748,12 +748,26 @@ final class CipherCore {
         throws IllegalBlockSizeException, BadPaddingException {
         try {
             byte[] output = new byte[getOutputSizeByOperation(inputLen, true)];
-            byte[] finalBuf = prepareInputBuffer(input, inputOffset,
-                    inputLen, output, 0);
+            int outputOffset = 0;
+            int outLen = 0;
+
+            if (inputLen > 0) {
+                /*
+                 * Call the update() method to get rid of as many bytes as
+                 * possible before potentially copying array.
+                 */
+                int updateOutLen = update(input, inputOffset, inputLen, output, outputOffset);
+                inputOffset = inputLen;
+                inputLen = 0;
+                outputOffset += updateOutLen;
+                outLen = updateOutLen;
+            }
+
+            byte[] finalBuf = prepareInputBuffer(input, inputOffset, inputLen, output, outputOffset);
             int finalOffset = (finalBuf == input) ? inputOffset : 0;
             int finalBufLen = (finalBuf == input) ? inputLen : finalBuf.length;
 
-            int outLen = fillOutputBuffer(finalBuf, finalOffset, output, 0,
+            outLen += fillOutputBuffer(finalBuf, finalOffset, output, outputOffset,
                     finalBufLen, input);
 
             endDoFinal();
@@ -817,13 +831,6 @@ final class CipherCore {
         int estOutSize = getOutputSizeByOperation(inputLen, true);
         int outputCapacity = checkOutputCapacity(output, outputOffset,
                 estOutSize);
-        int offset = outputOffset;
-        byte[] finalBuf = prepareInputBuffer(input, inputOffset,
-                inputLen, output, outputOffset);
-        byte[] internalOutput = null; // for decrypting only
-
-        int finalOffset = (finalBuf == input) ? inputOffset : 0;
-        int finalBufLen = (finalBuf == input) ? inputLen : finalBuf.length;
 
         if (decrypting) {
             // if the size of specified output buffer is less than
@@ -834,18 +841,44 @@ final class CipherCore {
             if (outputCapacity < estOutSize) {
                 cipher.save();
             }
+        }
+
+        int outLen = 0;
+        int estFinalBuffSize = estOutSize;
+        if (inputLen > 0) {
+            /*
+             * Call the update() method to get rid of as many bytes as
+             * possible before potentially copying array.
+             */
+            int updateOutLen = update(input, inputOffset, inputLen, output, outputOffset);
+            inputOffset = inputLen;
+            inputLen = 0;
+            outputOffset += updateOutLen;
+            outLen += updateOutLen;
+            estFinalBuffSize -= updateOutLen;
+        }
+
+        int offset = outputOffset;
+        byte[] finalBuf = prepareInputBuffer(input, inputOffset, inputLen, output, outputOffset);
+        byte[] internalOutput = null; // for decrypting only
+
+        int finalOffset = (finalBuf == input) ? inputOffset : 0;
+        int finalBufLen = (finalBuf == input) ? inputLen : finalBuf.length;
+
+        if (decrypting) {
             if (outputCapacity < estOutSize || padding != null) {
                 // create temporary output buffer if the estimated size is larger
                 // than the user-provided buffer or a padding needs to be removed
                 // before copying the unpadded result to the output buffer
-                internalOutput = new byte[estOutSize];
+                internalOutput = new byte[estFinalBuffSize];
                 offset = 0;
             }
         }
 
         byte[] outBuffer = (internalOutput != null) ? internalOutput : output;
-        int outLen = fillOutputBuffer(finalBuf, finalOffset, outBuffer,
+        int outBuffLen = fillOutputBuffer(finalBuf, finalOffset, outBuffer,
                 offset, finalBufLen, input);
+        outLen += outBuffLen;
 
         if (decrypting) {
 
@@ -859,7 +892,7 @@ final class CipherCore {
             // copy the result into user-supplied output buffer
             if (internalOutput != null) {
                 System.arraycopy(internalOutput, 0, output, outputOffset,
-                    outLen);
+                    outBuffLen);
                 // decrypt mode. Zero out output data that's not required
                 Arrays.fill(internalOutput, (byte) 0x00);
             }


### PR DESCRIPTION
In cases were bytes remain buffered and/or padding is enabled and encryption is performed, the entirety of the input provided in the `doFinal()` methods of the `CipherCore` class would be copied in a buffer with enough space to accommodate the extra bytes requires for buffered bytes and/or padding. The buffer would subsequently be zeroed out for security reasons.

To avoid said actions and improve the performance of the process in case of very large inputs, the updated code calls the `update()` method with as much data as possible before the final steps.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)