### PR TITLE
Run virtual/stress/Skynet with -Xnocompressedrefs

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
@@ -22,11 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test id=default
  * @summary Stress test virtual threads with a variation of the Skynet 1M benchmark
  * @requires vm.continuations
  * @requires !vm.debug | vm.gc != "Z"
- * @run main/othervm/timeout=300 -Xmx1g Skynet
+ * @run main/othervm/timeout=300 -Xmx1g -Xnocompressedrefs Skynet
  */
 
 /*


### PR DESCRIPTION
Skynet is a stress benchmark, which exceeds the below 4G capacity
of `-Xcompressedrefs`. The current workaround is to use
`-Xnocompressedrefs` where memory can be allocated outside the 4G
boundary. 

To run Skynet with `-Xcompressedrefs`, the following features will be
needed:
- Move unmounted continuation stacks out of the low memory area.
- Improve performance of the sub-4G allocator so that it doesn't
  regress under high memory usage.

Depends on eclipse-openj9/openj9#18251

Related: eclipse-openj9/openj9#16728

Related: eclipse-openj9/openj9#15781

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>