### PR TITLE
Temporarily restore PreviewFeature.Feature.UNNAMED_CLASSES

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 package jdk.internal.javac;
 
@@ -82,6 +87,9 @@ public @interface PreviewFeature {
         @JEP(number=476, title="Module Import Declarations", status="Preview")
         MODULE_IMPORTS,
         LANGUAGE_MODEL,
+        // Not used, but required by interim javac with Java 21 bootjdk.
+        @JEP(number=445, title="Unnamed Classes and Instance Main Methods", status="Deprecated")
+        UNNAMED_CLASSES,
         /**
          * A key for testing.
          */


### PR DESCRIPTION
To allow continued use of a Java 21 bootjdk (see https://github.com/eclipse-openj9/openj9/issues/19994).