### PR TITLE
z/TPF: Add z/TPF as a recognized operating system

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/OperatingSystem.java
+++ b/src/java.base/share/classes/jdk/internal/util/OperatingSystem.java
@@ -90,6 +90,10 @@ public enum OperatingSystem {
      * The z/OS Operating system.
      */
     ZOS,
+    /**
+     * The z/TPF Operating system.
+     */
+    ZTPF,
     ;
 
     // The current OperatingSystem
@@ -133,6 +137,14 @@ public enum OperatingSystem {
     @ForceInline
     public static boolean isZOS() {
         return PlatformProps.TARGET_OS_IS_ZOS;
+    }
+
+    /**
+     * {@return {@code true} if built for the z/TPF operating system}
+     */
+    @ForceInline
+    public static boolean isZTPF() {
+        return PlatformProps.TARGET_OS_IS_ZTPF;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -45,6 +45,7 @@ class PlatformProps {
     static final boolean TARGET_OS_IS_WINDOWS = "@@OPENJDK_TARGET_OS@@" == "windows";
     static final boolean TARGET_OS_IS_AIX     = "@@OPENJDK_TARGET_OS@@" == "aix";
     static final boolean TARGET_OS_IS_ZOS     = "@@OPENJDK_TARGET_OS@@" == "zos";
+    static final boolean TARGET_OS_IS_ZTPF    = "@@OPENJDK_TARGET_OS@@" == "ztpf";
 
     // The Architecture value for the current architecture
     static final String CURRENT_ARCH_STRING = "@@OPENJDK_TARGET_CPU@@";


### PR DESCRIPTION
Builds for z/TPF are done via cross-compilation.

When using the BOOT_JDK (s390x linux) the JLINK tool validates the OS it's building for.

The proposed update simply adds z/TPF as a recognized Operating System for Semeru.

If accepted looking to get this into JDK 21 Releases/Refreshes.  Please let me know what the earliest release this would be available in, and if it's possible to get the update into in-progress refreshes for Semeru 21.