### PR TITLE
Avoid Java 21 source features

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransLiterals.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransLiterals.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package com.sun.tools.javac.comp;
 
 import com.sun.tools.javac.code.Flags;
@@ -254,11 +260,12 @@ public final class TransLiterals extends TreeTranslator {
         }
 
         boolean isNamedProcessor(Name name) {
-            Symbol sym = switch (processor) {
-                case JCIdent ident -> ident.sym;
-                case JCFieldAccess access -> access.sym;
-                default -> null;
-            };
+            Symbol sym = null;
+            if (processor instanceof JCIdent ident) {
+                sym = ident.sym;
+            } else if (processor instanceof JCFieldAccess access) {
+                sym = access.sym;
+            }
             if (sym instanceof VarSymbol varSym) {
                 if (varSym.flags() == (Flags.PUBLIC | Flags.FINAL | Flags.STATIC) &&
                         varSym.name == name &&


### PR DESCRIPTION
At least temporarily until a newer boot JDK can be used.

Fixes: https://github.com/eclipse-openj9/openj9/issues/18486.