### PR TITLE
Replace date utility usage with DateUtil for SOURCE_DATE

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -517,7 +517,7 @@ run-preprocessors-j9 : stage-j9
 			OMR_DIR=$(OUTPUTDIR)/vm/omr \
 			SOURCETOOLS_DIR=$(call MixedPath,$(OPENJ9_TOPDIR))/sourcetools \
 			SPEC=$(OPENJ9_BUILDSPEC) \
-			UMA_OPTIONS_EXTRA="-buildDate $(shell date +'%Y%m%d')" \
+			UMA_OPTIONS_EXTRA="-buildDate $(shell $(JAVA_SMALL) $(TOPDIR)/make/src/classes/DateUtil.java --format=YYYYMMdd)" \
 			VERSION_MAJOR=$(VERSION_FEATURE) \
 			tools
 

--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -126,10 +126,7 @@ for i in "$@" ; do
 	esac
 done
 
-# clone OpenJ9 repos
-date '+[%F %T] Get OpenJ9 sources'
-START_TIME=$(date +%s)
-
+# Extract the various source repositories.
 for i in "${!git_urls[@]}" ; do
 	branch=${branches[$i]}
 
@@ -172,9 +169,6 @@ if [ ${pflag} = true ] ; then
 	# wait for all subprocesses to complete
 	wait
 fi
-
-END_TIME=$(date +%s)
-date "+[%F %T] OpenJ9 clone repositories finished in $(($END_TIME - $START_TIME)) seconds"
 
 for i in "${!git_urls[@]}" ; do
 	if [ -e /tmp/${i}.pid.rc ] ; then

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
 # ===========================================================================
 
 ###############################################################################
@@ -748,7 +748,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_REPRODUCIBLE_BUILD],
       AC_MSG_RESULT([$SOURCE_DATE, from SOURCE_DATE_EPOCH])
     else
       # Tell makefiles to take the time from configure
-      SOURCE_DATE=$($DATE +"%s")
+      SOURCE_DATE=$($JAVA $TOPDIR/make/src/classes/DateUtil.java)
       AC_MSG_RESULT([$SOURCE_DATE, from 'current' (default)])
     fi
   elif test "x$with_source_date" = xupdated; then


### PR DESCRIPTION
On some platforms, the date utility doesn't support the "%s" format specifier or supports neither the "-f" option nor the "-j" option. Use the boot jdk to run a java program instead.