### PR TITLE
Fix .gitignore entry for .project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ NashornProfile.txt
 **/JTreport/**
 **/JTwork/**
 /src/utils/LogCompilation/target/
-/.project/
+/.project
 /.settings/
 /compile_commands.json
 /.cache


### PR DESCRIPTION
Affected by upstream change:
* [8326964: Remove Eclipse Shared Workspaces](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/66c80c80d2e0b1d64a77b8bed644c8c3f7506719)