### PR TITLE
Adapt to recent build changes for Windows

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -108,8 +108,9 @@ ifeq (windows,$(OPENJDK_TARGET_OS))
   # convert windows path to unix path
   UnixPath = $(shell $(PATHTOOL) -u $1)
   # set Visual Studio environment
-  # wrap PATH in quotes as it contains spaces (unix path)
-  EXPORT_COMPILER_ENV_VARS := PATH="$(PATH)"
+  # - wrap LIB in single-quotes to hide backslashes from make
+  # - wrap PATH in double-quotes as it may contain spaces (unix path)
+  EXPORT_COMPILER_ENV_VARS := LIB='$(OPENJ9_VS_LIB)' PATH="$(PATH)"
 else ifeq (zos,$(OPENJDK_TARGET_OS))
   UnixPath = $1
   # Allow options to follow the input file name

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -832,7 +832,7 @@ AC_DEFUN([OPENJ9_GENERATE_TOOL_WRAPPERS],
   OPENJ9_GENERATE_TOOL_WRAPPER([jar], [$JAR])
   OPENJ9_GENERATE_TOOL_WRAPPER([java], [$JAVA])
   OPENJ9_GENERATE_TOOL_WRAPPER([javac], [$JAVAC])
-  OPENJ9_GENERATE_TOOL_WRAPPER([lib], [$AR])
+  OPENJ9_GENERATE_TOOL_WRAPPER([lib], [$LIB])
   OPENJ9_GENERATE_TOOL_WRAPPER([link], [$LD])
   OPENJ9_GENERATE_TOOL_WRAPPER([mc], [$MC])
   OPENJ9_GENERATE_TOOL_WRAPPER([ml], [$AS])

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -111,7 +111,7 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
   # Set environment variables for Microsoft Visual Studio toolchain.
   # Note that PATH is set in spec.gmk.
   export INCLUDE := @OPENJ9_VS_INCLUDE@
-  export LIB := @OPENJ9_VS_LIB@
+  OPENJ9_VS_LIB := @OPENJ9_VS_LIB@
   export MSVC_VERSION := @TOOLCHAIN_VERSION@
 endif
 

--- a/closed/autoconf/toolchain.cmake.in
+++ b/closed/autoconf/toolchain.cmake.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -18,9 +18,10 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # =========================================================================
 
-
-# Setting CMAKE_SYSTEM_NAME forces CMake into cross-compile mode, so only set it if we need to
-# Note: We consider Windows to be a cross-compile since CMake considers cygwin to be a different platform than Windows.
+# Setting CMAKE_SYSTEM_NAME forces CMake into cross-compile mode, so only set
+# it if we need to.
+# Note: We consider Windows to be a cross-compile since CMake considers cygwin
+# to be a different platform than Windows.
 if("@COMPILE_TYPE@" STREQUAL "cross" OR  "@OPENJDK_TARGET_OS@" STREQUAL "windows")
 	# CMAKE_SYSTEM_NAME expects the system name to start with a capital.
 	set(temp_system_name "@OPENJDK_TARGET_OS@")
@@ -55,11 +56,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	separate_arguments(FIXPATH UNIX_COMMAND "@FIXPATH@")
 	set(OMR_EXE_LAUNCHER "${FIXPATH}" CACHE STRING "")
 
-	# CMake will test to see if compiler works by getting it to compile files in
-	# /usr/lib, which fixpath wont translate
+	# CMake will test to see if compiler works by getting it to compile files
+	# in /usr/lib, which fixpath won't translate.
 	set(CMAKE_C_COMPILER_WORKS True CACHE BOOL "")
 	set(CMAKE_CXX_COMPILER_WORKS True CACHE BOOL "")
-
 else()
 	if(NOT CMAKE_C_COMPILER)
 		set(CMAKE_C_COMPILER "@CC@")


### PR DESCRIPTION
On Windows, the library creation utility is now captured in `$(LIB)` instead of `$(AR)`. Define `OPENJ9_VS_LIB` instead of `LIB` (to be exported as `LIB` where needed).

Fixes: https://github.com/eclipse-openj9/openj9/issues/19049.