### PR TITLE
Update SubclassGC test to call System.gc() twice

### DIFF
--- a/test/jdk/java/io/Serializable/subclassGC/SubclassGC.java
+++ b/test/jdk/java/io/Serializable/subclassGC/SubclassGC.java
@@ -31,6 +31,11 @@
  * @author Andrey Ozerov
  * @run main/othervm/policy=security.policy SubclassGC
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 import java.io.*;
 import java.lang.ref.Reference;
@@ -73,6 +78,7 @@ public class SubclassGC {
                 systemLoader = null;
 
                 System.err.println("\nStart Garbage Collection right now");
+                System.gc();
                 System.gc();
 
                 Reference<? extends Class<?>> dequeued = queue.remove(TIMEOUT);


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/19246

I don't know we've seen a failure on jdk17 so I'll only backport to jdk21 for now.