### PR TITLE
Remove unnecessary interrupt

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1615,9 +1615,6 @@ public class Thread implements Runnable {
      */
     void exit() {
         try {
-            /* Refresh interrupted value so it is accurate when thread reference is removed. */
-            interrupted = interrupted();
-
             try {
                 // pop any remaining scopes from the stack, this may block
                 if (headStackableScopes != null) {


### PR DESCRIPTION
The current implementation contains some code from the j9 threading implementation. With openjdk threading we dont need a deadinterrupt (which the old code is attempting to simulate) field as the interrupt state is tracked in the JCL rather than the JVM.

Also, the old code actually clears the interrupt state which is incorrect.