### PR TITLE
Assert privilege accessing os.name

### DIFF
--- a/src/java.base/share/classes/sun/security/ec/SunEC.java
+++ b/src/java.base/share/classes/sun/security/ec/SunEC.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 
+import sun.security.action.GetPropertyAction;
 import sun.security.ec.ed.EdDSAKeyFactory;
 import sun.security.ec.ed.EdDSAKeyPairGenerator;
 import sun.security.ec.ed.EdDSASignature;
@@ -61,7 +62,7 @@ public final class SunEC extends Provider {
     private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
 
     // Flag indicating whether the operating system is AIX.
-    private static final boolean isAIX = "AIX".equals(System.getProperty("os.name"));
+    private static final boolean isAIX = "AIX".equals(GetPropertyAction.privilegedGetProperty("os.name"));
 
     /* The property 'jdk.nativeEC' is used to control enablement of the native
      * ECDH implementation.


### PR DESCRIPTION
See https://github.com/eclipse-openj9/openj9/issues/18071.

Also, some tests with non-standard `java.policy` fail otherwise:
```
Caused by: java.security.AccessControlException: Access denied ("java.util.PropertyPermission" "os.name" "read")
	at java.base/java.security.AccessController.throwACE(AccessController.java:177)
	at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:239)
	at java.base/java.security.AccessController.checkPermission(AccessController.java:386)
	at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:411)
	at java.base/java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1146)
	at java.base/java.lang.System.getProperty(System.java:663)
	at java.base/java.lang.System.getProperty(System.java:646)
	at java.base/sun.security.ec.SunEC.<clinit>(SunEC.java:64)
```