### PR TITLE
Remove definitions of unused make macros

### DIFF
--- a/closed/custom/modules/java.base/Lib.gmk
+++ b/closed/custom/modules/java.base/Lib.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -18,24 +18,17 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-################################################################################
 # Create the Java Native crypto library
 ifeq ($(WITH_OPENSSL), yes)
   $(eval $(call SetupJdkLibrary, BUILD_JNCRYPTO, \
       NAME := jncrypto, \
       OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKLIB) \
-                -c $(OPENSSL_CFLAGS), \
+      CFLAGS := $(CFLAGS_JDKLIB) $(OPENSSL_CFLAGS), \
       DISABLED_WARNINGS_gcc := sign-compare implicit-fallthrough unused-value, \
       DISABLED_WARNINGS_clang := sign-compare, \
       DISABLED_WARNINGS_microsoft := 4101 4244 4146 4018, \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-          $(call SET_SHARED_LIBRARY_ORIGIN), \
+      LDFLAGS := $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS_unix := $(LIBDL), \
   ))
   TARGETS += $(BUILD_JNCRYPTO)
 endif
-
-INCLUDE_CUSTOM_EXTENSION_SYMBOLS := $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/$(LIBRARY_PREFIX)jncrypto.symbols
-INCLUDE_CUSTOM_EXTENSION_LIB := BUILD_JNCRYPTO
-################################################################################


### PR DESCRIPTION
Neither of these is used anywhere:
```
  INCLUDE_CUSTOM_EXTENSION_SYMBOLS
  INCLUDE_CUSTOM_EXTENSION_LIB
```
Also remove redundant `-c` from `CFLAGS`.