### PR TITLE
Revert PlatformLayouts to remove unused code

### DIFF
--- a/test/jdk/java/foreign/callarranger/platform/PlatformLayouts.java
+++ b/test/jdk/java/foreign/callarranger/platform/PlatformLayouts.java
@@ -21,12 +21,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
- * ===========================================================================
- */
-
 package platform;
 
 import jdk.internal.foreign.abi.SharedUtils;
@@ -287,61 +281,6 @@ public final class PlatformLayouts {
          * The {@code long} native type.
          */
         public static final ValueLayout.OfLong C_LONG = ValueLayout.JAVA_LONG;
-
-        /**
-         * The {@code long long} native type.
-         */
-        public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG;
-
-        /**
-         * The {@code float} native type.
-         */
-        public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT;
-
-        /**
-         * The {@code double} native type.
-         */
-        public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
-
-        /**
-         * The {@code T*} native type.
-         */
-        public static final AddressLayout C_POINTER = SharedUtils.C_POINTER;
-
-    }
-
-    /**
-     * This class defines layout constants modelling standard primitive types supported by the AIX PPC64 ABI.
-     */
-    public static final class AIX {
-
-        // Suppresses default constructor, ensuring non-instantiability.
-        private AIX() {}
-
-        /**
-         * The {@code bool} native type.
-         */
-        public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
-
-        /**
-         * The {@code char} native type.
-         */
-        public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
-
-        /**
-         * The {@code short} native type.
-         */
-        public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
-
-        /**
-         * The {@code int} native type.
-         */
-        public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT;
-
-        /**
-         * The {@code long} native type.
-         */
-        public static final ValueLayout.OfInt C_LONG = ValueLayout.JAVA_INT;
 
         /**
          * The {@code long long} native type.


### PR DESCRIPTION
It previously declared nested type AIX which was not used.