### PR TITLE
Add support for EC aliases in SunPKCS11

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -874,7 +874,7 @@ public final class SunPKCS11 extends AuthProvider {
         d(KPG, "DH",            P11KeyPairGenerator,
                 dhAlias,
                 m(CKM_DH_PKCS_KEY_PAIR_GEN));
-        d(KPG, "EC",            P11KeyPairGenerator,
+        dA(KPG, "EC",            P11KeyPairGenerator,
                 m(CKM_EC_KEY_PAIR_GEN));
 
         dA(KG,  "ARCFOUR",       P11KeyGenerator,
@@ -924,7 +924,7 @@ public final class SunPKCS11 extends AuthProvider {
         d(KF, "DH",             P11DHKeyFactory,
                 dhAlias,
                 m(CKM_DH_PKCS_KEY_PAIR_GEN, CKM_DH_PKCS_DERIVE));
-        d(KF, "EC",             P11ECKeyFactory,
+        dA(KF, "EC",             P11ECKeyFactory,
                 m(CKM_EC_KEY_PAIR_GEN, CKM_ECDH1_DERIVE,
                     CKM_ECDSA, CKM_ECDSA_SHA1));
 


### PR DESCRIPTION
In Java 8 with IBMPKCS11Impl, we allowed the usage of `1.2.840.10045.2.1` as an alias for `EC` when using ECKeyFactory. This is support we want to continue to offer with SunPKCS11 and Semeru.

Changing the function from `d()` to [`dA()`](https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/openj9/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java#L726) allows [`getAliases()`](https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/12ee8ca858929b069c1635152a1fefdf778e9af1/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java#L81) to be called. which checks the [list of known aliases](https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/12ee8ca858929b069c1635152a1fefdf778e9af1/src/java.base/share/classes/sun/security/util/KnownOIDs.java#L281) for EC that contains `1.2.840.10045.2.1`.

Signed-off-by: Bob Du <bob.du@ibm.com>