### PR TITLE
Stop using preprocessor flag Sidecar19-SE

### DIFF
--- a/closed/src/java.rmi/share/classes/module-info.java.extra
+++ b/closed/src/java.rmi/share/classes/module-info.java.extra
@@ -1,14 +1,14 @@
-/*[INCLUDE-IF Sidecar19-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 9]*/
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
  * ===========================================================================
- * 
+ *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  
+ * published by the Free Software Foundation.
  *
- * IBM designates this particular file as subject to the "Classpath" exception 
+ * IBM designates this particular file as subject to the "Classpath" exception
  * as provided by IBM in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
@@ -19,7 +19,7 @@
  *
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * ===========================================================================
  */
   uses com.ibm.sharedclasses.spi.SharedClassProvider;


### PR DESCRIPTION
I plan to remove flags like `Sidecar19-SE` and `Sidecar19-SE-OpenJ9` that can be expressed in terms of `JAVA_SPEC_VERSION`.