### PR TITLE
Simplify and improve module dependency management

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -27,7 +27,6 @@ ifeq (,$(wildcard $(SPEC)))
 endif
 include $(SPEC)
 include $(TOPDIR)/make/common/MakeBase.gmk
-include $(TOPDIR)/closed/JPP.gmk
 
 ifeq (,$(BUILD_ID))
   BUILD_ID := 000000

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -181,7 +181,6 @@ $(foreach var, \
 	$(eval $(var) += -I$(SUPPORT_OUTPUTDIR)/openj9_include))
 
 J9JCL_SOURCES_DIR      := $(SUPPORT_OUTPUTDIR)/j9jcl
-J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl.done
 
 # Required by OpenJCEPlus.
 BUILD_OPENJCEPLUS  := @BUILD_OPENJCEPLUS@

--- a/closed/custom/Main-post.gmk
+++ b/closed/custom/Main-post.gmk
@@ -18,12 +18,6 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-.PHONY : all
-
-all :
-
-include $(SPEC)
-include $(TOPDIR)/make/common/MakeBase.gmk
 include $(TOPDIR)/make/common/CopyFiles.gmk
 include $(TOPDIR)/closed/JPP.gmk
 
@@ -62,6 +56,8 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 
 IncludeIfUnsure := -includeIfUnsure -noWarnIncludeIf
 
+J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl.done
+
 $(J9JCL_SOURCES_DONEFILE) : \
 		$(foreach dir, $(JppSourceDirs), $(call RecursiveWildcard,$(dir),*)) \
 		$(COPY_OVERLAY_FILES)
@@ -83,4 +79,5 @@ $(J9JCL_SOURCES_DONEFILE) : \
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@
 
-all : $(J9JCL_SOURCES_DONEFILE)
+# Force (re-)generation of module dependencies after preprocessing OpenJ9 source files.
+$(MODULE_DEPS_MAKEFILE) : $(J9JCL_SOURCES_DONEFILE)

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -33,14 +33,6 @@ JVM_DOCS_TARGETS :=
 PHASE_MAKEDIRS := $(TOPDIR)/closed/make $(PHASE_MAKEDIRS)
 
 OPENJ9_MAKE := $(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/OpenJ9.gmk
-
-# An early part of the build process involves computing the list of main targets.
-# Those targets include {module}-java, {module}-jmod, etc. which requires that the
-# set of module names be known. We must build and run the preprocessor to ensure the
-# modules specific to OpenJ9 will be found and included in that set. The next two
-# rules make that happen.
-
-create-main-targets-include java.base-gensrc : generate-j9jcl-sources
 
 j9vm-build : buildtools-langtools
   ifeq ($(BUILD_OPENSSL),yes)

--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -59,16 +59,3 @@ TOP_SRC_DIRS += \
 ifeq (true,$(BUILD_OPENJCEPLUS))
   TOP_SRC_DIRS += $(OPENJCEPLUS_TOPDIR)/src/main
 endif
-
-.PHONY : generate-j9jcl-sources
-
-generate-j9jcl-sources $(J9JCL_SOURCES_DONEFILE) :
-	@+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/GensrcJ9JCL.gmk
-
-# When building multiple configurations at once (e.g. 'make CONF= images')
-# the 'create-main-targets-include' target will only be considered for the
-# first configuration; J9JCL source generation will be delayed for other
-# configurations. In order to produce a complete module-deps.gmk, we need
-# to ensure that the J9JCL source has been generated.
-
--include $(J9JCL_SOURCES_DONEFILE)


### PR DESCRIPTION
Move the rules to preprocess OpenJ9 source files to `Main-post.gmk` so `module-deps.gmk` can depend those actions. This also ensures that module dependencies are updated in incremental builds as appropriate.

Remove an unnecessary include of `JPP.gmk` in `OpenJ9.gmk`.

Move definition of `J9JCL_SOURCES_DONEFILE` to `Main-post.gmk`, which is now the only place it's used.