### PR TITLE
Use quotes consistently in version-numbers

### DIFF
--- a/closed/autoconf/version-numbers
+++ b/closed/autoconf/version-numbers
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,6 @@
 # Default settings unless overridden by configure
 
 COMPANY_NAME="Eclipse OpenJ9"
-VENDOR_URL=http://www.eclipse.org/openj9
+VENDOR_URL="http://www.eclipse.org/openj9"
 VENDOR_URL_BUG="https://github.com/eclipse-openj9/openj9/issues/new?labels=userRaised&template=user-problem.md"
 VENDOR_URL_VM_BUG="https://github.com/eclipse-openj9/openj9/issues/new?labels=userRaised&template=user-problem.md"


### PR DESCRIPTION
For consistency with [jdk11](https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/openj9/closed/autoconf/version-numbers).