### PR TITLE
[FFI/JTreg] Remove the pragma lines for AIX in test suites

### DIFF
--- a/test/jdk/java/foreign/nested/libNested.c
+++ b/test/jdk/java/foreign/nested/libNested.c
@@ -21,13 +21,16 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 #ifdef _WIN64
 #define EXPORT __declspec(dllexport)
 #else
 #define EXPORT
-#endif
-#ifdef _AIX
-#pragma align (natural)
 #endif
 
 struct S1{ double f0; long long f1; double f2; int f3; };
@@ -95,7 +98,3 @@ EXPORT struct S13 test_S13(struct S13 arg, struct S13(*cb)(struct S13)) { return
 EXPORT struct S14 test_S14(struct S14 arg, struct S14(*cb)(struct S14)) { return cb(arg); }
 EXPORT union U16 test_U16(union U16 arg, union U16(*cb)(union U16)) { return cb(arg); }
 EXPORT struct S15 test_S15(struct S15 arg, struct S15(*cb)(struct S15)) { return cb(arg); }
-
-#ifdef _AIX
-#pragma align (reset)
-#endif

--- a/test/jdk/java/foreign/shared.h
+++ b/test/jdk/java/foreign/shared.h
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 #ifdef __clang__
 #pragma clang optimize off
 #elif defined __GNUC__
@@ -33,9 +39,6 @@
 #define EXPORT __declspec(dllexport)
 #else
 #define EXPORT
-#endif
-#ifdef _AIX
-#pragma align (natural)
 #endif
 
 struct S_I { int p0; };
@@ -123,7 +126,3 @@ struct S_PPF { void* p0; void* p1; float p2; };
 struct S_PPD { void* p0; void* p1; double p2; };
 struct S_PPP { void* p0; void* p1; void* p2; };
 struct S_FFFF { float p0; float p1; float p2; float p3; };
-
-#ifdef _AIX
-#pragma align (reset)
-#endif


### PR DESCRIPTION
The intention of the changes is to avoid conflicts
with our own code with 4-byte alignment for double on
AIX which already supports both the default setting
by the compiler and the natural alignment for double.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
