### PR TITLE
Temporarily restore Thread/ThreadGroup suspend/resume/stop

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1819,6 +1819,44 @@ public class Thread implements Runnable {
      */
     boolean alive() {
         return eetop != NO_REF;
+    }
+
+    /**
+     * Throws {@code UnsupportedOperationException}.
+     *
+     * @throws  UnsupportedOperationException always
+     *
+     * @deprecated This method was originally specified to suspend a thread.
+     *     It was inherently deadlock-prone. If the target thread held a lock on
+     *     a monitor protecting a critical system resource when it was suspended,
+     *     no thread could access the resource until the target thread was resumed.
+     *     If the thread intending to resume the target thread attempted to lock
+     *     the monitor prior to calling {@code resume}, deadlock would result.
+     *     Such deadlocks typically manifested themselves as "frozen" processes.
+     *     For more information, see
+     *     <a href="{@docRoot}/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html">Why
+     *     are Thread.stop, Thread.suspend and Thread.resume Deprecated?</a>.
+     */
+    @Deprecated(since="1.2", forRemoval=true)
+    public final void suspend() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Throws {@code UnsupportedOperationException}.
+     *
+     * @throws  UnsupportedOperationException always
+     *
+     * @deprecated This method was originally specified to resume a thread
+     *     suspended with {@link #suspend()}. Suspending a thread was
+     *     inherently deadlock-prone.
+     *     For more information, see
+     *     <a href="{@docRoot}/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html">Why
+     *     are Thread.stop, Thread.suspend and Thread.resume Deprecated?</a>.
+     */
+    @Deprecated(since="1.2", forRemoval=true)
+    public final void resume() {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -555,6 +555,17 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
     }
 
     /**
+     * Throws {@code UnsupportedOperationException}.
+     *
+     * @deprecated This method was originally specified to stop all threads in
+     *             the thread group. It was inherently unsafe.
+     */
+    @Deprecated(since="1.2", forRemoval=true)
+    public final void stop() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Interrupts all {@linkplain Thread#isAlive() live} platform threads in
      * this thread group and its subgroups.
      *
@@ -574,6 +585,28 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
                 thread.interrupt();
             }
         }
+    }
+
+    /**
+     * Throws {@code UnsupportedOperationException}.
+     *
+     * @deprecated This method was originally specified to suspend all threads
+     *             in the thread group.
+     */
+    @Deprecated(since="1.2", forRemoval=true)
+    public final void suspend() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Throws {@code UnsupportedOperationException}.
+     *
+     * @deprecated This method was originally specified to resume all threads
+     *             in the thread group.
+     */
+    @Deprecated(since="1.2", forRemoval=true)
+    public final void resume() {
+        throw new UnsupportedOperationException();
     }
 
     /**


### PR DESCRIPTION
Until https://github.com/eclipse-openj9/openj9/issues/18758 can be addressed, this restores referenced API in `Thread` and `ThreadGroup`, by partially reverting
* 8320532: Remove Thread/ThreadGroup suspend/resume
* 8320786: Remove ThreadGroup.stop