### PR TITLE
Add Redhat NSS FIPS support on p/z linux platforms

### DIFF
--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -243,9 +243,9 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   endif # OPENJ9_ENABLE_JITSERVER
 endif # OPENSSL_BUNDLE_LIB_PATH
 ################################################################################
-# Copy the nss.fips.cfg only on x86 linux
+# Copy the nss.fips.cfg only on x86/p/z linux
 
-ifeq ($(OPENJDK_TARGET_OS)-$(OPENJDK_TARGET_CPU_ARCH), linux-x86)
+ifneq ($(filter linux-x86_64 linux-ppc64le linux-s390x, $(OPENJDK_TARGET_OS)-$(OPENJDK_TARGET_CPU)), )
   NSS_FIPS_CFG_SRC := $(TOPDIR)/closed/src/java.base/share/conf/security/nss.fips.cfg
   NSS_FIPS_CFG_DST := $(CONF_DST_DIR)/security/nss.fips.cfg
 

--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -64,7 +64,7 @@ public final class RestrictedSecurity {
 
     private static RestrictedSecurityProperties restricts;
 
-    private static final List<String> supportPlatforms = List.of("amd64");
+    private static final List<String> supportPlatforms = List.of("amd64", "ppc64le", "s390x");
 
     static {
         @SuppressWarnings("removal")

--- a/make/jdk/src/classes/build/tools/makejavasecurity/MakeJavaSecurity.java
+++ b/make/jdk/src/classes/build/tools/makejavasecurity/MakeJavaSecurity.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package build.tools.makejavasecurity;
 
 import java.io.*;
@@ -91,7 +97,8 @@ public class MakeJavaSecurity {
         }
 
         // Filter out platform-unrelated ones. We only support
-        // #ifdef, #ifndef, #else, and #endif. Nesting not supported (yet).
+        // #ifdef, #ifndef, #else, #endif and #if defined A || B.
+        // Other Nesting not supported (yet).
         int mode = 0;   // 0: out of block, 1: in match, 2: in non-match
         Iterator<String> iter = lines.iterator();
         while (iter.hasNext()) {
@@ -111,6 +118,18 @@ public class MakeJavaSecurity {
                     mode = line.endsWith(args[2]+"-"+args[3]) ? 2 : 1;
                 } else {
                     mode = line.endsWith(args[2]) ? 2 : 1;
+                }
+                iter.remove();
+            } else if (line.startsWith("#if defined ")) {
+                for (String l : line.split("\\|\\|")) {
+                    if (l.indexOf('-') > 0) {
+                        mode = l.trim().endsWith(args[2] + "-" + args[3]) ? 1 : 2;
+                    } else {
+                        mode = l.trim().endsWith(args[2]) ? 1 : 2;
+                    }
+                    if (mode == 1) {
+                        break;
+                    }
                 }
                 iter.remove();
             } else if (line.startsWith("#else")) {

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -85,7 +85,7 @@ security.provider.tbd=Apple
 #endif
 security.provider.tbd=SunPKCS11
 
-#ifdef linux-x86
+#if defined linux-x86 || defined linux-ppc || defined linux-s390
 #
 # Java Restricted Security Mode
 #


### PR DESCRIPTION
The Redhat NSS FIPS module is certified on ppc64le and s390x linux platforms. Adding the Redhat NSS FIPS support for the Semeru OpenJDK on these two platforms.