### PR TITLE
Avoid building test jars in the test image

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1279,7 +1279,7 @@ all-docs-bundles: docs-jdk-bundles docs-javase-bundles docs-reference-bundles
 # This target builds the test image
 test-image: prepare-test-image test-image-jdk-jtreg-native \
     test-image-demos-jdk test-image-libtest-jtreg-native \
-    test-image-lib test-image-lib-native
+    test-image-lib-native
 
 ifneq ($(JVM_TEST_IMAGE_TARGETS), )
   # If JVM_TEST_IMAGE_TARGETS is externally defined, use it instead of the


### PR DESCRIPTION
Some of them, such as jfr, don't build.

Issue https://github.com/eclipse-openj9/openj9/issues/18618

Tested via https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_mac_OpenJDK/216/

Note this is merging to openj9-staging which will automatically launch an Acceptance build.