### PR TITLE
Revert: 8310379: Relax prerequisites for java.base-jmod target

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2023 All Rights Reserved
 # ===========================================================================
 
 ################################################################################
@@ -979,8 +979,7 @@ else
   # When creating the BUILDJDK, we don't need to add hashes to java.base, thus
   # we don't need to depend on all other jmods
   ifneq ($(CREATING_BUILDJDK), true)
-    java.base-jmod: jrtfs-jar $(filter-out java.base-jmod \
-        $(addsuffix -jmod, $(call FindAllUpgradeableModules)), $(JMOD_TARGETS))
+    java.base-jmod: jrtfs-jar $(filter-out java.base-jmod, $(JMOD_TARGETS))
   endif
 
   # If not already set, set the JVM target so that the JVM will be built.


### PR DESCRIPTION
Building `java.base.jmod` requires all non-upgradable modules, but the macro `FindAllUpgradeableModules` doesn't take into account requires relationships.

Fixes: https://github.com/eclipse-openj9/openj9/issues/17757.