### PR TITLE
[FFI/Jtreg_JDKnext] Identify the case of symbol for JAVA_INT

### DIFF
--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @run testng TestLayouts
@@ -261,9 +267,10 @@ public class TestLayouts {
     @Test
     public void testStructToString() {
         StructLayout padding = MemoryLayout.structLayout(JAVA_INT).withName("struct");
-        assertEquals(padding.toString(), "[i4](struct)");
+        String basicLayoutString = (JAVA_INT.order() == ByteOrder.LITTLE_ENDIAN) ? "[i4](struct)" : "[I4](struct)";
+        assertEquals(padding.toString(), basicLayoutString);
         var toStringUnaligned = padding.withByteAlignment(8).toString();
-        assertEquals(toStringUnaligned, "8%[i4](struct)");
+        assertEquals(toStringUnaligned, "8%" + basicLayoutString);
     }
 
     @Test(dataProvider = "layoutKinds")


### PR DESCRIPTION
The change distinguishes the LE/BE platforms by checking
the case of symbol for JAVA_INT.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>