### PR TITLE
Add OpenJ9PropsExt properties for vm.gc.ZGenerational & vm.gc.ZSinglegen

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -49,6 +49,8 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.gc.Serial", "false");
             map.put("vm.gc.Shenandoah", "false");
             map.put("vm.gc.Z", "false");
+            map.put("vm.gc.ZGenerational", "false");
+            map.put("vm.gc.ZSinglegen", "false");
             map.put("vm.graal.enabled", "false");
             map.put("vm.hasJFR", "false");
             map.put("vm.jvmti", "true");


### PR DESCRIPTION
Add `OpenJ9PropsExt` properties for `vm.gc.ZGenerational` & `vm.gc.ZSinglegen`

This addresses the error from [an internal JDK21 build](https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdk21_j9_extended.openjdk_ppc64_aix_Personal/1/consoleFull)
```
09:33:43  TEST: jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ZGC_Generational
09:33:43  
09:33:43  TEST RESULT: Error. Error evaluating expression: invalid boolean value: `null' for expression `vm.gc.ZGenerational'
09:33:43  --------------------------------------------------
09:33:43  TEST: jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ZGC_Singlegen
09:33:43  
09:33:43  TEST RESULT: Error. Error evaluating expression: invalid boolean value: `null' for expression `vm.gc.ZSinglegen'
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>