### PR TITLE
Fix BoundVThreadTest - Bad Thread Object

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/BoundVThreadTest/libBoundVThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/BoundVThreadTest/libBoundVThreadTest.cpp
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
@@ -137,8 +143,8 @@ test_unsupported_jvmti_functions(jvmtiEnv *jvmti, JNIEnv *jni, jthread vthread, 
   err = jvmti->GetAllStackTraces(MAX_FRAMES, &stack_info, &thread_cnt);
   check_jvmti_status(jni, err, "test_unsupported_jvmti_functions: error in JVMTI GetAllStackTraces");
   for (int idx = 0; idx < thread_cnt; idx++) {
-    jthread thread = threads_ptr[idx];
-    if (jni->IsVirtualThread(thread)) {
+    jvmtiStackInfo *info = &stack_info[idx];
+    if (jni->IsVirtualThread(info->thread)) {
       fatal(jni, "GetAllStackTraces should not include virtual threads");
     }
   }


### PR DESCRIPTION
After GetAllStackTraces, derive the thread object from the
stack_info array, which is filled by GetAllStackTraces.

Currently, the thread object is retrieved from the threads_ptr
array, which is filled by GetAllThreads before the call to
GetAllStackTraces. Live platform threads might have been created
or destroyed between the call to GetAllThreads and GetAllStackTraces.
This makes the threads_ptr array stale after GetAllStackTraces. A bad
thread object is accessed from the stale threads_ptr which causes a
segfault.

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/25.

Related: https://github.com/eclipse-openj9/openj9/issues/17868

Signed-off-by: Babneet Singh [sbabneet@ca.ibm.com](mailto:sbabneet@ca.ibm.com)