### PR TITLE
Remove uses of SHARED_LIBRARY and STATIC_LIBRARY

### DIFF
--- a/closed/CopySupport.gmk
+++ b/closed/CopySupport.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -124,6 +124,6 @@ openj9_copy_exes = \
 openj9_copy_shlibs = \
 	$(foreach name, $1, \
 		$(call openj9_copy_files_and_debuginfos, \
-			$(addsuffix /$(call SHARED_LIBRARY,$(name)), \
+			$(addsuffix /$(LIBRARY_PREFIX)$(name)$(SHARED_LIBRARY_SUFFIX), \
 				$(OPENJ9_VM_BUILD_DIR) \
 				$(LIB_DST_DIR)/$(OPENJ9_LIBS_SUBDIR))))

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -195,7 +195,7 @@ $(foreach file, \
 		vmLifecyleTests \
 		vmtest \
 		) \
-	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/$(call SHARED_LIBRARY,%), \
+	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/$(LIBRARY_PREFIX)%$(SHARED_LIBRARY_SUFFIX), \
 		access \
 		anntests \
 		balloon29 \
@@ -228,7 +228,7 @@ $(foreach file, \
 		vmruntimestateagent29 \
 		) \
 	$(OPENJ9_VM_BUILD_DIR)/libloadLibraryTest.jnilib \
-	$(SUPPORT_OUTPUTDIR)/test/agct/lib/$(call SHARED_LIBRARY,AsyncGetCallTraceTest), \
+	$(SUPPORT_OUTPUTDIR)/test/agct/lib/$(LIBRARY_PREFIX)AsyncGetCallTraceTest$(SHARED_LIBRARY_SUFFIX), \
 	$(if $(wildcard $(file)), \
 		$(eval $(call openj9_test_image_rules, $(file)))))
 

--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -61,14 +61,14 @@ endif
 # redirector
 
 $(call openj9_copy_files_and_debuginfos, \
-	$(addsuffix $(call SHARED_LIBRARY,jvm), \
+	$(addsuffix $(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX), \
 		$(OPENJ9_VM_BUILD_DIR)/redirector/ \
 		$(addprefix $(LIB_DST_DIR), /j9vm/ /server/)))
 
 # jsig
 
 $(call openj9_copy_files_and_debuginfos, \
-	$(addsuffix $(call SHARED_LIBRARY,jsig), \
+	$(addsuffix $(LIBRARY_PREFIX)jsig$(SHARED_LIBRARY_SUFFIX), \
 		$(OPENJ9_VM_BUILD_DIR)/ \
 		$(addprefix $(LIB_DST_DIR), / /j9vm/ /server/)))
 
@@ -102,7 +102,7 @@ $(call openj9_copy_shlibs, \
 ifeq (zos,$(OPENJDK_TARGET_OS))
 
 $(call openj9_copy_files_and_debuginfos, \
-	$(addsuffix /$(call SHARED_LIBRARY,j9a2e), \
+	$(addsuffix /$(LIBRARY_PREFIX)j9a2e$(SHARED_LIBRARY_SUFFIX), \
 		$(OPENJ9_VM_BUILD_DIR) \
 		$(LIB_DST_DIR)))
 
@@ -118,7 +118,7 @@ $(call openj9_copy_files,, \
 
 # 31/64-bit interoperability shim library and side deck files.
 $(call openj9_copy_files_and_debuginfos, \
-	$(addsuffix $(call SHARED_LIBRARY,jvm31), \
+	$(addsuffix $(LIBRARY_PREFIX)jvm31$(SHARED_LIBRARY_SUFFIX), \
 		$(OPENJ9_VM_BUILD_DIR)/ \
 		$(addprefix $(LIB_DST_DIR), /j9vm/ /server/)))
 
@@ -133,13 +133,13 @@ endif # zos
 ifeq ($(call isTargetOs, windows), true)
 
 $(call openj9_copy_files,, \
-	$(addsuffix /$(call STATIC_LIBRARY,jsig), \
+	$(addsuffix /$(LIBRARY_PREFIX)jsig$(STATIC_LIBRARY_SUFFIX), \
 		$(OPENJ9_VM_BUILD_DIR)/lib \
 		$(LIB_DST_DIR)))
 
 $(call openj9_copy_files,, \
-	$(OPENJ9_VM_BUILD_DIR)/redirector/$(call STATIC_LIBRARY,redirector_jvm) \
-	$(LIB_DST_DIR)/$(call STATIC_LIBRARY,jvm))
+	$(OPENJ9_VM_BUILD_DIR)/redirector/$(LIBRARY_PREFIX)redirector_jvm$(STATIC_LIBRARY_SUFFIX) \
+	$(LIB_DST_DIR)/$(LIBRARY_PREFIX)jvm$(STATIC_LIBRARY_SUFFIX))
 
 endif # windows
 

--- a/closed/make/modules/ibm.healthcenter/Copy.gmk
+++ b/closed/make/modules/ibm.healthcenter/Copy.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2021, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -65,9 +65,9 @@ HEALTHCENTER_EXCLUSIONS := \
 # Not all components are available on all platforms, hence the use of $(wildcard).
 # Also note that evaluation must be delayed, so we use '=' instead of ':='.
 HEALTHCENTER_LIBRARIES = \
-	$(HEALTHCENTER_HOME)/$(call SHARED_LIBRARY,healthcenter) \
-	$(HEALTHCENTER_HOME)/plugins/$(call SHARED_LIBRARY,hcapiplugin) \
-	$(wildcard $(HEALTHCENTER_HOME)/plugins/$(call SHARED_LIBRARY,hcmqtt))
+	$(HEALTHCENTER_HOME)/$(LIBRARY_PREFIX)healthcenter$(SHARED_LIBRARY_SUFFIX) \
+	$(HEALTHCENTER_HOME)/plugins/$(LIBRARY_PREFIX)hcapiplugin$(SHARED_LIBRARY_SUFFIX) \
+	$(wildcard $(HEALTHCENTER_HOME)/plugins/$(LIBRARY_PREFIX)hcmqtt$(SHARED_LIBRARY_SUFFIX))
 
 # User-configurable .properties files should be encoded in EBCDIC on z/OS.
 ifeq (zos,$(OPENJDK_TARGET_OS))

--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -52,10 +52,12 @@ public final class RestrictedSecurity {
 
     private static final Debug debug = Debug.getInstance("semerufips");
 
-    // Restricted security mode enable check, only supported on Linux x64.
+    // Restricted security mode enable check.
     private static final boolean userEnabledFIPS;
     private static boolean isFIPSSupported;
     private static boolean isFIPSEnabled;
+
+    private static final boolean allowSetProperties;
 
     private static final boolean isNSSSupported;
     private static final boolean isOpenJCEPlusSupported;
@@ -70,6 +72,8 @@ public final class RestrictedSecurity {
     private static String userSecurityID;
 
     private static RestrictedSecurityProperties restricts;
+
+    private static final Set<String> unmodifiableProperties = new HashSet<>();
 
     private static final Map<String, List<String>> supportedPlatformsNSS = new HashMap<>();
     private static final Map<String, List<String>> supportedPlatformsOpenJCEPlus = new HashMap<>();
@@ -89,7 +93,8 @@ public final class RestrictedSecurity {
                         return new String[] { System.getProperty("semeru.fips"),
                                 System.getProperty("semeru.customprofile"),
                                 System.getProperty("os.name"),
-                                System.getProperty("os.arch") };
+                                System.getProperty("os.arch"),
+                                System.getProperty("semeru.fips.allowsetproperties") };
                     }
                 });
 
@@ -128,6 +133,7 @@ public final class RestrictedSecurity {
         isFIPSSupported = isNSSSupported;
 
         userEnabledFIPS = Boolean.parseBoolean(props[0]);
+        allowSetProperties = Boolean.parseBoolean(props[4]);
 
         if (userEnabledFIPS) {
             if (isFIPSSupported) {
@@ -368,6 +374,53 @@ public final class RestrictedSecurity {
     }
 
     /**
+     * Check whether a security property can be set.
+     *
+     * A security property that is set by a RestrictedSecurity profile,
+     * while FIPS security mode is enabled, cannot be reset programmatically.
+     *
+     * Every time an attempt to set a security property is made, a check is
+     * performed. If the above scenario holds true, a SecurityException is
+     * thrown.
+     *
+     * One can override this behaviour and allow the user to set any security
+     * property through the use of {@code -Dsemeru.fips.allowsetproperties=true}.
+     *
+     * @param key the security property that the user wants to set
+     * @throws SecurityException
+     *         if the security property is set by the profile and cannot
+     *         be altered
+     */
+    public static void checkSetSecurityProperty(String key) {
+        if (debug != null) {
+            debug.println("RestrictedSecurity: Checking whether property '"
+                    + key + "' can be set.");
+        }
+
+        /*
+         * Only disallow setting of security properties that are set by the active profile,
+         * if FIPS has been enabled.
+         *
+         * Allow any change, if the 'semeru.fips.allowsetproperties' flag is set to true.
+         */
+        if (unmodifiableProperties.contains(key)) {
+            if (debug != null) {
+                debug.println("RestrictedSecurity: Property '" + key + "' cannot be set.");
+                debug.println("If you want to override the check and allow all security"
+                        + "properties to be set, use '-Dsemeru.fips.allowsetproperties=true'.");
+                debug.println("BEWARE: You might not be FIPS compliant if you select to override!");
+            }
+            throw new SecurityException("FIPS mode: User-specified '" + key
+                    + "' cannot override profile definition.");
+        }
+
+        if (debug != null) {
+            debug.println("RestrictedSecurity: Property '"
+                    + key + "' can be set without issue.");
+        }
+    }
+
+    /**
      * Remove the security providers and only add restricted security providers.
      *
      * @param props the java.security properties
@@ -468,10 +521,10 @@ public final class RestrictedSecurity {
         // JDK properties name as key, restricted security properties value as value.
         propsMapping.put("jdk.tls.disabledNamedCurves", restricts.jdkTlsDisabledNamedCurves);
         propsMapping.put("jdk.tls.disabledAlgorithms", restricts.jdkTlsDisabledAlgorithms);
-        propsMapping.put("jdk.tls.ephemeralDHKeySize", restricts.jdkTlsDphemeralDHKeySize);
+        propsMapping.put("jdk.tls.ephemeralDHKeySize", restricts.jdkTlsEphemeralDHKeySize);
         propsMapping.put("jdk.tls.legacyAlgorithms", restricts.jdkTlsLegacyAlgorithms);
         propsMapping.put("jdk.certpath.disabledAlgorithms", restricts.jdkCertpathDisabledAlgorithms);
-        propsMapping.put("jdk.security.legacyAlgorithm", restricts.jdkSecurityLegacyAlgorithm);
+        propsMapping.put("jdk.security.legacyAlgorithms", restricts.jdkSecurityLegacyAlgorithms);
         String fipsMode = System.getProperty("com.ibm.fips.mode");
         if (fipsMode == null) {
             System.setProperty("com.ibm.fips.mode", restricts.jdkFipsMode);
@@ -486,6 +539,11 @@ public final class RestrictedSecurity {
             String propsOldValue = props.getProperty(jdkPropsName);
             if (isNullOrBlank(propsOldValue)) {
                 propsOldValue = "";
+            }
+
+            if ((propsNewValue != null) && userEnabledFIPS && !allowSetProperties) {
+                // Add to set of properties set by the active profile.
+                unmodifiableProperties.add(jdkPropsName);
             }
 
             if (!isNullOrBlank(propsNewValue)) {
@@ -588,10 +646,10 @@ public final class RestrictedSecurity {
         // Security properties.
         private String jdkTlsDisabledNamedCurves;
         private String jdkTlsDisabledAlgorithms;
-        private String jdkTlsDphemeralDHKeySize;
+        private String jdkTlsEphemeralDHKeySize;
         private String jdkTlsLegacyAlgorithms;
         private String jdkCertpathDisabledAlgorithms;
-        private String jdkSecurityLegacyAlgorithm;
+        private String jdkSecurityLegacyAlgorithms;
         private String keyStoreType;
         private String keyStore;
 
@@ -740,13 +798,13 @@ public final class RestrictedSecurity {
                     securityProps.getProperty(profileID + ".tls.disabledNamedCurves"));
             jdkTlsDisabledAlgorithms = parseProperty(
                     securityProps.getProperty(profileID + ".tls.disabledAlgorithms"));
-            jdkTlsDphemeralDHKeySize = parseProperty(
+            jdkTlsEphemeralDHKeySize = parseProperty(
                     securityProps.getProperty(profileID + ".tls.ephemeralDHKeySize"));
             jdkTlsLegacyAlgorithms = parseProperty(
                     securityProps.getProperty(profileID + ".tls.legacyAlgorithms"));
             jdkCertpathDisabledAlgorithms = parseProperty(
                     securityProps.getProperty(profileID + ".jce.certpath.disabledAlgorithms"));
-            jdkSecurityLegacyAlgorithm = parseProperty(
+            jdkSecurityLegacyAlgorithms = parseProperty(
                     securityProps.getProperty(profileID + ".jce.legacyAlgorithms"));
             keyStoreType = parseProperty(
                     securityProps.getProperty(profileID + ".keystore.type"));
@@ -1136,13 +1194,17 @@ public final class RestrictedSecurity {
         }
 
         /**
-         * Check if the input string is null. If null return "".
+         * Trim input string if not null.
          *
          * @param string the input string
-         * @return "" if the string is null
+         * @return the string trimmed or null
          */
         private static String parseProperty(String string) {
-            return (string != null) ? string.trim() : "";
+            if (string != null) {
+                string = string.trim();
+            }
+
+            return string;
         }
 
         /**

--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -794,6 +794,10 @@ public final class Security {
      */
     public static void setProperty(String key, String datum) {
         check("setProperty." + key);
+
+        // Check whether the change to the property is allowed.
+        RestrictedSecurity.checkSetSecurityProperty(key);
+
         props.put(key, datum);
         invalidateSMCache(key);  /* See below. */
 


### PR DESCRIPTION
They were removed by:
* [8330351: Remove the SHARED_LIBRARY and STATIC_LIBRARY macros](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/51bae6ee3f3f889b19d2f703709d71de31d4154a)

Fixes: https://github.com/eclipse-openj9/openj9/issues/19330.