### PR TITLE
Improve patch to ValueLayouts for AIX

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -307,7 +307,7 @@ public final class ValueLayouts {
         }
 
         public static OfDouble of(ByteOrder order) {
-            return new OfDoubleImpl(order, OperatingSystem.isAix() ? 4 : ADDRESS_SIZE_BYTES, Optional.empty());
+            return new OfDoubleImpl(order, OperatingSystem.isAix() ? 4 : Double.BYTES, Optional.empty());
         }
 
         @Override


### PR DESCRIPTION
Include changes from:
* [8326172: Dubious claim on long[]/double[] alignment in MemorySegment javadoc](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/c45d7ed2002bd6be5451f35e44bdd12cb71af9ee)