### PR TITLE
Remove unnecessary changes to EC key implementations

### DIFF
--- a/src/java.base/share/classes/sun/security/ec/ECPrivateKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/ec/ECPrivateKeyImpl.java
@@ -23,12 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
- * ===========================================================================
- */
-
 package sun.security.ec;
 
 import java.io.IOException;
@@ -40,8 +34,6 @@ import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
 import java.util.Arrays;
-
-import jdk.crypto.jniprovider.NativeCrypto;
 
 import sun.security.ec.point.AffinePoint;
 import sun.security.ec.point.MutablePoint;
@@ -76,7 +68,6 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
 
     @java.io.Serial
     private static final long serialVersionUID = 88695385615075129L;
-    private static NativeCrypto nativeCrypto;
 
     private BigInteger s;       // private value
     private byte[] arrayS;      // private value as a little-endian array

--- a/src/java.base/share/classes/sun/security/ec/ECPublicKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/ec/ECPublicKeyImpl.java
@@ -23,24 +23,15 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
- * ===========================================================================
- */
-
 package sun.security.ec;
 
 import java.io.IOException;
-import java.math.BigInteger;
 
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
-
-import jdk.crypto.jniprovider.NativeCrypto;
 
 import sun.security.util.BitArray;
 import sun.security.util.ECParameters;
@@ -58,7 +49,6 @@ public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
 
     @java.io.Serial
     private static final long serialVersionUID = -2462037275160462289L;
-    private static NativeCrypto nativeCrypto;
 
     @SuppressWarnings("serial") // Type of field is not
                                 // Serializable;see writeReplace


### PR DESCRIPTION
There is no need for additional code in the `ECPrivateKeyImpl` and `ECPublicKeyImpl` classes anymore, compared to the upstream, so the IBM copyright is also no longer needed.

Signed-off by: Kostas Tsiounis <kostas.tsiounis@ibm.com>