### PR TITLE
[FFI/Jtreg_JDKnext] Capture the invalid thread state in upcall

### DIFF
--- a/test/jdk/java/foreign/trivial/TestTrivialUpcall.java
+++ b/test/jdk/java/foreign/trivial/TestTrivialUpcall.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
@@ -45,7 +51,7 @@ public class TestTrivialUpcall extends UpcallTestHelper {
     @Test
     public void testUpcallFailure() throws IOException, InterruptedException {
         // test to see if we catch a trivial downcall doing an upcall
-        runInNewProcess(Runner.class, true).assertStdOutContains("wrong thread state for upcall");
+        runInNewProcess(Runner.class, true).assertStdErrContains("wrong thread state for upcall");
     }
 
     public static class Runner extends NativeTestHelper {


### PR DESCRIPTION
The tiny change is to capture the error message from `System.err`
rather than `System.out` to support the related code in OpenJ9
at #eclipse-openj9/openj9/pull/17847 which is different from the RI
implementation.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
