### PR TITLE
Fix MaxSizeUTF16String test to support OpenJ9

### DIFF
--- a/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
+++ b/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -137,6 +142,8 @@ public class MaxSizeUTF16String {
         byte[] bytes = s1.getBytes(StandardCharsets.UTF_8);
         int remaining = Integer.MAX_VALUE - bytes.length;
         assertTrue(remaining >= bytes1.length, "remainder too large: " + remaining);
+        min += 1; // adjust for OpenJ9
+        max += 1;
 
         // Strings of size min+1...min+2, throw OOME
         // The resulting byte array would exceed implementation limits


### PR DESCRIPTION
Openj9 can allocate `new byte[Integer.MAX_VALUE - 1]` but this exceeds the Hotspot implementation limit.

Fixes https://github.com/eclipse-openj9/openj9/issues/19303

Tested in grinder https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3472 showing `MaxSizeUTF16String::testMaxUTF8_UTF16Encode` is SUCCESSFUL. There is another issue https://github.com/eclipse-openj9/openj9/issues/19309 preventing the test from passing.