### PR TITLE
Ensures time compensation is not less than checkpointRestoreTimeDelta

### DIFF
--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -588,7 +588,9 @@ class TimerThread extends Thread {
                             // A zero checkpointRestoreTimeDelta value indicates no Checkpoint performed yet,
                             // it can't be negative, otherwise a RestoreException already was thrown.
                             if (checkpointRestoreTimeDelta > 0) {
+                                // Ensure the time compensation in milliseconds is not less than the checkpoint restore time delta.
                                 task.nextExecutionTime += (checkpointRestoreTimeDelta / 1000000);
+                                task.nextExecutionTime += ((checkpointRestoreTimeDelta % 1000000 == 0) ? 0 : 1);
                                 // clear the flag - only one time adjustment required
                                 task.criuAdjustRequired = false;
                             }


### PR DESCRIPTION
Ensures time compensation is not less than checkpointRestoreTimeDelta

Ensure the time compensation in milliseconds is not less than the `checkpoint restore time delta`.

Related to 
* https://github.com/eclipse-openj9/openj9/pull/18369

Signed-off-by: Jason Feng <fengj@ca.ibm.com>