### PR TITLE
Add s390x-linux to platforms bundling OpenJCEPlus

### DIFF
--- a/closed/make/modules/openjceplus/Lib.gmk
+++ b/closed/make/modules/openjceplus/Lib.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -35,6 +35,8 @@ ifeq ($(call isTargetOs, aix), true)
 else ifeq ($(call isTargetOs, linux), true)
   ifeq ($(call isTargetCpu, ppc64le), true)
     OPENJCEPLUS_JGSKIT_PLATFORM := ppcle-linux64
+  else ifeq ($(call isTargetCpu, s390x), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := s390-linux64
   else ifeq ($(call isTargetCpu, x86_64), true)
     OPENJCEPLUS_JGSKIT_PLATFORM := x86-linux64
   endif

--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -78,7 +78,7 @@ public final class RestrictedSecurity {
         supportedPlatformsNSS.put("Arch", List.of("amd64", "ppc64le", "s390x"));
         supportedPlatformsNSS.put("OS", List.of("Linux"));
 
-        supportedPlatformsOpenJCEPlus.put("Arch", List.of("amd64", "ppc64"));
+        supportedPlatformsOpenJCEPlus.put("Arch", List.of("amd64", "ppc64", "s390x"));
         supportedPlatformsOpenJCEPlus.put("OS", List.of("Linux", "AIX", "Windows"));
 
         @SuppressWarnings("removal")

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -155,7 +155,7 @@ RestrictedSecurity.NSS.140-2.securerandom.provider = SunPKCS11-NSS-FIPS
 RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 #endif
 
-#if defined aix-ppc || defined linux-ppc || defined linux-x86 || defined windows
+#if defined aix-ppc || defined linux-ppc || defined linux-s390 || defined linux-x86 || defined windows
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = true
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true


### PR DESCRIPTION
Bundling of `OpenJCEPlus` with the `OpenJDK` is now supported in `s390x-linux` platforms.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)