### PR TITLE
Add support for ECDSA signatures using native OpenSSL library

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -416,6 +416,19 @@ public class NativeCrypto {
                                       int id,
                                       int hashAlgorithm);
 
+    /* Native ECDSA interfaces. */
+    public final native int ECDSASign(long key,
+                                      byte[] digest,
+                                      int digestLen,
+                                      byte[] signature,
+                                      int sigLen);
+
+    public final native int ECDSAVerify(long key,
+                                        byte[] digest,
+                                        int digestLen,
+                                        byte[] signature,
+                                        int sigLen);
+
     /* Native XDH (X25519, X448) interfaces. */
     public final native int XDHCreateKeys(byte[] privateKey,
                                           int privateKeyLength,

--- a/closed/src/java.base/share/classes/sun/security/ec/NativeECDSASignature.java
+++ b/closed/src/java.base/share/classes/sun/security/ec/NativeECDSASignature.java
@@ -1,0 +1,722 @@
+/*
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
+package sun.security.ec;
+
+import java.nio.ByteBuffer;
+import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.ProviderException;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.SignatureException;
+import java.security.SignatureSpi;
+import java.security.interfaces.ECKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.util.Optional;
+
+import jdk.crypto.jniprovider.NativeCrypto;
+import sun.security.provider.Sun;
+import sun.security.util.ECUtil;
+
+/**
+ * ECDSA signature implementation. This class currently supports the
+ * following algorithm names:
+ *
+ * <ul>
+ *   <li>"NONEwithECDSA"</li>
+ *   <li>"SHA1withECDSA"</li>
+ *   <li>"SHA224withECDSA"</li>
+ *   <li>"SHA256withECDSA"</li>
+ *   <li>"SHA384withECDSA"</li>
+ *   <li>"SHA512withECDSA"</li>
+ *   <li>"SHA3-224withECDSA"</li>
+ *   <li>"SHA3-256withECDSA"</li>
+ *   <li>"SHA3-384withECDSA"</li>
+ *   <li>"SHA3-512withECDSA"</li>
+ *   <li>"NONEwithECDSAinP1363Format"</li>
+ *   <li>"SHA1withECDSAinP1363Format"</li>
+ *   <li>"SHA224withECDSAinP1363Format"</li>
+ *   <li>"SHA256withECDSAinP1363Format"</li>
+ *   <li>"SHA384withECDSAinP1363Format"</li>
+ *   <li>"SHA512withECDSAinP1363Format"</li>
+ *   <li>"SHA3-224withECDSAinP1363Format"</li>
+ *   <li>"SHA3-256withECDSAinP1363Format"</li>
+ *   <li>"SHA3-384withECDSAinP1363Format"</li>
+ *   <li>"SHA3-512withECDSAinP1363Format"</li>
+ * </ul>
+ *
+ * @since   1.7
+ */
+abstract class NativeECDSASignature extends SignatureSpi {
+
+    private static NativeCrypto nativeCrypto;
+    private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
+
+    // message digest implementation we use
+    private final MessageDigest messageDigest;
+
+    // supplied entropy
+    private SecureRandom random;
+
+    // flag indicating whether the digest has been reset
+    private boolean needsReset;
+
+    // private key, if initialized for signing
+    private ECPrivateKey privateKey;
+
+    // private key impl, if initialized for signing
+    private ECPrivateKeyImpl privateKeyImpl;
+
+    // public key, if initialized for verifying
+    private ECPublicKey publicKey;
+
+    // public key impl, if initialized for verifying
+    private ECPublicKeyImpl publicKeyImpl;
+
+    // the format (i.e., true for the IEEE P1363 format and false for ASN.1)
+    private final boolean p1363Format;
+
+    // the Java implementation, if needed
+    private ECDSASignature javaImplementation;
+
+    /**
+     * Constructs a new NativeECDSASignature.
+     *
+     * @exception ProviderException if the native ECC library is unavailable.
+     */
+    NativeECDSASignature() {
+        this(false);
+    }
+
+    /**
+     * Constructs a new NativeECDSASignature that will use the specified
+     * signature format. {@code p1363Format} should be {@code true} to
+     * use the IEEE P1363 format. If {@code p1363Format} is {@code false},
+     * the DER-encoded ASN.1 format will be used. This constructor is
+     * used by the RawECDSA subclasses.
+     */
+    NativeECDSASignature(boolean p1363Format) {
+        this.messageDigest = null;
+        this.p1363Format = p1363Format;
+    }
+
+    /**
+     * Constructs a new NativeECDSASignature. Used by subclasses.
+     */
+    NativeECDSASignature(String digestName) {
+        this(digestName, false);
+    }
+
+    /**
+     * Constructs a new NativeECDSASignature that will use the specified
+     * digest and signature format. {@code p1363Format} should be
+     * {@code true} to use the IEEE P1363 format. If {@code p1363Format}
+     * is {@code false}, the DER-encoded ASN.1 format will be used. This
+     * constructor is used by subclasses.
+     */
+    NativeECDSASignature(String digestName, boolean p1363Format) {
+        try {
+            this.messageDigest = MessageDigest.getInstance(digestName);
+        } catch (NoSuchAlgorithmException e) {
+            throw new ProviderException(e);
+        }
+        this.needsReset = false;
+        this.p1363Format = p1363Format;
+    }
+
+    // Class for Raw ECDSA signatures.
+    static class RawECDSA extends NativeECDSASignature {
+
+        // the longest supported digest is 512 bits (SHA-512)
+        private static final int RAW_ECDSA_MAX = 64;
+
+        private final byte[] precomputedDigest;
+        private int offset;
+
+        RawECDSA(boolean p1363Format) {
+            super(p1363Format);
+            precomputedDigest = new byte[RAW_ECDSA_MAX];
+        }
+
+        // Stores the precomputed message digest value.
+        @Override
+        protected void engineUpdate(byte b) throws SignatureException {
+            if (offset >= precomputedDigest.length) {
+                offset = RAW_ECDSA_MAX + 1;
+                return;
+            }
+            precomputedDigest[offset++] = b;
+        }
+
+        // Stores the precomputed message digest value.
+        @Override
+        protected void engineUpdate(byte[] b, int off, int len)
+        throws SignatureException {
+            if (offset >= precomputedDigest.length) {
+                offset = RAW_ECDSA_MAX + 1;
+                return;
+            }
+            System.arraycopy(b, off, precomputedDigest, offset, len);
+            offset += len;
+        }
+
+        // Stores the precomputed message digest value.
+        @Override
+        protected void engineUpdate(ByteBuffer byteBuffer) {
+            int len = byteBuffer.remaining();
+            if (len <= 0) {
+                return;
+            }
+            if (len >= (precomputedDigest.length - offset)) {
+                offset = RAW_ECDSA_MAX + 1;
+                return;
+            }
+            byteBuffer.get(precomputedDigest, offset, len);
+            offset += len;
+        }
+
+        @Override
+        protected void resetDigest() {
+            offset = 0;
+        }
+
+        // Returns the precomputed message digest value.
+        @Override
+        protected byte[] getDigestValue() throws SignatureException {
+            if (offset > RAW_ECDSA_MAX) {
+                throw new SignatureException("Message digest is too long");
+
+            }
+            byte[] result = new byte[offset];
+            System.arraycopy(precomputedDigest, 0, result, 0, offset);
+            offset = 0;
+
+            return result;
+        }
+    }
+
+    // Nested class for NONEwithECDSA signatures.
+    public static final class Raw extends RawECDSA {
+        public Raw() {
+            super(false);
+        }
+    }
+
+    // Nested class for NONEwithECDSAinP1363Format signatures.
+    public static final class RawinP1363Format extends RawECDSA {
+        public RawinP1363Format() {
+            super(true);
+        }
+    }
+
+    // Nested class for SHA1withECDSA signatures.
+    public static final class SHA1 extends NativeECDSASignature {
+        public SHA1() {
+            super("SHA1");
+        }
+    }
+
+    // Nested class for SHA1withECDSAinP1363Format signatures.
+    public static final class SHA1inP1363Format extends NativeECDSASignature {
+        public SHA1inP1363Format() {
+            super("SHA1", true);
+        }
+    }
+
+    // Nested class for SHA224withECDSA signatures.
+    public static final class SHA224 extends NativeECDSASignature {
+        public SHA224() {
+            super("SHA-224");
+        }
+    }
+
+    // Nested class for SHA224withECDSAinP1363Format signatures.
+    public static final class SHA224inP1363Format extends NativeECDSASignature {
+        public SHA224inP1363Format() {
+            super("SHA-224", true);
+        }
+    }
+
+    // Nested class for SHA256withECDSA signatures.
+    public static final class SHA256 extends NativeECDSASignature {
+        public SHA256() {
+            super("SHA-256");
+        }
+    }
+
+    // Nested class for SHA256withECDSAinP1363Format signatures.
+    public static final class SHA256inP1363Format extends NativeECDSASignature {
+        public SHA256inP1363Format() {
+            super("SHA-256", true);
+        }
+    }
+
+    // Nested class for SHA384withECDSA signatures.
+    public static final class SHA384 extends NativeECDSASignature {
+        public SHA384() {
+            super("SHA-384");
+        }
+    }
+
+    // Nested class for SHA384withECDSAinP1363Format signatures.
+    public static final class SHA384inP1363Format extends NativeECDSASignature {
+        public SHA384inP1363Format() {
+            super("SHA-384", true);
+        }
+    }
+
+    // Nested class for SHA512withECDSA signatures.
+    public static final class SHA512 extends NativeECDSASignature {
+        public SHA512() {
+            super("SHA-512");
+        }
+    }
+
+    // Nested class for SHA512withECDSAinP1363Format signatures.
+    public static final class SHA512inP1363Format extends NativeECDSASignature {
+        public SHA512inP1363Format() {
+            super("SHA-512", true);
+        }
+    }
+
+    // Nested class for SHA3_224withECDSA signatures.
+    public static final class SHA3_224 extends NativeECDSASignature {
+        public SHA3_224() {
+        super("SHA3-224");
+        }
+    }
+
+    // Nested class for SHA3_224withECDSAinP1363Format signatures.
+    public static final class SHA3_224inP1363Format extends NativeECDSASignature {
+        public SHA3_224inP1363Format() {
+            super("SHA3-224", true);
+        }
+    }
+
+    // Nested class for SHA3_256withECDSA signatures.
+    public static final class SHA3_256 extends NativeECDSASignature {
+        public SHA3_256() {
+            super("SHA3-256");
+        }
+    }
+
+    // Nested class for SHA3_256withECDSAinP1363Format signatures.
+    public static final class SHA3_256inP1363Format extends NativeECDSASignature {
+        public SHA3_256inP1363Format() {
+            super("SHA3-256", true);
+        }
+    }
+
+    // Nested class for SHA3_384withECDSA signatures.
+    public static final class SHA3_384 extends NativeECDSASignature {
+        public SHA3_384() {
+            super("SHA3-384");
+        }
+    }
+
+    // Nested class for SHA3_384withECDSAinP1363Format signatures.
+    public static final class SHA3_384inP1363Format extends NativeECDSASignature {
+        public SHA3_384inP1363Format() {
+            super("SHA3-384", true);
+        }
+    }
+
+    // Nested class for SHA3_512withECDSA signatures.
+    public static final class SHA3_512 extends NativeECDSASignature {
+        public SHA3_512() {
+            super("SHA3-512");
+        }
+    }
+
+    // Nested class for SHA3_512withECDSAinP1363Format signatures.
+    public static final class SHA3_512inP1363Format extends NativeECDSASignature {
+        public SHA3_512inP1363Format() {
+            super("SHA3-512", true);
+        }
+    }
+
+    // Initialize for verification. See JCA doc.
+    @Override
+    protected void engineInitVerify(PublicKey publicKey)
+    throws InvalidKeyException {
+        ECPublicKey key = (ECPublicKey) ECKeyFactory.toECKey(publicKey);
+        // Should check that the supplied key is appropriate for signature
+        // algorithm (e.g. P-256 for SHA256withECDSA).
+        this.publicKey = key;
+        this.privateKey = null;
+        resetDigest();
+
+        if (key instanceof ECPublicKeyImpl keyImpl) {
+            this.publicKeyImpl = keyImpl;
+            this.privateKeyImpl = null;
+            this.javaImplementation = null;
+            if (nativeCryptTrace) {
+                System.err.println("InitVerify: Using native crypto implementation for verifying signature.");
+            }
+        } else {
+            this.javaImplementation = getJavaInstance();
+            this.javaImplementation.engineInitVerify(publicKey);
+        }
+    }
+
+    // Initialize for signing. See JCA doc.
+    @Override
+    protected void engineInitSign(PrivateKey privateKey)
+    throws InvalidKeyException {
+        engineInitSign(privateKey, null);
+    }
+
+    // Initialize for signing. See JCA doc.
+    @Override
+    protected void engineInitSign(PrivateKey privateKey, SecureRandom random)
+    throws InvalidKeyException {
+        if (random == null) {
+            if (nativeCryptTrace) {
+                System.err.println("No SecureRandom implementation was provided during"
+                        + " initialization. Using OpenSSL.");
+            }
+        } else if ((random.getProvider() instanceof Sun)
+            && ("NativePRNG".equals(random.getAlgorithm()) || "DRBG".equals(random.getAlgorithm()))
+        ) {
+            if (nativeCryptTrace) {
+                System.err.println("Default SecureRandom implementation was provided during"
+                        + " initialization. Using OpenSSL.");
+            }
+        } else {
+            if (nativeCryptTrace) {
+                System.err.println("SecureRandom implementation was provided during"
+                        + " initialization. Using Java implementation instead of OpenSSL.");
+            }
+            this.javaImplementation = getJavaInstance();
+            this.javaImplementation.engineInitSign(privateKey, random);
+            return;
+        }
+
+        ECPrivateKey key = (ECPrivateKey) ECKeyFactory.toECKey(privateKey);
+        ECUtil.checkPrivateKey(key);
+        // Should check that the supplied key is appropriate for signature
+        // algorithm (e.g. P-256 for SHA256withECDSA).
+        this.privateKey = key;
+        this.publicKey = null;
+        this.random = random;
+        resetDigest();
+
+        if (key instanceof ECPrivateKeyImpl keyImpl) {
+            this.publicKeyImpl = null;
+            this.privateKeyImpl = keyImpl;
+            this.javaImplementation = null;
+            if (nativeCryptTrace) {
+                System.err.println("InitSign: Using native crypto implementation for verifying signature.");
+            }
+        } else {
+            this.javaImplementation = getJavaInstance();
+            this.javaImplementation.engineInitSign(privateKey, random);
+        }
+    }
+
+    /**
+     * Resets the message digest if needed.
+     */
+    protected void resetDigest() {
+        if (needsReset) {
+            if (messageDigest != null) {
+                messageDigest.reset();
+            }
+            needsReset = false;
+        }
+    }
+
+    /**
+     * Returns the message digest value.
+     */
+    protected byte[] getDigestValue() throws SignatureException {
+        needsReset = false;
+        return messageDigest.digest();
+    }
+
+    // Update the signature with the plaintext data. See JCA doc.
+    @Override
+    protected void engineUpdate(byte b) throws SignatureException {
+        if (this.javaImplementation != null) {
+            this.javaImplementation.engineUpdate(b);
+        } else {
+            messageDigest.update(b);
+            needsReset = true;
+        }
+    }
+
+    // Update the signature with the plaintext data. See JCA doc.
+    @Override
+    protected void engineUpdate(byte[] b, int off, int len)
+    throws SignatureException {
+        if (this.javaImplementation != null) {
+            this.javaImplementation.engineUpdate(b, off, len);
+        } else {
+            messageDigest.update(b, off, len);
+            needsReset = true;
+        }
+    }
+
+    // Update the signature with the plaintext data. See JCA doc.
+    @Override
+    protected void engineUpdate(ByteBuffer byteBuffer) {
+        if (this.javaImplementation != null) {
+            this.javaImplementation.engineUpdate(byteBuffer);
+        } else {
+            int len = byteBuffer.remaining();
+            if (len <= 0) {
+                return;
+            }
+
+            messageDigest.update(byteBuffer);
+            needsReset = true;
+        }
+    }
+
+    // Sign the data and return the signature. See JCA doc.
+    @Override
+    protected byte[] engineSign() throws SignatureException {
+        if (this.javaImplementation != null) {
+            return this.javaImplementation.engineSign();
+        }
+
+        long nativePrivateKey = privateKeyImpl.getNativePtr();
+        byte[] digest = getDigestValue();
+        int digestLen = digest.length;
+        ECParameterSpec params = privateKey.getParams();
+        int sigLen = ((params.getOrder().bitLength() + 7) / 8) * 2;
+        byte[] sig = new byte[sigLen];
+
+        ECDSAOperations.forParameters(params)
+                .orElseThrow(() -> new SignatureException("Curve not supported: " + params));
+
+        if (nativePrivateKey == -1) {
+            throw new ProviderException("Keys could not be converted to native OpenSSL format");
+        }
+        if (nativeCryptTrace) {
+            System.err.println("Sign: Keys were successfully converted to native OpenSSL format.");
+        }
+
+        if (nativeCrypto == null) {
+            nativeCrypto = NativeCrypto.getNativeCrypto();
+        }
+
+        int ret;
+        synchronized (this.privateKey) {
+            ret = nativeCrypto.ECDSASign(nativePrivateKey, digest, digestLen, sig, sig.length);
+        }
+        if (ret == -1) {
+            throw new ProviderException("An error occured when creating signature");
+        }
+
+        if (nativeCryptTrace) {
+            System.err.println("Sign: Signature was successfully created.");
+        }
+
+        if (p1363Format) {
+            return sig;
+        } else {
+            return ECUtil.encodeSignature(sig);
+        }
+    }
+
+    // Verify the data and return the result. See JCA doc.
+    @Override
+    protected boolean engineVerify(byte[] signature) throws SignatureException {
+        if (this.javaImplementation != null) {
+            return this.javaImplementation.engineVerify(signature);
+        }
+
+        ECPoint w = publicKey.getW();
+        ECParameterSpec params = publicKey.getParams();
+
+        // Partial public key validation.
+        try {
+            ECUtil.validatePublicKey(w, params);
+        } catch (InvalidKeyException e) {
+            return false;
+        }
+
+        ECDSAOperations ops = ECDSAOperations.forParameters(params)
+                .orElseThrow(() -> new SignatureException("Curve not supported: " + params));
+
+        // Full public key validation, only necessary when h != 1.
+        if (params.getCofactor() != 1) {
+            if (!ops.getEcOperations().checkOrder(w)) {
+                return false;
+            }
+        }
+
+        long nativePublicKey = publicKeyImpl.getNativePtr();
+        if (nativePublicKey == -1) {
+            throw new ProviderException("Could not convert keys to native format");
+        }
+        if (nativeCryptTrace) {
+            System.err.println("Verify: Keys were successfully converted to native OpenSSL format.");
+        }
+
+        if (nativeCrypto == null) {
+            nativeCrypto = NativeCrypto.getNativeCrypto();
+        }
+
+        byte[] sig;
+        if (p1363Format) {
+            sig = signature;
+        } else {
+            sig = ECUtil.decodeSignature(signature);
+        }
+
+        byte[] digest = getDigestValue();
+        int digestLen = digest.length;
+
+        int ret;
+        synchronized (this.publicKey) {
+            ret = nativeCrypto.ECDSAVerify(nativePublicKey, digest, digestLen, sig, sig.length);
+        }
+
+        if (ret == 1) {
+            if (nativeCryptTrace) {
+                System.err.println("Verify: Signature was successfully verified.");
+            }
+            return true;
+        } else if (ret == 0) {
+            if (nativeCryptTrace) {
+                System.err.println("Verify: Signature verification was unsuccessful.");
+            }
+            return false;
+        } else {
+            throw new ProviderException("An error occured when verifying signature");
+        }
+    }
+
+    // Set parameter, not supported. See JCA doc.
+    @Deprecated
+    @Override
+    protected void engineSetParameter(String param, Object value)
+    throws InvalidParameterException {
+        throw new UnsupportedOperationException("setParameter() not supported");
+    }
+
+    @Override
+    protected void engineSetParameter(AlgorithmParameterSpec params)
+            throws InvalidAlgorithmParameterException {
+        // Interop: some certificates include parameters in an ECDSA
+        // algorithm identifier. We only accept one matching the key.
+        if (params == null) {
+            return;
+        }
+        if (!(params instanceof ECParameterSpec ecparams)) {
+            throw new InvalidAlgorithmParameterException(
+                    "Parameters must be of type ECParameterSpec");
+        }
+        ECKey key = (this.privateKey == null? this.publicKey : this.privateKey);
+        if ((key != null) && !ECUtil.equals(ecparams, key.getParams())) {
+            throw new InvalidAlgorithmParameterException
+                ("Signature params does not match key params");
+        }
+    }
+
+    // Get parameter, not supported. See JCA doc.
+    @Deprecated
+    @Override
+    protected Object engineGetParameter(String param)
+    throws InvalidParameterException {
+        throw new UnsupportedOperationException("getParameter() not supported");
+    }
+
+    @Override
+    protected AlgorithmParameters engineGetParameters() {
+        // Always return null even if setParameter is called before.
+        // According to RFC 3279 2.2.3 and RFC 5758 3.2, no parameters is
+        // defined for ECDSA AlgorithmIdentifiers.
+        return null;
+    }
+
+    private ECDSASignature getJavaInstance() {
+        if (this.messageDigest == null) {
+            return this.p1363Format
+                    ? new ECDSASignature.RawinP1363Format()
+                    : new ECDSASignature.Raw();
+        } else {
+            String mdAlgo = messageDigest.getAlgorithm();
+            switch (mdAlgo) {
+                case "SHA1":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA1inP1363Format()
+                            : new ECDSASignature.SHA1();
+                case "SHA-224":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA224inP1363Format()
+                            : new ECDSASignature.SHA224();
+                case "SHA-256":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA256inP1363Format()
+                            : new ECDSASignature.SHA256();
+                case "SHA-384":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA384inP1363Format()
+                            : new ECDSASignature.SHA384();
+                case "SHA-512":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA512inP1363Format()
+                            : new ECDSASignature.SHA512();
+                case "SHA3-224":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA3_224inP1363Format()
+                            : new ECDSASignature.SHA3_224();
+                case "SHA3-256":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA3_256inP1363Format()
+                            : new ECDSASignature.SHA3_256();
+                case "SHA3-384":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA3_384inP1363Format()
+                            : new ECDSASignature.SHA3_384();
+                case "SHA3-512":
+                    return this.p1363Format
+                            ? new ECDSASignature.SHA3_512inP1363Format()
+                            : new ECDSASignature.SHA3_512();
+                default:
+                    throw new ProviderException("Unexpected algorithm: " + mdAlgo);
+            }
+        }
+    }
+}

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -155,6 +155,14 @@ typedef int OSSL_EC_KEY_check_key_t(const EC_KEY *);
 typedef int EC_set_public_key_t(EC_KEY *, BIGNUM *, BIGNUM *, int);
 typedef const BIGNUM *OSSL_EC_KEY_get0_private_key_t(const EC_KEY *);
 
+typedef ECDSA_SIG *OSSL_ECDSA_do_sign_t(const unsigned char *, int, EC_KEY *);
+typedef int OSSL_ECDSA_do_verify_t(const unsigned char *, int, const ECDSA_SIG *, EC_KEY *);
+typedef ECDSA_SIG *OSSL_ECDSA_SIG_new_t(void);
+typedef void OSSL_ECDSA_SIG_free_t(ECDSA_SIG *);
+typedef const BIGNUM *OSSL_ECDSA_SIG_get0_r_t(const ECDSA_SIG *);
+typedef const BIGNUM *OSSL_ECDSA_SIG_get0_s_t(const ECDSA_SIG *);
+typedef int OSSL_ECDSA_SIG_set0_t(ECDSA_SIG *, BIGNUM *, BIGNUM *);
+
 typedef EVP_PKEY_CTX *OSSL_EVP_PKEY_CTX_new_t(EVP_PKEY *, ENGINE *);
 typedef EVP_PKEY_CTX *OSSL_EVP_PKEY_CTX_new_id_t(int, ENGINE *);
 typedef int OSSL_EVP_PKEY_keygen_init_t(EVP_PKEY_CTX *);
@@ -281,6 +289,15 @@ OSSL_EC_KEY_set_public_key_t* OSSL_EC_KEY_set_public_key;
 OSSL_EC_KEY_check_key_t* OSSL_EC_KEY_check_key;
 EC_set_public_key_t* EC_set_public_key;
 OSSL_EC_KEY_get0_private_key_t *OSSL_EC_KEY_get0_private_key;
+
+/* Define pointers for OpenSSL functions to handle ECDSA algorithm. */
+OSSL_ECDSA_do_sign_t *OSSL_ECDSA_do_sign;
+OSSL_ECDSA_do_verify_t *OSSL_ECDSA_do_verify;
+OSSL_ECDSA_SIG_new_t *OSSL_ECDSA_SIG_new;
+OSSL_ECDSA_SIG_free_t *OSSL_ECDSA_SIG_free;
+OSSL_ECDSA_SIG_get0_r_t *OSSL_ECDSA_SIG_get0_r;
+OSSL_ECDSA_SIG_get0_s_t *OSSL_ECDSA_SIG_get0_s;
+OSSL_ECDSA_SIG_set0_t *OSSL_ECDSA_SIG_set0;
 
 /* Define pointers for OpenSSL functions to handle XDH algorithm. */
 OSSL_EVP_PKEY_CTX_new_t *OSSL_EVP_PKEY_CTX_new;
@@ -566,7 +583,7 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         OSSL_ECGF2M = JNI_TRUE;
     }
 
-    /* Load the functions symbols for OpenSSL XDH algorithm. (Need OpenSSL 1.1.x or above). */
+    /* Load the functions symbols for OpenSSL XDH and ECDSA algorithms. (Need OpenSSL 1.1.x or above). */
     if (ossl_ver >= OPENSSL_VERSION_1_1_1) {
         OSSL_EVP_PKEY_CTX_new = (OSSL_EVP_PKEY_CTX_new_t *)find_crypto_symbol(crypto_library, "EVP_PKEY_CTX_new");
         OSSL_EVP_PKEY_CTX_new_id = (OSSL_EVP_PKEY_CTX_new_id_t *)find_crypto_symbol(crypto_library, "EVP_PKEY_CTX_new_id");
@@ -581,6 +598,14 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         OSSL_EVP_PKEY_derive_set_peer = (OSSL_EVP_PKEY_derive_set_peer_t *)find_crypto_symbol(crypto_library, "EVP_PKEY_derive_set_peer");
         OSSL_EVP_PKEY_derive = (OSSL_EVP_PKEY_derive_t *)find_crypto_symbol(crypto_library, "EVP_PKEY_derive");
         OSSL_EVP_PKEY_free = (OSSL_EVP_PKEY_free_t *)find_crypto_symbol(crypto_library, "EVP_PKEY_free");
+
+        OSSL_ECDSA_do_sign = (OSSL_ECDSA_do_sign_t *)find_crypto_symbol(crypto_library, "ECDSA_do_sign");
+        OSSL_ECDSA_do_verify = (OSSL_ECDSA_do_verify_t *)find_crypto_symbol(crypto_library, "ECDSA_do_verify");
+        OSSL_ECDSA_SIG_new = (OSSL_ECDSA_SIG_new_t *)find_crypto_symbol(crypto_library, "ECDSA_SIG_new");
+        OSSL_ECDSA_SIG_free = (OSSL_ECDSA_SIG_free_t *)find_crypto_symbol(crypto_library, "ECDSA_SIG_free");
+        OSSL_ECDSA_SIG_get0_r = (OSSL_ECDSA_SIG_get0_r_t *)find_crypto_symbol(crypto_library, "ECDSA_SIG_get0_r");
+        OSSL_ECDSA_SIG_get0_s = (OSSL_ECDSA_SIG_get0_s_t *)find_crypto_symbol(crypto_library, "ECDSA_SIG_get0_s");
+        OSSL_ECDSA_SIG_set0 = (OSSL_ECDSA_SIG_set0_t *)find_crypto_symbol(crypto_library, "ECDSA_SIG_set0");
     } else {
         OSSL_EVP_PKEY_CTX_new = NULL;
         OSSL_EVP_PKEY_CTX_new_id = NULL;
@@ -595,6 +620,14 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         OSSL_EVP_PKEY_derive_set_peer = NULL;
         OSSL_EVP_PKEY_derive = NULL;
         OSSL_EVP_PKEY_free = NULL;
+
+        OSSL_ECDSA_do_sign = NULL;
+        OSSL_ECDSA_do_verify = NULL;
+        OSSL_ECDSA_SIG_new = NULL;
+        OSSL_ECDSA_SIG_free = NULL;
+        OSSL_ECDSA_SIG_get0_r = NULL;
+        OSSL_ECDSA_SIG_get0_s = NULL;
+        OSSL_ECDSA_SIG_set0 = NULL;
     }
 
     /* Load the functions symbols for OpenSSL PBE algorithm. */
@@ -679,7 +712,14 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
              (NULL == OSSL_EVP_PKEY_derive_init) ||
              (NULL == OSSL_EVP_PKEY_derive_set_peer) ||
              (NULL == OSSL_EVP_PKEY_derive) ||
-             (NULL == OSSL_EVP_PKEY_free))) ||
+             (NULL == OSSL_EVP_PKEY_free) ||
+             (NULL == OSSL_ECDSA_do_sign) ||
+             (NULL == OSSL_ECDSA_do_verify) ||
+             (NULL == OSSL_ECDSA_SIG_new) ||
+             (NULL == OSSL_ECDSA_SIG_free) ||
+             (NULL == OSSL_ECDSA_SIG_get0_r) ||
+             (NULL == OSSL_ECDSA_SIG_get0_s) ||
+             (NULL == OSSL_ECDSA_SIG_set0))) ||
         /* Check symbols that are only available in OpenSSL 1.1.x and above */
         ((ossl_ver >= OPENSSL_VERSION_1_1_0) && ((NULL == OSSL_chacha20) || (NULL == OSSL_chacha20_poly1305))) ||
         /* Check symbols that are only available in OpenSSL 1.0.x and above */
@@ -3096,6 +3136,137 @@ cleanup:
     }
     if (NULL != nativeKey) {
         (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, 0);
+    }
+
+    return ret;
+}
+
+/* Create an ECDSA Signature
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    ECDSASign
+ * Signature: (J[BI[B)I
+ */
+JNIEXPORT jint JNICALL
+Java_jdk_crypto_jniprovider_NativeCrypto_ECDSASign
+  (JNIEnv *env, jclass obj, jlong key, jbyteArray digest, jint digestLen, jbyteArray sig, jint sigLen)
+{
+    jint ret = -1;
+
+    unsigned char *nativeDigest = NULL;
+    unsigned char *nativeSig = NULL;
+    EC_KEY *privateKey = (EC_KEY *)(intptr_t)key;
+    ECDSA_SIG *signature = NULL;
+    const BIGNUM *rBN = NULL;
+    const BIGNUM *sBN = NULL;
+
+    nativeDigest = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, digest, 0));
+    if (NULL == nativeDigest) {
+        goto cleanup;
+    }
+
+    signature = (*OSSL_ECDSA_do_sign)(nativeDigest, digestLen, privateKey);
+    if (NULL == signature) {
+        printf("Failed to create an ECDSA Signature.\n");
+        goto cleanup;
+    }
+
+    rBN = (*OSSL_ECDSA_SIG_get0_r)(signature);
+    sBN = (*OSSL_ECDSA_SIG_get0_s)(signature);
+
+    nativeSig = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, sig, 0));
+    if (NULL == nativeSig) {
+        goto cleanup;
+    }
+
+    ret = getArrayFromBN(rBN, nativeSig, sigLen / 2);
+    if (-1 == ret) {
+        goto cleanup;
+    }
+
+    ret = getArrayFromBN(sBN, &nativeSig[sigLen / 2], sigLen / 2);
+    if (-1 == ret) {
+        goto cleanup;
+    }
+
+    ret = sigLen;
+
+cleanup:
+    if (NULL != nativeSig) {
+        (*env)->ReleasePrimitiveArrayCritical(env, sig, nativeSig, 0);
+    }
+
+    if (NULL != signature) {
+        (*OSSL_ECDSA_SIG_free)(signature);
+    }
+
+    if (NULL != nativeDigest) {
+        (*env)->ReleasePrimitiveArrayCritical(env, digest, nativeDigest, JNI_ABORT);
+    }
+
+    return ret;
+}
+
+/* Verify an ECDSA Signature
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    ECDSAVerify
+ * Signature: (J[BI[B)I
+ */
+JNIEXPORT jint JNICALL
+Java_jdk_crypto_jniprovider_NativeCrypto_ECDSAVerify
+  (JNIEnv *env, jclass obj, jlong key, jbyteArray digest, jint digestLen, jbyteArray sig, jint sigLen)
+{
+    jint ret = -1;
+
+    unsigned char *nativeDigest = NULL;
+    unsigned char *nativeSig = NULL;
+    EC_KEY *publicKey = (EC_KEY *)(intptr_t)key;
+    ECDSA_SIG *signature = NULL;
+    BIGNUM *rBN = NULL;
+    BIGNUM *sBN = NULL;
+
+    nativeSig = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, sig, 0));
+    if (NULL == nativeSig) {
+        goto cleanup;
+    }
+
+    rBN = (*OSSL_BN_bin2bn)(nativeSig, sigLen / 2, NULL);
+    sBN = (*OSSL_BN_bin2bn)(&nativeSig[sigLen / 2], sigLen / 2, NULL);
+    signature = (*OSSL_ECDSA_SIG_new)();
+    if (0 == (*OSSL_ECDSA_SIG_set0)(signature, rBN, sBN)) {
+        goto cleanup;
+    }
+
+    nativeDigest = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, digest, 0));
+    if (NULL == nativeDigest) {
+        goto cleanup;
+    }
+
+    ret = (*OSSL_ECDSA_do_verify)(nativeDigest, digestLen, signature, publicKey);
+
+cleanup:
+    if (NULL != nativeDigest) {
+        (*env)->ReleasePrimitiveArrayCritical(env, digest, nativeDigest, JNI_ABORT);
+    }
+
+    if (NULL != signature) {
+        // The BIGNUM structs will be freed by the signature.
+        sBN = NULL;
+        rBN = NULL;
+        (*OSSL_ECDSA_SIG_free)(signature);
+    }
+
+    // In case the BIGNUM structs weren't freed by the signature.
+    if (NULL != sBN) {
+        (*OSSL_BN_free)(sBN);
+    }
+    if (NULL != rBN) {
+        (*OSSL_BN_free)(rBN);
+    }
+
+    if (NULL != nativeSig) {
+        (*env)->ReleasePrimitiveArrayCritical(env, sig, nativeSig, JNI_ABORT);
     }
 
     return ret;

--- a/src/java.base/share/classes/sun/security/ec/SunEC.java
+++ b/src/java.base/share/classes/sun/security/ec/SunEC.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -74,6 +74,11 @@ public final class SunEC extends Provider {
      * OpenSSL 1.1.0 or above is required for EC key generation support.
      */
     private static final boolean useNativeECKeyGen = NativeCrypto.isAlgorithmEnabled("jdk.nativeECKeyGen", "SunEC");
+
+    /* The property 'jdk.nativeECDSA' is used to control enablement of the native
+     * ECDSA signature implementation.
+     */
+    private static final boolean useNativeECDSA = NativeCrypto.isAlgorithmEnabled("jdk.nativeECDSA", "SunEC");
 
     /* The property 'jdk.nativeXDHKeyAgreement' is used to control enablement of the native
      * XDH key agreement. XDH key agreement is only supported in OpenSSL 1.1.1 and above.
@@ -130,37 +135,96 @@ public final class SunEC extends Provider {
                     if (inP1363) {
                         algo = algo.substring(0, algo.length() - 13);
                     }
-                    if (algo.equals("SHA1withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA1inP1363Format() :
-                            new ECDSASignature.SHA1());
-                    } else if (algo.equals("SHA224withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA224inP1363Format() :
-                            new ECDSASignature.SHA224());
-                    } else if (algo.equals("SHA256withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA256inP1363Format() :
-                            new ECDSASignature.SHA256());
-                    } else if (algo.equals("SHA384withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA384inP1363Format() :
-                            new ECDSASignature.SHA384());
-                    } else if (algo.equals("SHA512withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA512inP1363Format() :
-                            new ECDSASignature.SHA512());
-                    } else if (algo.equals("NONEwithECDSA")) {
-                        return (inP1363? new ECDSASignature.RawinP1363Format() :
-                            new ECDSASignature.Raw());
-                    } else if (algo.equals("SHA3-224withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA3_224inP1363Format() :
-                            new ECDSASignature.SHA3_224());
-                    } else if (algo.equals("SHA3-256withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA3_256inP1363Format() :
-                            new ECDSASignature.SHA3_256());
-                    } else if (algo.equals("SHA3-384withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA3_384inP1363Format() :
-                            new ECDSASignature.SHA3_384());
-                    } else if (algo.equals("SHA3-512withECDSA")) {
-                        return (inP1363? new ECDSASignature.SHA3_512inP1363Format() :
-                            new ECDSASignature.SHA3_512());
-                     }
+                    if (useNativeECDSA
+                        && (NativeCrypto.getVersionIfAvailable() >= NativeCrypto.OPENSSL_VERSION_1_1_1)
+                    ) {
+                        if (nativeCryptTrace) {
+                            System.err.println("ECDSA Signature - Using OpenSSL integration.");
+                        }
+                        if (algo.equals("SHA1withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA1inP1363Format()
+                                    : new NativeECDSASignature.SHA1();
+                        } else if (algo.equals("SHA224withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA224inP1363Format()
+                                    : new NativeECDSASignature.SHA224();
+                        } else if (algo.equals("SHA256withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA256inP1363Format()
+                                    : new NativeECDSASignature.SHA256();
+                        } else if (algo.equals("SHA384withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA384inP1363Format()
+                                    : new NativeECDSASignature.SHA384();
+                        } else if (algo.equals("SHA512withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA512inP1363Format()
+                                    : new NativeECDSASignature.SHA512();
+                        } else if (algo.equals("NONEwithECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.RawinP1363Format()
+                                    : new NativeECDSASignature.Raw();
+                        } else if (algo.equals("SHA3-224withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA3_224inP1363Format()
+                                    : new NativeECDSASignature.SHA3_224();
+                        } else if (algo.equals("SHA3-256withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA3_256inP1363Format()
+                                    : new NativeECDSASignature.SHA3_256();
+                        } else if (algo.equals("SHA3-384withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA3_384inP1363Format()
+                                    : new NativeECDSASignature.SHA3_384();
+                        } else if (algo.equals("SHA3-512withECDSA")) {
+                            return inP1363
+                                    ? new NativeECDSASignature.SHA3_512inP1363Format()
+                                    : new NativeECDSASignature.SHA3_512();
+                        }
+                    } else {
+                        if (algo.equals("SHA1withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA1inP1363Format()
+                                    : new ECDSASignature.SHA1();
+                        } else if (algo.equals("SHA224withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA224inP1363Format()
+                                    : new ECDSASignature.SHA224();
+                        } else if (algo.equals("SHA256withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA256inP1363Format()
+                                    : new ECDSASignature.SHA256();
+                        } else if (algo.equals("SHA384withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA384inP1363Format()
+                                    : new ECDSASignature.SHA384();
+                        } else if (algo.equals("SHA512withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA512inP1363Format()
+                                    : new ECDSASignature.SHA512();
+                        } else if (algo.equals("NONEwithECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.RawinP1363Format()
+                                    : new ECDSASignature.Raw();
+                        } else if (algo.equals("SHA3-224withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA3_224inP1363Format()
+                                    : new ECDSASignature.SHA3_224();
+                        } else if (algo.equals("SHA3-256withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA3_256inP1363Format()
+                                    : new ECDSASignature.SHA3_256();
+                        } else if (algo.equals("SHA3-384withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA3_384inP1363Format()
+                                    : new ECDSASignature.SHA3_384();
+                        } else if (algo.equals("SHA3-512withECDSA")) {
+                            return inP1363
+                                    ? new ECDSASignature.SHA3_512inP1363Format()
+                                    : new ECDSASignature.SHA3_512();
+                        }
+                    }
                 } else if (type.equals("KeyFactory")) {
                     if (algo.equals("EC")) {
                         return new ECKeyFactory();
@@ -403,68 +467,135 @@ public final class SunEC extends Provider {
         /*
          * Signature engines
          */
-        putService(new ProviderService(this, "Signature",
-            "NONEwithECDSA", "sun.security.ec.ECDSASignature$Raw",
-            null, ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA1withECDSA", "sun.security.ec.ECDSASignature$SHA1",
-            ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA224withECDSA", "sun.security.ec.ECDSASignature$SHA224",
-            ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA256withECDSA", "sun.security.ec.ECDSASignature$SHA256",
-            ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA384withECDSA", "sun.security.ec.ECDSASignature$SHA384",
-            ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA512withECDSA", "sun.security.ec.ECDSASignature$SHA512",
-            ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA3-224withECDSA", "sun.security.ec.ECDSASignature$SHA3_224",
-            ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA3-256withECDSA", "sun.security.ec.ECDSASignature$SHA3_256",
-            ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA3-384withECDSA", "sun.security.ec.ECDSASignature$SHA3_384",
-            ATTRS));
-        putService(new ProviderServiceA(this, "Signature",
-            "SHA3-512withECDSA", "sun.security.ec.ECDSASignature$SHA3_512",
-            ATTRS));
+        if (useNativeECDSA
+            && (NativeCrypto.getVersionIfAvailable() >= NativeCrypto.OPENSSL_VERSION_1_1_1)
+        ) {
+            putService(new ProviderService(this, "Signature",
+                "NONEwithECDSA", "sun.security.ec.NativeECDSASignature$Raw",
+                null, ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA1withECDSA", "sun.security.ec.NativeECDSASignature$SHA1",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA224withECDSA", "sun.security.ec.NativeECDSASignature$SHA224",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA256withECDSA", "sun.security.ec.NativeECDSASignature$SHA256",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA384withECDSA", "sun.security.ec.NativeECDSASignature$SHA384",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA512withECDSA", "sun.security.ec.NativeECDSASignature$SHA512",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA3-224withECDSA", "sun.security.ec.NativeECDSASignature$SHA3_224",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA3-256withECDSA", "sun.security.ec.NativeECDSASignature$SHA3_256",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA3-384withECDSA", "sun.security.ec.NativeECDSASignature$SHA3_384",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA3-512withECDSA", "sun.security.ec.NativeECDSASignature$SHA3_512",
+                ATTRS));
 
-        putService(new ProviderService(this, "Signature",
-             "NONEwithECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$RawinP1363Format"));
-        putService(new ProviderService(this, "Signature",
-             "SHA1withECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$SHA1inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-             "SHA224withECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$SHA224inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-             "SHA256withECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$SHA256inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-            "SHA384withECDSAinP1363Format",
-            "sun.security.ec.ECDSASignature$SHA384inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-            "SHA512withECDSAinP1363Format",
-            "sun.security.ec.ECDSASignature$SHA512inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "NONEwithECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$RawinP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA1withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA1inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA224withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA224inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA256withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA256inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA384withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA384inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA512withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA512inP1363Format"));
 
-        putService(new ProviderService(this, "Signature",
-             "SHA3-224withECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$SHA3_224inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-             "SHA3-256withECDSAinP1363Format",
-             "sun.security.ec.ECDSASignature$SHA3_256inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-            "SHA3-384withECDSAinP1363Format",
-            "sun.security.ec.ECDSASignature$SHA3_384inP1363Format"));
-        putService(new ProviderService(this, "Signature",
-            "SHA3-512withECDSAinP1363Format",
-            "sun.security.ec.ECDSASignature$SHA3_512inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA3-224withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA3_224inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA3-256withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA3_256inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA3-384withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA3_384inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA3-512withECDSAinP1363Format",
+                "sun.security.ec.NativeECDSASignature$SHA3_512inP1363Format"));
+        } else {
+            putService(new ProviderService(this, "Signature",
+                "NONEwithECDSA", "sun.security.ec.ECDSASignature$Raw",
+                null, ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA1withECDSA", "sun.security.ec.ECDSASignature$SHA1",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA224withECDSA", "sun.security.ec.ECDSASignature$SHA224",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA256withECDSA", "sun.security.ec.ECDSASignature$SHA256",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA384withECDSA", "sun.security.ec.ECDSASignature$SHA384",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA512withECDSA", "sun.security.ec.ECDSASignature$SHA512",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA3-224withECDSA", "sun.security.ec.ECDSASignature$SHA3_224",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA3-256withECDSA", "sun.security.ec.ECDSASignature$SHA3_256",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA3-384withECDSA", "sun.security.ec.ECDSASignature$SHA3_384",
+                ATTRS));
+            putService(new ProviderServiceA(this, "Signature",
+                "SHA3-512withECDSA", "sun.security.ec.ECDSASignature$SHA3_512",
+                ATTRS));
+
+            putService(new ProviderService(this, "Signature",
+                "NONEwithECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$RawinP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA1withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA1inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA224withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA224inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA256withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA256inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA384withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA384inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA512withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA512inP1363Format"));
+
+            putService(new ProviderService(this, "Signature",
+                "SHA3-224withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA3_224inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA3-256withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA3_256inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA3-384withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA3_384inP1363Format"));
+            putService(new ProviderService(this, "Signature",
+                "SHA3-512withECDSAinP1363Format",
+                "sun.security.ec.ECDSASignature$SHA3_512inP1363Format"));
+        }
 
         /*
          *  Key Pair Generator engine
@@ -475,7 +606,7 @@ public final class SunEC extends Provider {
             && !isAIX
         ) {
             putService(new ProviderServiceA(this, "KeyPairGenerator",
-                "EC", "sun.security.ec.NaticeECKeyPairGenerator", ATTRS));
+                "EC", "sun.security.ec.NativeECKeyPairGenerator", ATTRS));
         } else {
             putService(new ProviderServiceA(this, "KeyPairGenerator",
                 "EC", "sun.security.ec.ECKeyPairGenerator", ATTRS));


### PR DESCRIPTION
A new class, namely `NativeECDSASignature.java`, is created and the corresponding options are added in other places to allow for the use of native `OpenSSL` library to create and verify `ECDSA` signatures.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)