### PR TITLE
[FFI/Jtreg_JDK22] Add permission for os.arch in the security policy

### DIFF
--- a/test/jdk/java/foreign/security.policy
+++ b/test/jdk/java/foreign/security.policy
@@ -1,6 +1,7 @@
 grant codeBase "file:${test.classes}/*" {
     // Permissions needed to run the test
     permission java.util.PropertyPermission "os.name", "read";
+    permission java.util.PropertyPermission "os.arch", "read";
     permission java.util.PropertyPermission "NativeTestHelper.DEFAULT_RANDOM.seed", "read";
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.foreign";
 };


### PR DESCRIPTION
The change ensure the system property required in OpenJ9
is permitted during the class initialization when the
test suite is executed.

Fixes: #eclipse-openj9/openj9/issues/18507

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>