### PR TITLE
Include legal files when bundling OpenJCEPlus

### DIFF
--- a/closed/make/modules/openjceplus/Copy.gmk
+++ b/closed/make/modules/openjceplus/Copy.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,6 +21,15 @@
 include $(TOPDIR)/closed/CopySupport.gmk
 
 ifeq (true,$(BUILD_OPENJCEPLUS))
+  # Copy OpenJCEPlus legal files.
+  $(call openj9_copy_files,, \
+      $(OPENJCEPLUS_TOPDIR)/LICENSE \
+      $(LEGAL_DST_DIR)/OPENJCEPLUS_LICENSE)
+
+  $(call openj9_copy_files,, \
+      $(OPENJCEPLUS_TOPDIR)/NOTICES.md \
+      $(LEGAL_DST_DIR)/NOTICES.md)
+
   # Copy OpenJCEPlus native libraries.
   $(eval $(call SetupCopyFiles, OPENJCEPLUS_JGSKIT_LIBS_COPY, \
       SRC := $(OPENJCEPLUS_TOPDIR)/target, \


### PR DESCRIPTION
The `LICENSE` and `NOTICES.md` files that are part of the `OpenJCEPlus` open-source project need to be included in the `OpenJDK`'s legal subdirectory, as well as within the corresponding `jmod`, when said project is bundled.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)