### PR TITLE
Parse -Xmso from more locations

### DIFF
--- a/src/java.base/share/native/libjli/args.c
+++ b/src/java.base/share/native/libjli/args.c
@@ -373,6 +373,12 @@ static JLI_List expandArgFile(const char *arg) {
 
     /* arg file cannot be opened */
     if (fptr == NULL || fstat(fileno(fptr), &st) != 0) {
+        if (parsingOpenJ9Args) {
+            if (fptr != NULL) {
+                fclose(fptr);
+            }
+            return NULL;
+        }
         JLI_ReportMessage(CFG_ERROR6, arg);
         exit(1);
     } else {
@@ -385,7 +391,7 @@ static JLI_List expandArgFile(const char *arg) {
     rv = readArgFile(fptr);
 
     /* error occurred reading the file */
-    if (rv == NULL) {
+    if (rv == NULL && !parsingOpenJ9Args) {
         JLI_ReportMessage(ARG_ERROR18, arg);
         exit(1);
     }
@@ -507,7 +513,7 @@ JLI_ParseOpenJ9ArgsFromEnvVar(JLI_List args, const char *var_name) {
     jboolean savedStopExpansion = stopExpansion;
     jboolean savedRelaunch = relaunch;
 
-     if (NULL == env) {
+    if (NULL == env) {
         return JNI_FALSE;
     }
 
@@ -519,6 +525,37 @@ JLI_ParseOpenJ9ArgsFromEnvVar(JLI_List args, const char *var_name) {
     relaunch = JNI_FALSE;
 
     result = expand(args, env, var_name);
+
+    /* Restore the state. */
+    parsingOpenJ9Args = JNI_FALSE;
+    firstAppArgIndex = savedFirstAppArgIndex;
+    expectingNoDashArg = savedExpectingNoDashArg;
+    argsCount = savedArgsCount;
+    stopExpansion = savedStopExpansion;
+    relaunch = savedRelaunch;
+
+    return result;
+}
+
+JNIEXPORT JLI_List JNICALL
+JLI_ParseOpenJ9ArgsFile(const char *filename) {
+    JLI_List result = NULL;
+
+    /* Save the state. */
+    int savedFirstAppArgIndex = firstAppArgIndex;
+    jboolean savedExpectingNoDashArg = expectingNoDashArg;
+    size_t savedArgsCount = argsCount;
+    jboolean savedStopExpansion = stopExpansion;
+    jboolean savedRelaunch = relaunch;
+
+    parsingOpenJ9Args = JNI_TRUE;
+    firstAppArgIndex = NOT_FOUND;
+    expectingNoDashArg = JNI_FALSE;
+    argsCount = 1;
+    stopExpansion = JNI_FALSE;
+    relaunch = JNI_FALSE;
+
+    result = expandArgFile(filename);
 
     /* Restore the state. */
     parsingOpenJ9Args = JNI_FALSE;

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -229,6 +229,44 @@ static jlong initialHeapSize    = 0;  /* initial heap size */
 #define STACK_SIZE_MINIMUM (64 * KB)
 #endif
 
+static void
+parseXmso(JLI_List openj9Args)
+{
+    size_t i = openj9Args->size;
+    while (i > 0) {
+        i -= 1;
+        if (JLI_StrCCmp(openj9Args->elements[i], "-Xmso") == 0) {
+            jlong tmp = 0;
+            if (parse_size(openj9Args->elements[i] + 5, &tmp)) {
+                threadStackSize = tmp;
+                if (threadStackSize > 0 && threadStackSize < (jlong)STACK_SIZE_MINIMUM) {
+                    threadStackSize = STACK_SIZE_MINIMUM;
+                }
+            }
+            break;
+        }
+    }
+    JLI_List_free(openj9Args);
+}
+
+static void
+parseXmsoInFile(const char *filename)
+{
+    JLI_List openj9Args = JLI_ParseOpenJ9ArgsFile(filename);
+    if (openj9Args != NULL) {
+        parseXmso(openj9Args);
+    }
+}
+
+static void
+parseXmsoInEnv(const char *envVar)
+{
+    JLI_List openj9Args = JLI_List_new(8); /* 8 is arbitrary */
+    if (JLI_ParseOpenJ9ArgsFromEnvVar(openj9Args, envVar)) {
+        parseXmso(openj9Args);
+    }
+}
+
 /*
  * Entry point.
  */
@@ -328,29 +366,17 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
         }
     }
 
+    /* Process -Xmso to set the main thread stack size. May be overridden by
+     * a later command line option.
+     */
     {
-        /* Process -Xmso in the OPENJ9_JAVA_OPTIONS environment variable to
-         * set the main thread stack size. May be overridden by a later command
-         * line option.
-         */
-        JLI_List openj9Args = JLI_List_new(8); /* 8 is arbitrary */
-        if (JLI_ParseOpenJ9ArgsFromEnvVar(openj9Args, "OPENJ9_JAVA_OPTIONS")) {
-            size_t i = openj9Args->size;
-            while (i > 0) {
-                i -= 1;
-                if (JLI_StrCCmp(openj9Args->elements[i], "-Xmso") == 0) {
-                    jlong tmp = 0;
-                    if (parse_size(openj9Args->elements[i] + 5, &tmp)) {
-                        threadStackSize = tmp;
-                        if (threadStackSize > 0 && threadStackSize < (jlong)STACK_SIZE_MINIMUM) {
-                            threadStackSize = STACK_SIZE_MINIMUM;
-                        }
-                    }
-                    break;
-                }
-            }
-            JLI_List_free(openj9Args);
-        }
+#define OPTIONS_DEFAULT_PATH "/lib/options.default"
+        char optionsfile[sizeof(jrepath) + sizeof(OPTIONS_DEFAULT_PATH) - 1];
+        JLI_Snprintf(optionsfile, sizeof(optionsfile), "%s" OPTIONS_DEFAULT_PATH, jrepath);
+        parseXmsoInFile(optionsfile);
+        parseXmsoInEnv("JAVA_TOOL_OPTIONS");
+        parseXmsoInEnv("OPENJ9_JAVA_OPTIONS");
+        parseXmsoInEnv("IBM_JAVA_OPTIONS");
     }
 
     /* Parse command line options; if the return value of
@@ -955,8 +981,13 @@ AddOption(char *str, void *info)
      */
 
     /* In OpenJ9 -Xmso is used to set native stack size instead of -Xss. -Xss is used to
-     * set Java thread size only, which is handled in the JVM code.
+     * set Java thread size only, which is handled in the JVM code. Check for -Xmso in any
+     * -Xoptionsfile= and on the command line itself. The default.options file and relevent
+     * environment variables are checked earlier.
      */
+    if (JLI_StrCCmp(str, "-Xoptionsfile=") == 0) {
+        parseXmsoInFile(str + 14);
+    }
     if (JLI_StrCCmp(str, "-Xmso") == 0) {
         jlong tmp;
         if (parse_size(str + 5, &tmp)) {

--- a/src/java.base/share/native/libjli/jli_util.h
+++ b/src/java.base/share/native/libjli/jli_util.h
@@ -167,4 +167,7 @@ JLI_AddArgsFromEnvVar(JLI_List args, const char *var_name);
 JNIEXPORT jboolean JNICALL
 JLI_ParseOpenJ9ArgsFromEnvVar(JLI_List args, const char *var_name);
 
+JNIEXPORT JLI_List JNICALL
+JLI_ParseOpenJ9ArgsFile(const char *filename);
+
 #endif  /* _JLI_UTIL_H */


### PR DESCRIPTION
To match OpenJ9, look in the options.default file, JAVA_TOOL_OPTIONS, and  IBM_JAVA_OPTIONS.

Issue https://github.com/eclipse-openj9/openj9/issues/16105