### PR TITLE
Stop creating jextract launcher

### DIFF
--- a/closed/make/modules/openj9.dtfj/Launcher.gmk
+++ b/closed/make/modules/openj9.dtfj/Launcher.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -19,11 +19,6 @@
 # ===========================================================================
 
 include LauncherCommon.gmk
-
-$(eval $(call SetupBuildLauncher, jextract, \
-    MAIN_CLASS := com.ibm.jvm.j9.dump.extract.Main, \
-    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
-))
 
 $(eval $(call SetupBuildLauncher, jpackcore, \
     MAIN_CLASS := com.ibm.jvm.j9.dump.extract.Main, \


### PR DESCRIPTION
It would conflict with the anticipated tool from openjdk.

Issue: https://github.com/eclipse-openj9/openj9/issues/18193.