### PR TITLE
Support provider fully-qualified class name in Restricted Security mode

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -28,6 +28,7 @@ import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedAction;
+import java.security.Provider;
 import java.security.Provider.Service;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -251,6 +252,12 @@ public final class RestrictedSecurity {
      */
     public static boolean isProviderAllowed(String providerName) {
         if (securityEnabled) {
+            // Remove argument, e.g. -NSS-FIPS, if present.
+            int pos = providerName.indexOf('-');
+            if (pos >= 0) {
+                providerName = providerName.substring(0, pos);
+            }
+
             return restricts.isRestrictedProviderAllowed(providerName);
         }
         return true;
@@ -264,17 +271,17 @@ public final class RestrictedSecurity {
      */
     public static boolean isProviderAllowed(Class<?> providerClazz) {
         if (securityEnabled) {
-            String providerName = providerClazz.getName();
+            String providerClassName = providerClazz.getName();
 
             // Check if the specified class extends java.security.Provider.
             if (java.security.Provider.class.isAssignableFrom(providerClazz)) {
-                return restricts.isRestrictedProviderAllowed(providerName);
+                return restricts.isRestrictedProviderAllowed(providerClassName);
             }
 
             // For a class that doesn't extend java.security.Provider, no need to
             // check allowed or not allowed, always return true to load it.
             if (debug != null) {
-                debug.println("The provider class " + providerName + " does not extend java.security.Provider.");
+                debug.println("The provider class " + providerClassName + " does not extend java.security.Provider.");
             }
         }
         return true;
@@ -647,27 +654,6 @@ public final class RestrictedSecurity {
     }
 
     /**
-     * Get the provider name defined in provider construction method.
-     *
-     * @param providerName provider name or provider with packages
-     * @return provider name defined in provider construction method
-     */
-    private static String getProvidersSimpleName(String providerName) {
-        if (providerName.equals("com.sun.security.sasl.Provider")) {
-            // The main class for the SunSASL provider is com.sun.security.sasl.Provider.
-            return "SunSASL";
-        } else {
-            // Remove the provider's class package names if present.
-            int pos = providerName.lastIndexOf('.');
-            if (pos >= 0) {
-                providerName = providerName.substring(pos + 1);
-            }
-            // Provider without package names.
-            return providerName;
-        }
-    }
-
-    /**
      * This class is used to save and operate on restricted security
      * properties which are loaded from the java.security file.
      */
@@ -700,7 +686,7 @@ public final class RestrictedSecurity {
         // Provider with argument (provider name + optional argument).
         private final List<String> providers;
         // Provider without argument.
-        private final List<String> providersSimpleName;
+        private final List<String> providersFullyQualifiedClassName;
         // The map is keyed by provider name.
         private final Map<String, Constraint[]> providerConstraints;
 
@@ -732,7 +718,7 @@ public final class RestrictedSecurity {
             this.jdkFipsMode = parser.getProperty("jdkFipsMode");
 
             this.providers = new ArrayList<>(parser.providers);
-            this.providersSimpleName = new ArrayList<>(parser.providersSimpleName);
+            this.providersFullyQualifiedClassName = new ArrayList<>(parser.providersFullyQualifiedClassName);
             this.providerConstraints = parser.providerConstraints
                                              .entrySet()
                                              .stream()
@@ -754,30 +740,26 @@ public final class RestrictedSecurity {
          * @return true if the Service is allowed
          */
         boolean isRestrictedServiceAllowed(Service service) {
-            String providerName = service.getProvider().getName();
+            Provider provider = service.getProvider();
+            String providerClassName = provider.getClass().getName();
 
             if (debug != null) {
-                debug.println("Checking service " + service.toString() + " offered by provider " + providerName + ".");
+                debug.println("Checking service " + service.toString() + " offered by provider " + providerClassName + ".");
             }
 
-            // Provider with argument, remove argument.
-            // e.g. SunPKCS11-NSS-FIPS, remove argument -NSS-FIPS.
-            int pos = providerName.indexOf('-');
-            providerName = (pos < 0) ? providerName : providerName.substring(0, pos);
-
-            Constraint[] constraints = providerConstraints.get(providerName);
+            Constraint[] constraints = providerConstraints.get(providerClassName);
 
             if (constraints == null) {
                 // Disallow unknown providers.
                 if (debug != null) {
                     debug.println("Security constraints check."
-                            + " Disallow unknown provider: " + providerName);
+                            + " Disallow unknown provider: " + providerClassName);
                 }
                 return false;
             } else if (constraints.length == 0) {
                 // Allow this provider with no constraints.
                 if (debug != null) {
-                    debug.println("No constraints for provider " + providerName + ".");
+                    debug.println("No constraints for provider " + providerClassName + ".");
                 }
                 return true;
             }
@@ -821,7 +803,7 @@ public final class RestrictedSecurity {
                         debug.println("The following service:"
                                 + "\n\tService type: " + type
                                 + "\n\tAlgorithm: " + algorithm
-                                + "\nis allowed in provider: " + providerName);
+                                + "\nis allowed in provider: " + providerClassName);
                     }
                     return true;
                 }
@@ -851,7 +833,7 @@ public final class RestrictedSecurity {
                                         + "\n\tService type: " + type
                                         + "\n\tAlgorithm: " + algorithm
                                         + "\n\tAttribute: " + cAttribute
-                                        + "\nis NOT allowed in provider: " + providerName);
+                                        + "\nis NOT allowed in provider: " + providerClassName);
                         }
                         return false;
                     }
@@ -865,7 +847,7 @@ public final class RestrictedSecurity {
                                 + "\n\tService type: " + type
                                 + "\n\tAlgorithm: " + algorithm
                                 + "\n\tAttribute: " + cAttribute
-                                + "\nis allowed in provider: " + providerName);
+                                + "\nis allowed in provider: " + providerClassName);
                 }
                 return true;
             }
@@ -876,7 +858,7 @@ public final class RestrictedSecurity {
                 debug.println("The following service:"
                             + "\n\tService type: " + type
                             + "\n\tAlgorithm: " + algorithm
-                            + "\nis NOT allowed in provider: " + providerName);
+                            + "\nis NOT allowed in provider: " + providerClassName);
             }
             return false;
         }
@@ -884,34 +866,25 @@ public final class RestrictedSecurity {
         /**
          * Check if the provider is allowed in restricted security mode.
          *
-         * @param providerName the provider to check
+         * @param providerClassName the provider to check
          * @return true if the provider is allowed
          */
-        boolean isRestrictedProviderAllowed(String providerName) {
+        boolean isRestrictedProviderAllowed(String providerClassName) {
             if (debug != null) {
-                debug.println("Checking the provider " + providerName + " in restricted security mode.");
+                debug.println("Checking the provider " + providerClassName + " in restricted security mode.");
             }
 
-            // Remove argument, e.g. -NSS-FIPS, if present.
-            int pos = providerName.indexOf('-');
-            if (pos >= 0) {
-                providerName = providerName.substring(0, pos);
-            }
-
-            // Provider name defined in provider construction method.
-            providerName = getProvidersSimpleName(providerName);
-
-            // Check if the provider is in restricted security provider list.
-            // If not, the provider won't be registered.
-            if (providersSimpleName.contains(providerName)) {
+            // Check if the provider fully-qualified cLass name is in restricted
+            // security provider list. If not, the provider won't be registered.
+            if (providersFullyQualifiedClassName.contains(providerClassName)) {
                 if (debug != null) {
-                    debug.println("The provider " + providerName + " is allowed in restricted security mode.");
+                    debug.println("The provider " + providerClassName + " is allowed in restricted security mode.");
                 }
                 return true;
             }
 
             if (debug != null) {
-                debug.println("The provider " + providerName + " is not allowed in restricted security mode.");
+                debug.println("The provider " + providerClassName + " is not allowed in restricted security mode.");
 
                 debug.println("Stack trace:");
                 StackTraceElement[] elements = Thread.currentThread().getStackTrace();
@@ -950,8 +923,8 @@ public final class RestrictedSecurity {
             for (int providerPosition = 0; providerPosition < providers.size(); providerPosition++) {
                 printProperty(profileID + ".jce.provider." + (providerPosition + 1) + ": ",
                         providers.get(providerPosition));
-                String providerSimpleName = providersSimpleName.get(providerPosition);
-                for (Constraint providerConstraint : providerConstraints.get(providerSimpleName)) {
+                String providerFullyQualifiedClassName = providersFullyQualifiedClassName.get(providerPosition);
+                for (Constraint providerConstraint : providerConstraints.get(providerFullyQualifiedClassName)) {
                     System.out.println("\t" + providerConstraint.toString());
                 }
             }
@@ -994,7 +967,7 @@ public final class RestrictedSecurity {
         // Provider with argument (provider name + optional argument).
         private final List<String> providers;
         // Provider without argument.
-        private final List<String> providersSimpleName;
+        private final List<String> providersFullyQualifiedClassName;
         // The map is keyed by provider name.
         private final Map<String, List<Constraint>> providerConstraints;
 
@@ -1022,7 +995,7 @@ public final class RestrictedSecurity {
             profileProperties = new HashMap<>();
 
             providers = new ArrayList<>();
-            providersSimpleName = new ArrayList<>();
+            providersFullyQualifiedClassName = new ArrayList<>();
             providerConstraints = new HashMap<>();
 
             profilesHashes = new HashMap<>();
@@ -1180,21 +1153,13 @@ public final class RestrictedSecurity {
             }
             providerName = providerName.trim();
 
-            // Remove argument, e.g. -NSS-FIPS, if present.
-            pos = providerName.indexOf('-');
-            if (pos >= 0) {
-                providerName = providerName.substring(0, pos);
-            }
-
-            // Provider name defined in provider construction method.
-            providerName = getProvidersSimpleName(providerName);
             boolean providerChanged = false;
             if (update) {
-                String previousProviderName = providersSimpleName.get(providerPos - 1);
+                String previousProviderName = providersFullyQualifiedClassName.get(providerPos - 1);
                 providerChanged = !previousProviderName.equals(providerName);
-                providersSimpleName.set(providerPos - 1, providerName);
+                providersFullyQualifiedClassName.set(providerPos - 1, providerName);
             } else {
-                providersSimpleName.add(providerPos - 1, providerName);
+                providersFullyQualifiedClassName.add(providerPos - 1, providerName);
             }
 
             if (debug != null) {
@@ -1210,14 +1175,14 @@ public final class RestrictedSecurity {
                 debug.println("\t\tRemoving provider in position " + providerPos);
             }
 
-            int numOfExistingProviders = providersSimpleName.size();
+            int numOfExistingProviders = providersFullyQualifiedClassName.size();
 
             // If this is the last provider, remove from all lists.
             if (providerPos == numOfExistingProviders) {
                 if (debug != null) {
                     debug.println("\t\t\tLast provider. Only one to be removed.");
                 }
-                String providerRemoved = providersSimpleName.remove(providerPos - 1);
+                String providerRemoved = providersFullyQualifiedClassName.remove(providerPos - 1);
                 providers.remove(providerPos - 1);
                 providerConstraints.remove(providerRemoved);
 
@@ -1241,7 +1206,7 @@ public final class RestrictedSecurity {
                 }
 
                 // Remove all of the providers that are set to empty.
-                String providerRemoved = providersSimpleName.remove(i - 1);
+                String providerRemoved = providersFullyQualifiedClassName.remove(i - 1);
                 providers.remove(i - 1);
                 providerConstraints.remove(providerRemoved);
 
@@ -1290,7 +1255,7 @@ public final class RestrictedSecurity {
 
         private void updateProviders(String profileExtensionId, List<String> allInfo) {
             boolean removedProvider = false;
-            int numOfExistingProviders = providersSimpleName.size();
+            int numOfExistingProviders = providersFullyQualifiedClassName.size();
             // Deal with update of existing providers.
             for (int i = 1; i <= numOfExistingProviders; i++) {
                 String property = profileExtensionId + ".jce.provider." + i;

--- a/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -171,13 +171,11 @@ final class ProviderConfig {
      */
     @SuppressWarnings("deprecation")
     Provider getProvider() {
-        if (!RestrictedSecurity.isProviderAllowed(provName)) {
-            // We're in restricted security mode which does not allow this provider,
-            // return without loading.
-            return null;
-        }
         // volatile variable load
         Provider p = provider;
+        // There is RestrictedSecurity check in the ServiceLoader before the
+        // provider is initialized. So the check has already occurred for the
+        // provider where provider != null.
         if (p != null) {
             return p;
         }
@@ -188,6 +186,11 @@ final class ProviderConfig {
                 return p;
             }
             if (!shouldLoad()) {
+                return null;
+            }
+            if (!RestrictedSecurity.isProviderAllowed(provName)) {
+                // We're in restricted security mode which does not allow this provider,
+                // return without loading.
                 return null;
             }
 
@@ -372,8 +375,12 @@ final class ProviderConfig {
                     if (debug != null) {
                         debug.println("Found SL Provider named " + pName);
                     }
-                    if (pName.equals(pn)) {
+                    if (p.getClass().getName().equals(pn)) {
                         return p;
+                    } else if (pName.equals(pn)) {
+                        if (!RestrictedSecurity.isEnabled()) {
+                            return p;
+                        }
                     }
                 } catch (SecurityException | ServiceConfigurationError |
                          InvalidParameterException ex) {

--- a/src/java.base/share/classes/sun/security/jca/ProviderList.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderList.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -116,13 +116,12 @@ public final class ProviderList {
 
     public static ProviderList insertAt(ProviderList providerList, Provider p,
             int position) {
-        String providerName = p.getName();
-        if (providerList.getProvider(providerName) != null) {
-            return providerList;
-        }
-        if (!RestrictedSecurity.isProviderAllowed(providerName)) {
+        if (!RestrictedSecurity.isProviderAllowed(p.getClass())) {
             // We're in restricted security mode which does not allow this provider,
             // return without adding.
+            return providerList;
+        }
+        if (providerList.getProvider(p.getName()) != null) {
             return providerList;
         }
         List<ProviderConfig> list = new ArrayList<>
@@ -157,7 +156,7 @@ public final class ProviderList {
         if (RestrictedSecurity.isEnabled()) {
             List<Provider> allowedProviders = new ArrayList<>();
             for (Provider p : providers) {
-                if (RestrictedSecurity.isProviderAllowed(p.getName())) {
+                if (RestrictedSecurity.isProviderAllowed(p.getClass())) {
                     // This provider is allowed, add it the list.
                     allowedProviders.add(p);
                 }

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -136,18 +136,19 @@ RestrictedSecurity.NSS.140-2.tls.legacyAlgorithms =
 
 RestrictedSecurity.NSS.140-2.jce.certpath.disabledAlgorithms =
 RestrictedSecurity.NSS.140-2.jce.legacyAlgorithms =
-RestrictedSecurity.NSS.140-2.jce.provider.1 = SunPKCS11 ${java.home}/conf/security/nss.fips.cfg
-RestrictedSecurity.NSS.140-2.jce.provider.2 = SUN [{CertificateFactory, X.509, ImplementedIn=Software}, \
+RestrictedSecurity.NSS.140-2.jce.provider.1 = sun.security.pkcs11.SunPKCS11 ${java.home}/conf/security/nss.fips.cfg
+RestrictedSecurity.NSS.140-2.jce.provider.2 = sun.security.provider.Sun [ \
+    {CertificateFactory, X.509, ImplementedIn=Software}, \
     {CertStore, Collection, ImplementedIn=Software}, \
     {CertStore, com.sun.security.IndexedCollection, ImplementedIn=Software}, \
     {Policy, JavaPolicy, *}, {Configuration, JavaLoginConfig, *}, \
     {CertPathBuilder, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
     {CertPathValidator, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
     {KeyStore, PKCS12, *}]
-RestrictedSecurity.NSS.140-2.jce.provider.3 = SunEC [{KeyFactory, EC, ImplementedIn=Software: \
+RestrictedSecurity.NSS.140-2.jce.provider.3 = sun.security.ec.SunEC [{KeyFactory, EC, ImplementedIn=Software: \
     SupportedKeyClasses=java.security.interfaces.ECPublicKey|java.security.interfaces.ECPrivateKey: \
     KeySize=256}, {AlgorithmParameters, EC, *}]
-RestrictedSecurity.NSS.140-2.jce.provider.4 = SunJSSE
+RestrictedSecurity.NSS.140-2.jce.provider.4 = sun.security.ssl.SunJSSE
 
 RestrictedSecurity.NSS.140-2.keystore.type = PKCS11
 RestrictedSecurity.NSS.140-2.javax.net.ssl.keyStore = NONE
@@ -160,7 +161,7 @@ RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = true
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:f5b04d07f6fd5d11374b23dd96110b231d0241096563ae55cf3ea6fb1788d97c
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:c0f81edb5bbd6a17a3ebbe7aa459441d6b1c77fc02773b8ecc79b4d996c3d055
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
@@ -199,14 +200,15 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.legacyAlgorithms =
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.certpath.disabledAlgorithms =
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.legacyAlgorithms =
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.2 = SUN [{CertificateFactory, X.509, ImplementedIn=Software}, \
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.2 = sun.security.provider.Sun [ \
+    {CertificateFactory, X.509, ImplementedIn=Software}, \
     {CertPathBuilder, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
     {CertPathValidator, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
     {CertStore, Collection, ImplementedIn=Software}, \
     {CertStore, com.sun.security.IndexedCollection, ImplementedIn=Software}, \
     {Configuration, JavaLoginConfig, *}, \
     {Policy, JavaPolicy, *}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.3 = SunJSSE
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.3 = sun.security.ssl.SunJSSE
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.javax.net.ssl.keyStore = NONE
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.securerandom.algorithm = SHA512DRBG


### PR DESCRIPTION
This PR is for updating the codes to only support the fully-qualified class name when setting the providers list in restricted security profiles. For example, the NSS FIPS140-2 provider list will be:

```
RestrictedSecurity.NSS.140-2.jce.provider.1 = sun.security.pkcs11.SunPKCS11 ${java.home}/conf/security/nss.fips.cfg
RestrictedSecurity.NSS.140-2.jce.provider.2 = sun.security.provider.Sun [ \
    {CertificateFactory, X.509, ImplementedIn=Software}, \
    {CertStore, Collection, ImplementedIn=Software}, \
    {CertStore, com.sun.security.IndexedCollection, ImplementedIn=Software}, \
    {Policy, JavaPolicy, *}, {Configuration, JavaLoginConfig, *}, \
    {CertPathBuilder, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
    {CertPathValidator, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
    {KeyStore, PKCS12, *}]
RestrictedSecurity.NSS.140-2.jce.provider.3 = sun.security.ec.SunEC [{KeyFactory, EC, ImplementedIn=Software: \
    SupportedKeyClasses=java.security.interfaces.ECPublicKey|java.security.interfaces.ECPrivateKey: \
    KeySize=256}, {AlgorithmParameters, EC, *}]
RestrictedSecurity.NSS.140-2.jce.provider.4 = sun.security.ssl.SunJSSE
```

