### PR TITLE
Fix compile issues with xlc on AIX

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -68,8 +68,7 @@ id="toc-native-compiler-toolchain-requirements">Native Compiler
 <li><a href="#apple-xcode" id="toc-apple-xcode">Apple Xcode</a></li>
 <li><a href="#microsoft-visual-studio"
 id="toc-microsoft-visual-studio">Microsoft Visual Studio</a></li>
-<li><a href="#ibm-open-xl-cc" id="toc-ibm-open-xl-cc">IBM Open XL
-C/C++</a></li>
+<li><a href="#ibm-xl-cc" id="toc-ibm-xl-cc">IBM XL C/C++</a></li>
 </ul></li>
 <li><a href="#boot-jdk-requirements" id="toc-boot-jdk-requirements">Boot
 JDK Requirements</a>
@@ -674,10 +673,11 @@ the following line: (note that the " characters are essential)</p>
 version number accordingly. If you have not installed the
 <code>BuildTools</code>, but e.g. <code>Professional</code>, adjust the
 product ID accordingly.</p>
-<h3 id="ibm-open-xl-cc">IBM Open XL C/C++</h3>
-<p>The minimum accepted version of Open XL is 17.1.1.4. This is in
-essence clang 15, and will be treated as such by the OpenJDK build
-system.</p>
+<h3 id="ibm-xl-cc">IBM XL C/C++</h3>
+<p>Please consult the AIX section of the <a
+href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported
+Build Platforms</a> OpenJDK Build Wiki page for details about which
+versions of XLC are supported.</p>
 <h2 id="boot-jdk-requirements">Boot JDK Requirements</h2>
 <p>Paradoxically, building the JDK requires a pre-existing JDK. This is
 called the "boot JDK". The boot JDK does not, however, have to be a JDK

--- a/doc/building.md
+++ b/doc/building.md
@@ -487,10 +487,11 @@ that the " characters are essential)
 accordingly. If you have not installed the `BuildTools`, but e.g.
 `Professional`, adjust the product ID accordingly.
 
-### IBM Open XL C/C++
+### IBM XL C/C++
 
-The minimum accepted version of Open XL is 17.1.1.4. This is in essence clang
-15, and will be treated as such by the OpenJDK build system.
+Please consult the AIX section of the [Supported Build Platforms](
+https://wiki.openjdk.org/display/Build/Supported+Build+Platforms) OpenJDK Build
+Wiki page for details about which versions of XLC are supported.
 
 ## Boot JDK Requirements
 

--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -359,6 +359,9 @@ AC_DEFUN_ONCE([BPERF_SETUP_PRECOMPILED_HEADERS],
   if test "x$ICECC" != "x"; then
     AC_MSG_RESULT([no, does not work effectively with icecc])
     PRECOMPILED_HEADERS_AVAILABLE=false
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    AC_MSG_RESULT([no, does not work with xlc])
+    PRECOMPILED_HEADERS_AVAILABLE=false
   elif test "x$TOOLCHAIN_TYPE" = xgcc; then
     # Check that the compiler actually supports precomp headers.
     echo "int alfa();" > conftest.h

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -77,6 +77,12 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
       fi
     fi
 
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    SHARED_LIBRARY_FLAGS="-qmkshrobj -bM:SRE -bnoentry"
+    SET_EXECUTABLE_ORIGIN=""
+    SET_SHARED_LIBRARY_ORIGIN=''
+    SET_SHARED_LIBRARY_NAME=''
+
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     SHARED_LIBRARY_FLAGS="-dll"
     SET_EXECUTABLE_ORIGIN=''
@@ -146,6 +152,8 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
 
     CFLAGS_DEBUG_SYMBOLS="-g ${GDWARF_FLAGS}"
     ASFLAGS_DEBUG_SYMBOLS="-g"
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    CFLAGS_DEBUG_SYMBOLS="-g1"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     CFLAGS_DEBUG_SYMBOLS="-Z7"
   fi
@@ -211,7 +219,11 @@ AC_DEFUN([DEBUG_PREFIX_MAP_GCC_INCLUDE_PATHS],
 AC_DEFUN([FLAGS_SETUP_WARNINGS],
 [
   # Set default value.
-  WARNINGS_AS_ERRORS_DEFAULT=true
+  if test "x$TOOLCHAIN_TYPE" != xxlc; then
+    WARNINGS_AS_ERRORS_DEFAULT=true
+  else
+    WARNINGS_AS_ERRORS_DEFAULT=false
+  fi
 
   UTIL_ARG_ENABLE(NAME: warnings-as-errors, DEFAULT: $WARNINGS_AS_ERRORS_DEFAULT,
       RESULT: WARNINGS_AS_ERRORS,
@@ -260,6 +272,15 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       WARNINGS_ENABLE_ALL="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
 
       DISABLED_WARNINGS="unknown-warning-option unused-parameter unused"
+      ;;
+
+    xlc)
+      DISABLE_WARNING_PREFIX="-Wno-"
+      CFLAGS_WARNINGS_ARE_ERRORS="-qhalt=w"
+
+      # Possibly a better subset than "all" is "lan:trx:ret:zea:cmp:ret"
+      WARNINGS_ENABLE_ALL="-qinfo=all -qformat=all"
+      DISABLED_WARNINGS=""
       ;;
   esac
   AC_SUBST(DISABLE_WARNING_PREFIX)
@@ -342,6 +363,15 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_SIZE="-Os"
     C_O_FLAG_DEBUG="-O0"
     C_O_FLAG_NONE="-O0"
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    C_O_FLAG_HIGHEST_JVM="-O3 -qhot=level=1 -qinline -qinlglue"
+    C_O_FLAG_HIGHEST="-O3 -qhot=level=1 -qinline -qinlglue"
+    C_O_FLAG_HI="-O3 -qinline -qinlglue"
+    C_O_FLAG_NORM="-O2"
+    C_O_FLAG_DEBUG="-qnoopt"
+    # FIXME: Value below not verified.
+    C_O_FLAG_DEBUG_JVM=""
+    C_O_FLAG_NONE="-qnoopt"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     C_O_FLAG_HIGHEST_JVM="-O2 -Oy-"
     C_O_FLAG_HIGHEST="-O2"
@@ -485,6 +515,12 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   else
     DEBUG_CFLAGS_JDK="-DDEBUG"
 
+    if test "x$TOOLCHAIN_TYPE" = xxlc; then
+      # We need '-qminimaltoc' or '-qpic=large -bbigtoc' if the TOC overflows.
+      # Hotspot now overflows its 64K TOC (currently only for debug),
+      # so for debug we build with '-qpic=large -bbigtoc'.
+      DEBUG_CFLAGS_JVM="-qpic=large"
+    fi
     if test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
       DEBUG_CFLAGS_JVM="-fpic -mcmodel=large"
     fi
@@ -501,6 +537,9 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     ALWAYS_DEFINES_JVM="-D_GNU_SOURCE -D_REENTRANT"
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     ALWAYS_DEFINES_JVM="-D_GNU_SOURCE"
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    ALWAYS_DEFINES_JVM="-D_REENTRANT"
+    ALWAYS_DEFINES_JDK="-D_GNU_SOURCE -D_REENTRANT -DSTDC"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # Access APIs for Windows 8 and above
     # see https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
@@ -565,6 +604,12 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     fi
     TOOLCHAIN_CFLAGS_JDK="$TOOLCHAIN_CFLAGS_JDK -fvisibility=hidden"
 
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    # Suggested additions: -qsrcmsg to get improved error reporting
+    # set -qtbtable=full for a better traceback table/better stacks in hs_err when xlc16 is used
+    TOOLCHAIN_CFLAGS_JDK="-qtbtable=full -qchars=signed -qfullpath -qsaveopt -qstackprotect"  # add on both CFLAGS
+    TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced -fno-exceptions \
+        -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # The -utf-8 option sets source and execution character sets to UTF-8 to enable correct
     # compilation of all source files regardless of the active code page on Windows.
@@ -573,7 +618,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   fi
 
   # CFLAGS C language level for JDK sources (hotspot only uses C++)
-  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang || test "x$TOOLCHAIN_TYPE" = xxlc; then
     LANGSTD_CFLAGS="-std=c11"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     LANGSTD_CFLAGS="-std:c11"
@@ -581,12 +626,12 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   TOOLCHAIN_CFLAGS_JDK_CONLY="$LANGSTD_CFLAGS $TOOLCHAIN_CFLAGS_JDK_CONLY"
 
   # CXXFLAGS C++ language level for all of JDK, including Hotspot.
-  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang || test "x$TOOLCHAIN_TYPE" = xxlc; then
     LANGSTD_CXXFLAGS="-std=c++14"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     LANGSTD_CXXFLAGS="-std:c++14"
   else
-    AC_MSG_ERROR([Cannot enable C++14 for this toolchain])
+    AC_MSG_ERROR([Don't know how to enable C++14 for this toolchain])
   fi
   TOOLCHAIN_CFLAGS_JDK_CXXONLY="$TOOLCHAIN_CFLAGS_JDK_CXXONLY $LANGSTD_CXXFLAGS"
   TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM $LANGSTD_CXXFLAGS"
@@ -605,6 +650,8 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     WARNING_CFLAGS="$WARNINGS_ENABLE_ALL"
 
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    WARNING_CFLAGS=""  # currently left empty
   fi
 
   # Set some additional per-OS defines.
@@ -629,16 +676,31 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     PICFLAG="-fPIC"
     PIEFLAG="-fPIE"
+  elif test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
+    JVM_PICFLAG="-fpic -mcmodel=large -Wl,-bbigtoc
+    JDK_PICFLAG="-fpic
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    # '-qpic' defaults to 'qpic=small'. This means that the compiler generates only
+    # one instruction for accessing the TOC. If the TOC grows larger than 64K, the linker
+    # will have to patch this single instruction with a call to some out-of-order code which
+    # does the load from the TOC. This is of course slower, and we also would have
+    # to use '-bbigtoc' for linking anyway so we could also change the PICFLAG to 'qpic=large'.
+    # With 'qpic=large' the compiler will by default generate a two-instruction sequence which
+    # can be patched directly by the linker and does not require a jump to out-of-order code.
+    #
+    # Since large TOC causes perf. overhead, only pay it where we must. Currently this is
+    # for all libjvm variants (both gtest and normal) but no other binaries. So, build
+    # libjvm with -qpic=large and link with -bbigtoc.
+    JVM_PICFLAG="-qpic=large"
+    JDK_PICFLAG="-qpic"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     PICFLAG=""
   fi
 
-  if test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
-    JVM_PICFLAG="-fpic -mcmodel=large"
-  else
+  if test "x$TOOLCHAIN_TYPE" != xxlc; then
     JVM_PICFLAG="$PICFLAG"
+    JDK_PICFLAG="$PICFLAG"
   fi
-  JDK_PICFLAG="$PICFLAG"
 
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
     # Linking is different on MacOSX
@@ -688,7 +750,8 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -DARCH='\"$FLAGS_CPU_LEGACY\"' \
       -D$FLAGS_CPU_LEGACY"
 
-  if test "x$FLAGS_CPU_BITS" = x64; then
+  if test "x$FLAGS_CPU_BITS" = x64 && test "x$FLAGS_OS" != xaix; then
+    # xlc on AIX defines _LP64=1 by default and issues a warning if we redefine it.
     $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_LP64=1"
     $1_DEFINES_CPU_JVM="${$1_DEFINES_CPU_JVM} -D_LP64=1"
   fi
@@ -763,6 +826,11 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then
       $1_CFLAGS_CPU="-mcpu=pwr8"
+    fi
+
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    if test "x$FLAGS_CPU" = xppc64; then
+      $1_CFLAGS_CPU_JVM="-qarch=ppc64"
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then

--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -26,6 +26,10 @@
 ################################################################################
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+
 AC_DEFUN([FLAGS_SETUP_LDFLAGS],
 [
   FLAGS_SETUP_LDFLAGS_HELPER
@@ -74,10 +78,15 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       BASIC_LDFLAGS="-Wl,--exclude-libs,ALL"
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then
-      BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnorwexec -Wl,-bnolibpath -Wl,-bnoexpall \
+      BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnolibpath -Wl,-bnoexpall \
         -Wl,-bernotok -Wl,-bdatapsize:64k -Wl,-btextpsize:64k -Wl,-bstackpsize:64k"
       BASIC_LDFLAGS_JVM_ONLY="$BASIC_LDFLAGS_JVM_ONLY -Wl,-lC_r -Wl,-bbigtoc"
     fi
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    BASIC_LDFLAGS="-b64 -brtl -bnolibpath -bnoexpall -bernotok -btextpsize:64K \
+        -bdatapsize:64K -bstackpsize:64K"
+    # libjvm.so has gotten too large for normal TOC size; compile with qpic=large and link with bigtoc
+    BASIC_LDFLAGS_JVM_ONLY="-Wl,-lC_r -bbigtoc"
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     BASIC_LDFLAGS="-opt:ref"
@@ -105,6 +114,14 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       if test x$DEBUG_LEVEL = xrelease; then
         DEBUGLEVEL_LDFLAGS_JDK_ONLY="$DEBUGLEVEL_LDFLAGS_JDK_ONLY -Wl,-O1"
       fi
+    fi
+
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    # We need '-qminimaltoc' or '-qpic=large -bbigtoc' if the TOC overflows.
+    # Hotspot now overflows its 64K TOC (currently only for debug),
+    # so we build with '-qpic=large -bbigtoc'.
+    if test "x$DEBUG_LEVEL" != xrelease; then
+      DEBUGLEVEL_LDFLAGS_JVM_ONLY="$DEBUGLEVEL_LDFLAGS_JVM_ONLY -bbigtoc"
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -261,9 +261,12 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
   # The sysroot flags are needed for configure to be able to run the compilers
   FLAGS_SETUP_SYSROOT_FLAGS
 
+  # For xlc, the word size flag is required for correct behavior.
   # For clang/gcc, the flag is only strictly required for reduced builds, but
   # set it always where possible (x86 and ppc).
-  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
+  if test "x$TOOLCHAIN_TYPE" = xxlc; then
+    MACHINE_FLAG="-q${OPENJDK_TARGET_CPU_BITS}"
+  elif test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     if test "x$OPENJDK_TARGET_CPU_ARCH" = xx86 &&
         test "x$OPENJDK_TARGET_CPU" != xx32 ||
         test "x$OPENJDK_TARGET_CPU_ARCH" = xppc; then
@@ -318,6 +321,47 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
 
 AC_DEFUN([FLAGS_SETUP_TOOLCHAIN_CONTROL],
 [
+  # COMPILER_TARGET_BITS_FLAG  : option for selecting 32- or 64-bit output
+  # COMPILER_COMMAND_FILE_FLAG : option for passing a command file to the compiler
+  # COMPILER_BINDCMD_FILE_FLAG : option for specifying a file which saves the binder
+  #                              commands produced by the link step (currently AIX only)
+  if test "x$TOOLCHAIN_TYPE" = xxlc; then
+    COMPILER_TARGET_BITS_FLAG="-q"
+    COMPILER_COMMAND_FILE_FLAG="-f"
+    COMPILER_BINDCMD_FILE_FLAG="-bloadmap:"
+  else
+    COMPILER_TARGET_BITS_FLAG="-m"
+    COMPILER_COMMAND_FILE_FLAG="@"
+    COMPILER_BINDCMD_FILE_FLAG=""
+
+    # Check if @file is supported by gcc
+    if test "x$TOOLCHAIN_TYPE" = xgcc; then
+      AC_MSG_CHECKING([if @file is supported by gcc])
+      # Extra empty "" to prevent ECHO from interpreting '--version' as argument
+      $ECHO "" "--version" > command.file
+      # Redirect stderr and stdout to config.log (AS_MESSAGE_LOG_FD) via merge
+      if $CXX @command.file 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD; then
+        AC_MSG_RESULT(yes)
+        COMPILER_COMMAND_FILE_FLAG="@"
+      else
+        AC_MSG_RESULT(no)
+        COMPILER_COMMAND_FILE_FLAG=
+      fi
+      $RM command.file
+    fi
+  fi
+
+  AC_SUBST(COMPILER_TARGET_BITS_FLAG)
+  AC_SUBST(COMPILER_COMMAND_FILE_FLAG)
+  AC_SUBST(COMPILER_BINDCMD_FILE_FLAG)
+
+  # Check that the compiler supports -mX (or -qX on AIX) flags
+  # Set COMPILER_SUPPORTS_TARGET_BITS_FLAG to 'true' if it does
+  FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${COMPILER_TARGET_BITS_FLAG}${OPENJDK_TARGET_CPU_BITS}],
+      IF_TRUE: [COMPILER_SUPPORTS_TARGET_BITS_FLAG=true],
+      IF_FALSE: [COMPILER_SUPPORTS_TARGET_BITS_FLAG=false])
+  AC_SUBST(COMPILER_SUPPORTS_TARGET_BITS_FLAG)
+
   if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     CC_OUT_OPTION=-Fo
   else
@@ -332,6 +376,8 @@ AC_DEFUN([FLAGS_SETUP_TOOLCHAIN_CONTROL],
     GENDEPS_FLAGS="-MMD -MF"
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     GENDEPS_FLAGS="-MMD -MF"
+  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+    GENDEPS_FLAGS="-qmakedep=gcc -MF"
   fi
   AC_SUBST(GENDEPS_FLAGS)
 ])

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -477,7 +477,7 @@ MACOSX_VERSION_MAX := @MACOSX_VERSION_MAX@
 MACOSX_CODESIGN_MODE := @MACOSX_CODESIGN_MODE@
 MACOSX_CODESIGN_IDENTITY := @MACOSX_CODESIGN_IDENTITY@
 
-# Toolchain type: gcc, clang, microsoft...
+# Toolchain type: gcc, clang, xlc, microsoft...
 TOOLCHAIN_TYPE := @TOOLCHAIN_TYPE@
 TOOLCHAIN_VERSION := @TOOLCHAIN_VERSION@
 CC_VERSION_NUMBER := @CC_VERSION_NUMBER@
@@ -485,6 +485,17 @@ CXX_VERSION_NUMBER := @CXX_VERSION_NUMBER@
 
 # Legacy support
 HOTSPOT_TOOLCHAIN_TYPE := @HOTSPOT_TOOLCHAIN_TYPE@
+
+# Option used to tell the compiler whether to create 32- or 64-bit executables
+COMPILER_TARGET_BITS_FLAG := @COMPILER_TARGET_BITS_FLAG@
+COMPILER_SUPPORTS_TARGET_BITS_FLAG := @COMPILER_SUPPORTS_TARGET_BITS_FLAG@
+
+# Option used to pass a command file to the compiler
+COMPILER_COMMAND_FILE_FLAG := @COMPILER_COMMAND_FILE_FLAG@
+
+# Option for specifying a file which saves the binder commands
+# produced by the link step (for debugging, currently AIX only)
+COMPILER_BINDCMD_FILE_FLAG := @COMPILER_BINDCMD_FILE_FLAG@
 
 CC_OUT_OPTION := @CC_OUT_OPTION@
 

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -35,23 +35,25 @@
 m4_include([toolchain_microsoft.m4])
 
 # All valid toolchains, regardless of platform (used by help.m4)
-VALID_TOOLCHAINS_all="gcc clang microsoft"
+VALID_TOOLCHAINS_all="gcc clang xlc microsoft"
 
 # These toolchains are valid on different platforms
 VALID_TOOLCHAINS_linux="gcc clang"
 VALID_TOOLCHAINS_macosx="clang"
-VALID_TOOLCHAINS_aix="clang"
+VALID_TOOLCHAINS_aix="xlc clang"
 VALID_TOOLCHAINS_windows="microsoft"
 
 # Toolchain descriptions
 TOOLCHAIN_DESCRIPTION_clang="clang/LLVM"
 TOOLCHAIN_DESCRIPTION_gcc="GNU Compiler Collection"
 TOOLCHAIN_DESCRIPTION_microsoft="Microsoft Visual Studio"
+TOOLCHAIN_DESCRIPTION_xlc="IBM XL C/C++"
 
 # Minimum supported versions, empty means unspecified
 TOOLCHAIN_MINIMUM_VERSION_clang="13.0"
 TOOLCHAIN_MINIMUM_VERSION_gcc="10.0"
 TOOLCHAIN_MINIMUM_VERSION_microsoft="19.28.0.0" # VS2019 16.8, aka MSVC 14.28
+TOOLCHAIN_MINIMUM_VERSION_xlc="17.1.1.4"
 
 # Minimum supported linker versions, empty means unspecified
 TOOLCHAIN_MINIMUM_LD_VERSION_gcc="2.18"
@@ -232,6 +234,25 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   # First toolchain type in the list is the default
   DEFAULT_TOOLCHAIN=${VALID_TOOLCHAINS%% *}
 
+  # On AIX the default toolchain depends on the installed (found) compiler
+  #   xlclang++     -> xlc toolchain
+  #   ibm-clang++_r -> clang toolchain
+  # The compiler is searched on the PATH and TOOLCHAIN_PATH
+  # xlclang++ has precedence over ibm-clang++_r if both are installed
+  if test "x$OPENJDK_TARGET_OS" = xaix; then
+    DEFAULT_TOOLCHAIN="clang"
+    if test "x$TOOLCHAIN_PATH" != x; then
+      if test -e ${TOOLCHAIN_PATH}/xlclang++; then
+        DEFAULT_TOOLCHAIN="xlc"
+      fi
+    else
+      UTIL_LOOKUP_PROGS(XLCLANG_TEST_PATH, xlclang++)
+      if test "x$XLCLANG_TEST_PATH" != x; then
+        DEFAULT_TOOLCHAIN="xlc"
+      fi
+    fi
+  fi
+
   if test "x$with_toolchain_type" = xlist; then
     # List all toolchains
     AC_MSG_NOTICE([The following toolchains are valid on this platform:])
@@ -256,13 +277,48 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   fi
   AC_SUBST(TOOLCHAIN_TYPE)
 
-  TOOLCHAIN_CC_BINARY_clang="ibm-clang_r clang"
+  # on AIX, check for xlclang++ on the PATH and TOOLCHAIN_PATH and use it if it is available
+  if test "x$OPENJDK_TARGET_OS" = xaix; then
+    if test "x$TOOLCHAIN_PATH" != x; then
+      XLC_TEST_PATH=${TOOLCHAIN_PATH}/
+    fi
+    if test "x$TOOLCHAIN_TYPE" = xclang; then
+      TOOLCHAIN_DESCRIPTION_clang="IBM Open XL C/C++"
+      XLCLANG_VERSION_OUTPUT=`${XLC_TEST_PATH}ibm-clang++_r --version 2>&1 | $HEAD -n 1`
+      $ECHO "$XLCLANG_VERSION_OUTPUT" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
+      if test $? -eq 0; then
+        AC_MSG_NOTICE([ibm-clang++_r output: $XLCLANG_VERSION_OUTPUT])
+      else
+        AC_MSG_ERROR([ibm-clang++_r version output check failed, output: $XLCLANG_VERSION_OUTPUT])
+      fi
+    else
+      XLCLANG_VERSION_OUTPUT=`${XLC_TEST_PATH}xlclang++ -qversion 2>&1 | $HEAD -n 1`
+      $ECHO "$XLCLANG_VERSION_OUTPUT" | $GREP "IBM XL C/C++ for AIX" > /dev/null
+      if test $? -eq 0; then
+        AC_MSG_NOTICE([xlclang++ output: $XLCLANG_VERSION_OUTPUT])
+      else
+        AC_MSG_ERROR([xlclang++ version output check failed, output: $XLCLANG_VERSION_OUTPUT])
+      fi
+    fi
+  fi
+
+  if test "x$OPENJDK_TARGET_OS" = xaix; then
+    TOOLCHAIN_CC_BINARY_clang="ibm-clang_r"
+  else
+    TOOLCHAIN_CC_BINARY_clang="clang"
+  fi
   TOOLCHAIN_CC_BINARY_gcc="gcc"
   TOOLCHAIN_CC_BINARY_microsoft="cl"
+  TOOLCHAIN_CC_BINARY_xlc="xlclang"
 
-  TOOLCHAIN_CXX_BINARY_clang="ibm-clang++_r clang++"
+  if test "x$OPENJDK_TARGET_OS" = xaix; then
+    TOOLCHAIN_CXX_BINARY_clang="ibm-clang++_r"
+  else
+    TOOLCHAIN_CXX_BINARY_clang="clang++"
+  fi
   TOOLCHAIN_CXX_BINARY_gcc="g++"
   TOOLCHAIN_CXX_BINARY_microsoft="cl"
+  TOOLCHAIN_CXX_BINARY_xlc="xlclang++"
 
   # Use indirect variable referencing
   toolchain_var_name=TOOLCHAIN_DESCRIPTION_$TOOLCHAIN_TYPE
@@ -352,7 +408,25 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
   COMPILER=[$]$1
   COMPILER_NAME=$2
 
-  if test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+  if test  "x$TOOLCHAIN_TYPE" = xxlc; then
+    # xlc -qversion output typically looks like
+    #     IBM XL C/C++ for AIX, V11.1 (5724-X13)
+    #     Version: 11.01.0000.0015
+    COMPILER_VERSION_OUTPUT=`$COMPILER -qversion 2>&1`
+    # Check that this is likely to be the IBM XL C compiler.
+    $ECHO "$COMPILER_VERSION_OUTPUT" | $GREP "IBM XL C" > /dev/null
+    if test $? -ne 0; then
+      ALT_VERSION_OUTPUT=`$COMPILER --version 2>&1`
+      AC_MSG_NOTICE([The $COMPILER_NAME compiler (located as $COMPILER) does not seem to be the required $TOOLCHAIN_TYPE compiler.])
+      AC_MSG_NOTICE([The result from running with -qversion was: "$COMPILER_VERSION_OUTPUT"])
+      AC_MSG_NOTICE([The result from running with --version was: "$ALT_VERSION_OUTPUT"])
+      AC_MSG_ERROR([A $TOOLCHAIN_TYPE compiler is required. Try setting --with-tools-dir.])
+    fi
+    # Collapse compiler output into a single line
+    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT`
+    COMPILER_VERSION_NUMBER=`$ECHO $COMPILER_VERSION_OUTPUT | \
+        $SED -e 's/^.*Version: \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
+  elif test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # There is no specific version flag, but all output starts with a version string.
     # First line typically looks something like:
     # Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 16.00.40219.01 for 80x86
@@ -391,22 +465,12 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
         $SED -e 's/^.* \(@<:@1-9@:>@<:@0-9@:>@*\.@<:@0-9.@:>@*\)@<:@^0-9.@:>@.*$/\1/'`
   elif test  "x$TOOLCHAIN_TYPE" = xclang; then
     # clang --version output typically looks like
-    #    Apple clang version 15.0.0 (clang-1500.3.9.4)
-    #    Target: arm64-apple-darwin23.2.0
-    #    Thread model: posix
-    #    InstalledDir: /Library/Developer/CommandLineTools/usr/bin
+    #    Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
+    #    clang version 3.3 (tags/RELEASE_33/final)
     # or
-    #    clang version 10.0.0-4ubuntu1
+    #    Debian clang version 3.2-7ubuntu1 (tags/RELEASE_32/final) (based on LLVM 3.2)
     #    Target: x86_64-pc-linux-gnu
     #    Thread model: posix
-    #    InstalledDir: /usr/bin
-    #    Target: x86_64-pc-linux-gnu
-    #    Thread model: posix
-    # or
-    #    IBM Open XL C/C++ for AIX 17.1.0 (5725-C72, 5765-J18), clang version 13.0.0
-    #    Target: powerpc-ibm-aix7.2.0.0
-    #    Thread model: posix
-    #    InstalledDir: /opt/IBM/openxlC/17.1.0/bin
     COMPILER_VERSION_OUTPUT=`$COMPILER --version 2>&1`
     # Check that this is likely to be clang
     $ECHO "$COMPILER_VERSION_OUTPUT" | $GREP "clang" > /dev/null
@@ -415,12 +479,10 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
       AC_MSG_NOTICE([The result from running with --version was: "$COMPILER_VERSION_OUTPUT"])
       AC_MSG_ERROR([A $TOOLCHAIN_TYPE compiler is required. Try setting --with-tools-dir.])
     fi
-    # Remove "Thread model:" and further details from the version string, and
-    # collapse into a single line
-    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT | \
-        $SED -e 's/ *Thread model: .*//'`
+    # Collapse compiler output into a single line
+    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT`
     COMPILER_VERSION_NUMBER=`$ECHO $COMPILER_VERSION_OUTPUT | \
-        $SED -e 's/^.*clang version \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
+        $SED -e 's/^.* version \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
   else
       AC_MSG_ERROR([Unknown toolchain type $TOOLCHAIN_TYPE.])
   fi
@@ -513,7 +575,10 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_LD_VERSION],
   LINKER=[$]$1
   LINKER_NAME="$2"
 
-  if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+  if test  "x$TOOLCHAIN_TYPE" = xxlc; then
+    LINKER_VERSION_STRING="Unknown"
+    LINKER_VERSION_NUMBER="0.0"
+  elif test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # There is no specific version flag, but all output starts with a version string.
     # First line typically looks something like:
     #   Microsoft (R) Incremental Linker Version 12.00.31101.0
@@ -933,14 +998,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_MISC_CHECKS],
       if test "x$COMPILER_CPU_TEST" != "xARM64"; then
         AC_MSG_ERROR([Target CPU mismatch. We are building for $OPENJDK_TARGET_CPU but CL is for "$COMPILER_CPU_TEST"; expected "arm64".])
       fi
-    fi
-  fi
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    # Make sure we have the Open XL version of clang on AIX
-
-    $ECHO "$CC_VERSION_STRING" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
-    if test $? -ne 0; then
-      AC_MSG_ERROR([ibm-clang_r version output check failed, output: $CC_VERSION_OUTPUT])
     fi
   fi
 

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -133,6 +133,11 @@ define CreateDynamicLibraryOrExecutable
   ifeq ($$($1_TYPE), LIBRARY)
     # Generating a dynamic library.
     $1_EXTRA_LDFLAGS += $$(call SET_SHARED_LIBRARY_NAME,$$($1_BASENAME))
+
+    # Create loadmap on AIX. Helps in diagnosing some problems.
+    ifneq ($(COMPILER_BINDCMD_FILE_FLAG), )
+      $1_EXTRA_LDFLAGS += $(COMPILER_BINDCMD_FILE_FLAG)$$($1_OBJECT_DIR)/$$($1_NOSUFFIX).loadmap
+    endif
   endif
 
   $1_VARDEPS := $$($1_LD) $$($1_SYSROOT_LDFLAGS) $$($1_LDFLAGS) \

--- a/make/common/native/Paths.gmk
+++ b/make/common/native/Paths.gmk
@@ -209,7 +209,12 @@ define SetupObjectFileList
   # If there are many object files, use an @-file...
   ifneq ($$(word 17, $$($1_ALL_OBJS)), )
     $1_OBJ_FILE_LIST := $$($1_OBJECT_DIR)/_$1_objectfilenames.txt
-    $1_LD_OBJ_ARG := @$$($1_OBJ_FILE_LIST)
+    ifneq ($(COMPILER_COMMAND_FILE_FLAG), )
+      $1_LD_OBJ_ARG := $(COMPILER_COMMAND_FILE_FLAG)$$($1_OBJ_FILE_LIST)
+    else
+      # ...except for toolchains which don't support them.
+      $1_LD_OBJ_ARG := `cat $$($1_OBJ_FILE_LIST)`
+    endif
 
     # If we are building static library, 'AR' on macosx/aix may not support @-file.
     ifeq ($$($1_TYPE), STATIC_LIBRARY)

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -98,6 +98,8 @@ ifneq ($(DEBUG_LEVEL), release)
   DISABLED_WARNINGS_gcc += strict-overflow
 endif
 
+DISABLED_WARNINGS_xlc := tautological-compare shift-negative-value
+
 DISABLED_WARNINGS_microsoft := 4624 4244 4291 4146 4127 4722
 
 ################################################################################
@@ -204,6 +206,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_clang_aix_debug.cpp := format-nonliteral, \
     DISABLED_WARNINGS_clang_aix_jvm.cpp := format-nonliteral, \
     DISABLED_WARNINGS_clang_aix_osThread_aix.cpp := tautological-undefined-compare, \
+    DISABLED_WARNINGS_xlc := $(DISABLED_WARNINGS_xlc), \
     DISABLED_WARNINGS_microsoft := $(DISABLED_WARNINGS_microsoft), \
     ASFLAGS := $(JVM_ASFLAGS), \
     LD_SET_ORIGIN := false, \

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -77,6 +77,7 @@ TARGETS += $(BUILD_LIBNET)
 $(eval $(call SetupJdkLibrary, BUILD_LIBNIO, \
     NAME := nio, \
     OPTIMIZATION := HIGH, \
+    WARNINGS_AS_ERRORS_xlc := false, \
     EXTRA_HEADER_DIRS := \
         libnio/ch \
         libnio/fs \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -57,6 +57,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     ProcessImpl_md.c_CFLAGS := $(VERSION_CFLAGS), \
     java_props_md.c_CFLAGS := \
         -DARCHPROPNAME='"$(OPENJDK_TARGET_CPU_OSARCH)"', \
+    WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc_ProcessImpl_md.c := unused-result, \
     JDK_LIBS := libjvm, \
     LIBS_linux := $(LIBDL), \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -205,6 +205,7 @@ ifeq ($(call isTargetOs, windows macosx)+$(ENABLE_HEADLESS_ONLY), false+false)
       OPTIMIZATION := LOW, \
       CFLAGS := -DXAWT -DXAWT_HACK $(LIBAWT_XAWT_CFLAGS) \
           $(FONTCONFIG_CFLAGS) $(CUPS_CFLAGS) $(X_CFLAGS), \
+      WARNINGS_AS_ERRORS_xlc := false, \
       DISABLED_WARNINGS_gcc := int-to-pointer-cast, \
       DISABLED_WARNINGS_gcc_awt_Taskbar.c := parentheses, \
       DISABLED_WARNINGS_gcc_GLXSurfaceData.c := unused-function, \
@@ -411,6 +412,14 @@ else
      HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHB_NO_VISIBILITY
    endif
 
+   # Early re-canonizing has to be disabled to workaround an internal XlC compiler error
+   # when building libharfbuzz
+   ifeq ($(call isTargetOs, aix), true)
+    ifneq ($(TOOLCHAIN_TYPE), clang)
+     HARFBUZZ_CFLAGS += -qdebug=necan
+    endif
+   endif
+
    # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
    # hb-subset and hb-style APIs are not needed, excluded to cut on compilation
    # time.
@@ -496,6 +505,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
     EXTRA_SRC := $(LIBFONTMANAGER_EXTRA_SRC), \
+    WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc := $(HARFBUZZ_DISABLED_WARNINGS_gcc), \
     DISABLED_WARNINGS_CXX_gcc := $(HARFBUZZ_DISABLED_WARNINGS_CXX_gcc), \
     DISABLED_WARNINGS_clang := $(HARFBUZZ_DISABLED_WARNINGS_clang), \

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -22,6 +22,9 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+# ===========================================================================
+# (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+# ===========================================================================
 
 ################################################################################
 # This file builds the native component of the JTReg tests for JDK.
@@ -93,6 +96,10 @@ else
     BUILD_JDK_JTREG_EXECUTABLES_LIBS_exelauncher := -ldl
   endif
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX)
+endif
+
+ifeq ($(call isTargetOs, aix), true)
+  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeJliLaunchTest := -lz
 endif
 
 ifeq ($(call isTargetOs, macosx), true)


### PR DESCRIPTION
Revert ["8327701: Remove the xlc toolchain"](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/ceeb8571963012d55755ad7d875b5fedb93e7db1).