### PR TITLE
Add NotCheckpointSafe annotations to PhantomCleanable

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -48,6 +48,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
+		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \

--- a/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
+++ b/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 package jdk.internal.ref;
 
@@ -29,6 +34,10 @@ import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
 import java.lang.ref.PhantomReference;
 import java.util.Objects;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * PhantomCleanable subclasses efficiently encapsulate cleanup state and
@@ -83,6 +92,9 @@ public abstract class PhantomCleanable<T> extends PhantomReference<T>
     /**
      * Insert this PhantomCleanable after the list head.
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private void insert() {
         synchronized (list) {
             prev = list;
@@ -98,6 +110,9 @@ public abstract class PhantomCleanable<T> extends PhantomReference<T>
      * @return true if Cleanable was removed or false if not because
      * it had already been removed before
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private boolean remove() {
         synchronized (list) {
             if (next != this) {
@@ -116,6 +131,9 @@ public abstract class PhantomCleanable<T> extends PhantomReference<T>
      *
      * @return true if the list is empty
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     boolean isListEmpty() {
         synchronized (list) {
             return list == list.next;


### PR DESCRIPTION
Add NotCheckpointSafe annotations to PhantomCleanable to 
avoid blocking operations during restore in CRIU single 
thread mode, and fix the failures in the
cmdLineTester_criu_nonPortableRestore tests that occur 
due to blocking operations during restore in CRIU
single thread mode.

Issue: eclipse-openj9/openj9#18399
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>