### PR TITLE
Allow JDK 20 for boot jdk

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Start.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Start.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.javadoc.internal.tool;
 
 import java.io.File;
@@ -681,7 +687,7 @@ public class Start {
                 .toList();
         switch (suggestions.size()) {
             case 0 -> { }
-            case 1 -> showLinesUsingKey("main.did-you-mean", suggestions.getFirst());
+            case 1 -> showLinesUsingKey("main.did-you-mean", suggestions.get(0));
             default -> showLinesUsingKey("main.did-you-mean-one-of", String.join(" ", suggestions));
         }
         showLinesUsingKey("main.for-more-details-see-usage");


### PR DESCRIPTION
Temporary workaround for https://github.com/eclipse-openj9/openj9/issues/18707.