### PR TITLE
Restore required synchronization in Thread.getAndClearInterrupt()

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1795,15 +1795,17 @@ public class Thread implements Runnable {
         if (com.ibm.oti.vm.VM.isJVMInSingleThreadedMode()) {
             return interruptedImpl();
         }
-        boolean oldValue = interrupted;
-        // We may have been interrupted the moment after we read the field,
-        // so only clear the field if we saw that it was set and will return
-        // true; otherwise we could lose an interrupt.
-        if (oldValue) {
-            interrupted = false;
-            clearInterruptEvent();
+        synchronized (interruptLock) {
+            boolean oldValue = interrupted;
+            // We may have been interrupted the moment after we read the field,
+            // so only clear the field if we saw that it was set and will return
+            // true; otherwise we could lose an interrupt.
+            if (oldValue) {
+                interrupted = false;
+                clearInterruptEvent();
+            }
+            return oldValue;
         }
-        return oldValue;
     }
 
     /**


### PR DESCRIPTION
It was removed in #746, but should not have been. The consequences were seen in ibmruntimes/openj9-openjdk-jdk21#133 which sought to remove the same synchronization.