### PR TITLE
Optimize ChaCha20-Poly1305 initialization

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -321,7 +321,8 @@ public class NativeCrypto {
                                     byte[] iv,
                                     int ivlen,
                                     byte[] key,
-                                    int keylen);
+                                    int keylen,
+                                    boolean doReset);
 
     public final native int ChaCha20Update(long context,
                                        byte[] input,

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -2153,11 +2153,11 @@ int OSSL102_RSA_set0_crt_params(RSA *r2, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqm
 /*
  * Class:     jdk_crypto_jniprovider_NativeCrypto
  * Method:    ChaCha20Init
- * Signature: (JI[BI[BI)I
+ * Signature: (JI[BI[BIZ)I
  */
 JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_ChaCha20Init
   (JNIEnv *env, jobject thisObj, jlong c, jint mode, jbyteArray iv, jint ivLen,
-  jbyteArray key, jint key_len)
+  jbyteArray key, jint key_len, jboolean doReset)
 {
     EVP_CIPHER_CTX *ctx = (EVP_CIPHER_CTX*)(intptr_t) c;
     unsigned char *ivNative = NULL;
@@ -2170,12 +2170,18 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_ChaCha20Init
     }
 
     if ((0 == mode) || (1 == mode)) {
-        evp_cipher1 = (*OSSL_chacha20_poly1305)();
+        /* Use the existing evp_cipher? */
+        if (JNI_FALSE == doReset) {
+            evp_cipher1 = (*OSSL_chacha20_poly1305)();
+        }
         encrypt = mode;
     } else if (2 == mode) {
+        /* Use the existing evp_cipher? */
+        if (JNI_FALSE == doReset) {
+            evp_cipher1 = (*OSSL_chacha20)();
+        }
         /* encrypt or decrypt does not matter */
         encrypt = 1;
-        evp_cipher1 = (*OSSL_chacha20)();
     } else {
         return -1;
     }
@@ -2200,12 +2206,14 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_ChaCha20Init
     }
 
     /* if using Poly1305 */
-    if (2 != mode) {
-        if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_AEAD_SET_IVLEN, ivLen, NULL)) {
-            printErrors();
-            (*env)->ReleaseByteArrayElements(env, iv, (jbyte*)ivNative, JNI_ABORT);
-            (*env)->ReleaseByteArrayElements(env, key, (jbyte*)keyNative, JNI_ABORT);
-            return -1;
+    if (JNI_FALSE == doReset) {
+        if (2 != mode) {
+            if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_AEAD_SET_IVLEN, ivLen, NULL)) {
+                printErrors();
+                (*env)->ReleaseByteArrayElements(env, iv, (jbyte*)ivNative, JNI_ABORT);
+                (*env)->ReleaseByteArrayElements(env, key, (jbyte*)keyNative, JNI_ABORT);
+                return -1;
+            }
         }
     }
 


### PR DESCRIPTION
The ChaCha20 initialization cost has been
found to be expensive in the OpenSSL 3.x
API compared to the OpenSSL 1.x API.

In order to optimize the cost on OpenSSL
3.x, a flag is setup to distinguish two
different types of initializations. One
initialization would be a full
initialization. It will perform the full
initialization when the mode is switched
between encrypt and decrypt, or a first
time encryption or decryption. The other
initialization would be a partial
initialization. Once the mode is decided,
the partial initialization will only use
key and iv, but will NOT recreate and
reinitialize the EVP context as what we
have for now. The key and iv are required
once per Cipher instance, the EVP context
can be used whenever we are reusing a
specific Java cipher object within methods
such as Cipher.doFinal().