### PR TITLE
Update copyrightCheckDir to post to Slack on failure

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.groovy
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2024 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,7 +20,7 @@
  * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
  *
  * ===========================================================================
-*/
+ */
 
 def VERBOSE = ""
 def ROOTDIR = ""
@@ -52,6 +52,9 @@ timeout(time: 6, unit: 'HOURS') {
                                                 timeout: 30]],
                                 userRemoteConfigs: [[url: scm.getUserRemoteConfigs().get(0).getUrl()]]]
                     sh (script: "sh buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh REPO=${params.ghprbGhRepository} ${VERBOSE} ${ROOTDIR}")
+                } catch (e) {
+                    slackSend channel: '#jenkins-sandbox', color: 'danger', message: "Failed: ${JOB_NAME} #${BUILD_NUMBER} (<${BUILD_URL}|Open>)"
+                    throw e
                 } finally {
                     cleanWs()
                 }
@@ -59,4 +62,3 @@ timeout(time: 6, unit: 'HOURS') {
         } // timestamps
     } // stage
 } // timeout
-


### PR DESCRIPTION
Tested (a version modified to fail) via https://openj9-jenkins.osuosl.org/view/Infrastructure/job/CopyrightCheck-OpenJDK22/137/
The expected Slack message occurred.
https://openj9.slack.com/archives/CBRG8KTGV/p1713474395613149

Used https://github.com/eclipse-openj9/openj9/blob/master/buildenv/jenkins/jobs/infrastructure/artifactory_cleanup.groovy#L76 as an example.