### PR TITLE
Modify get_source.sh to automatically fetch release branches

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -57,10 +57,16 @@ declare -A shas
 declare -A references
 
 git_urls[openj9]=https://github.com/eclipse-openj9/openj9
-branches[openj9]=master
-
 git_urls[omr]=https://github.com/eclipse-openj9/openj9-omr
-branches[omr]=openj9
+
+currentbranch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$currentbranch" =~ v[0-9]+\.[0-9]+(\.[0-9]+)?-release ]] ; then
+	branches[openj9]=$currentbranch
+	branches[omr]=$currentbranch
+else
+	branches[openj9]=master
+	branches[omr]=openj9
+fi
 
 pflag=false
 


### PR DESCRIPTION
If the current branch matches the pattern of a release branch, fetch openj9/omr branches of the same name.

This will work for a normal release, and can be overwritten for special cases. It avoids having to modify a release branch after creation in order to get the matching openj9/omr release branches. Further changes to the release branch can be pushed rather than merged, as long as the release branch matches the head stream.