### PR TITLE
Use LDR_CNTRL on AIX to use 64KB pages and modify removeAixExpectedVars

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -311,6 +311,11 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     const char *mallocOptionsValue = "multiheap,considersize";
     if (setenv(mallocOptionsName, mallocOptionsValue, 0) != 0) {
         fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap,considersize') failed: performance may be affected\n");
+    }
+    const char * ldrCntrlName = "LDR_CNTRL";
+    const char *ldrCntrlValue = "TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K";
+    if (setenv(ldrCntrlName, ldrCntrlValue, 0) != 0) {
+        fprintf(stderr, "setenv('LDR_CNTRL=TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K') failed: performance may be affected\n");
     }
 #endif
 

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -23,7 +23,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -811,8 +811,9 @@ public class Basic {
      */
     private static String removeAixExpectedVars(String vars) {
         String cleanedVars = vars.replace("AIXTHREAD_GUARDPAGES=0,", "");
-        // OpenJ9 adds MALLOCOPTIONS
+        // OpenJ9 adds MALLOCOPTIONS and LDR_CNTRL
         cleanedVars = cleanedVars.replace("MALLOCOPTIONS=multiheap,considersize,", "");
+        cleanedVars = cleanedVars.replace("LDR_CNTRL=TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K,", "");
         return cleanedVars;
     }
 


### PR DESCRIPTION
We can improve performance on AIX by setting LDR_CNTRL to use 64KB pages by default.

OpenJ9 Tracker: https://github.com/eclipse-openj9/openj9/issues/19052