### PR TITLE
CRIU adds @NotCheckpointSafe for ZipFile.getEntry(String)

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -49,6 +49,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/Timer.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
+		src/java.base/share/classes/java/util/zip/ZipFile.java \
 		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
 		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
 		src/java.base/share/classes/module-info.java \

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util.zip;
 
 import java.io.Closeable;
@@ -74,6 +80,10 @@ import sun.security.util.SignatureFileVerifier;
 
 import static java.util.zip.ZipConstants64.*;
 import static java.util.zip.ZipUtils.*;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * This class is used to read entries from a ZIP file.
@@ -342,6 +352,9 @@ public class ZipFile implements ZipConstants, Closeable {
      * @return the ZIP file entry, or null if not found
      * @throws IllegalStateException if the ZIP file has been closed
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     public ZipEntry getEntry(String name) {
         Objects.requireNonNull(name, "name");
         ZipEntry entry = null;


### PR DESCRIPTION
CRIU adds `@NotCheckpointSafe` for `ZipFile.getEntry(String)`

This is to address a blocking error on checkpoint in single-threaded mode.
The thread doing the checkpoint stacktrace:
```
1XMCURTHDINFO  Current thread
3XMTHREADINFO      "Default Executor-thread-1" J9VMThread:0x000000000083E600, omrthread_t:0x00007FC1500326B8, java/lang/Thread:0x000000008461CD88, state:R, prio=5
3XMJAVALTHREAD            (java/lang/Thread getId:0x36, isDaemon:true)
3XMJAVALTHRCCL            org/eclipse/osgi/internal/framework/ContextFinder(0x00000000842CECA0)
3XMTHREADINFO1            (native thread ID:0x71D8, native priority:0x5, native policy:UNKNOWN, vmstate:R, vm thread flags:0x00041020)
3XMTHREADINFO2            (native stack address range from:0x00007FC1C8281000, to:0x00007FC1C8301000, size:0x80000)
3XMCPUTIME               CPU usage total: 2.100446247 secs, current category="Application"
3XMHEAPALLOC             Heap bytes allocated since last GC cycle=159528 (0x26F28)
3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at java/util/zip/ZipFile.getEntry(ZipFile.java:337(Compiled Code))
4XESTACKTRACE                at java/util/jar/JarFile.getEntry(JarFile.java:517(Compiled Code))
4XESTACKTRACE                at java/util/jar/JarFile.getJarEntry(JarFile.java:472(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/URLClassPath$JarLoader.getResource(URLClassPath.java:1092(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/URLClassPath.getResource(URLClassPath.java:427(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/URLClassPath.getResource(URLClassPath.java:482(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:958(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:867(Compiled Code))
5XESTACKTRACE                   (entered lock: java/lang/ClassLoader$ClassNameBasedLock@0x00000000FE693BA8, entry count: 1)
4XESTACKTRACE                at jdk/internal/loader/BuiltinClassLoader.loadClass(BuiltinClassLoader.java:825(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188(Compiled Code))
4XESTACKTRACE                at java/lang/ClassLoader.loadClass(ClassLoader.java:1093(Compiled Code))
4XESTACKTRACE                at com/ibm/ws/kernel/internal/classloader/JarFileClassLoader._loadClass(JarFileClassLoader.java:181(Compiled Code))
5XESTACKTRACE                   (entered lock: com/ibm/ws/kernel/boot/classloader/NameBasedClassLoaderLock@0x00000000FE693B60, entry count: 1)
4XESTACKTRACE                at com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstJarClassloader.loadClass(BootstrapChildFirstJarClassloader.java:83(Compiled Code))
4XESTACKTRACE                at java/lang/ClassLoader.loadClass(ClassLoader.java:1093(Compiled Code))
4XESTACKTRACE                at com/ibm/ws/kernel/launch/internal/FrameworkManager$5.prepare(FrameworkManager.java:623)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl$$Lambda$290/0x0000000000000000.accept(Bytecode PC:6)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.callHooks(CheckpointImpl.java:577)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.prepare(CheckpointImpl.java:590)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.lambda$checkpoint$14(CheckpointImpl.java:396)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl$$Lambda$300/0x0000000000000000.run(Bytecode PC:8)
4XESTACKTRACE                at openj9/internal/criu/InternalCRIUSupport.lambda$registerCheckpointHookHelper$1(InternalCRIUSupport.java:788)
4XESTACKTRACE                at openj9/internal/criu/InternalCRIUSupport$$Lambda$302/0x0000000000000000.run(Bytecode PC:8)
4XESTACKTRACE                at openj9/internal/criu/J9InternalCheckpointHookAPI$J9InternalCheckpointHook.runHook(J9InternalCheckpointHookAPI.java:143)
4XESTACKTRACE                at openj9/internal/criu/J9InternalCheckpointHookAPI.runHooks(J9InternalCheckpointHookAPI.java:98)
5XESTACKTRACE                   (entered lock: openj9/internal/criu/InternalCRIUSupport@0x00000000FE62A288, entry count: 1)
4XESTACKTRACE                at openj9/internal/criu/J9InternalCheckpointHookAPI.runPreCheckpointHooksSingleThread(J9InternalCheckpointHookAPI.java:107)
5XESTACKTRACE                   (entered lock: org/eclipse/openj9/criu/CRIUSupport@0x00000000FE62A258, entry count: 1)
4XESTACKTRACE                at openj9/internal/criu/InternalCRIUSupport.checkpointJVMImpl(Native Method)
4XESTACKTRACE                at openj9/internal/criu/InternalCRIUSupport.checkpointJVM(InternalCRIUSupport.java:997)
4XESTACKTRACE                at org/eclipse/openj9/criu/CRIUSupport.checkpointJVM(CRIUSupport.java:530)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/openj9/ExecuteCRIU_OpenJ9.dump(ExecuteCRIU_OpenJ9.java:55)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.checkpoint(CheckpointImpl.java:396)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.checkpointOrExitOnFailure(CheckpointImpl.java:303)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.check(CheckpointImpl.java:297)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager$$Lambda$281/0x0000000000000000.accept(Bytecode PC:6)
4XESTACKTRACE                at java/util/ArrayList.forEach(ArrayList.java:1511(Compiled Code))
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager.checkServerReady(FeatureManager.java:868)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager.update(FeatureManager.java:829)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager.processFeatureChanges(FeatureManager.java:931)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager$1.run(FeatureManager.java:714)
4XESTACKTRACE                at com/ibm/ws/threading/internal/ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
4XESTACKTRACE                at java/util/concurrent/ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136(Compiled Code))
4XESTACKTRACE                at java/util/concurrent/ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
4XESTACKTRACE                at java/lang/Thread.run(Thread.java:857)
```
And the causing thread stacktrace:
```
3XMTHREADINFO      "MemoryMXBean notification dispatcher" J9VMThread:0x000000000071BD00, omrthread_t:0x00007FC14802E828, java/lang/Thread:0x00000000FE1141F0, state:R, prio=6
3XMJAVALTHREAD            (java/lang/Thread getId:0x4B, isDaemon:true)
3XMJAVALTHRCCL            jdk/internal/loader/ClassLoaders$AppClassLoader(0x0000000083FF6FB8)
3XMTHREADINFO1            (native thread ID:0x71F1, native priority:0x6, native policy:UNKNOWN, vmstate:CW, vm thread flags:0x00200081)
3XMTHREADINFO2            (native stack address range from:0x00007FC1C8403000, to:0x00007FC1C8483000, size:0x80000)
3XMCPUTIME               CPU usage total: 0.021229566 secs, current category="Application"
3XMHEAPALLOC             Heap bytes allocated since last GC cycle=163360 (0x27E20)
3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at java/util/zip/ZipFile$Source.getEntryPos(ZipFile.java:1813(Compiled Code))
4XESTACKTRACE                at java/util/zip/ZipFile.getEntry(ZipFile.java:339(Compiled Code))
5XESTACKTRACE                   (entered lock: java/util/jar/JarFile@0x0000000084014268, entry count: 1)
4XESTACKTRACE                at java/util/jar/JarFile.getEntry(JarFile.java:517(Compiled Code))
4XESTACKTRACE                at java/util/jar/JarFile.getJarEntry(JarFile.java:472(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/URLClassPath$JarLoader.getResource(URLClassPath.java:1092(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/URLClassPath.getResource(URLClassPath.java:427(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/URLClassPath.getResource(URLClassPath.java:482(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:958(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:867(Compiled Code))
5XESTACKTRACE                   (entered lock: java/lang/ClassLoader$ClassNameBasedLock@0x00000000FE6533C0, entry count: 1)
4XESTACKTRACE                at jdk/internal/loader/BuiltinClassLoader.loadClass(BuiltinClassLoader.java:825(Compiled Code))
4XESTACKTRACE                at jdk/internal/loader/ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188(Compiled Code))
4XESTACKTRACE                at java/lang/ClassLoader.loadClass(ClassLoader.java:1093(Compiled Code))
4XESTACKTRACE                at java/lang/ClassLoader.findSystemClass(ClassLoader.java:699(Compiled Code))
4XESTACKTRACE                at com/ibm/ws/classloading/internal/GatewayClassLoader.loadClassNoException0(GatewayClassLoader.java:219(Compiled Code))
4XESTACKTRACE                at com/ibm/ws/classloading/internal/GatewayClassLoader.loadClassNoException(GatewayClassLoader.java:231(Compiled Code))
4XESTACKTRACE                at com/ibm/ws/classloading/internal/AppClassLoader.findOrDelegateLoadClass(AppClassLoader.java:694(Compiled Code))
5XESTACKTRACE                   (entered lock: com/ibm/ws/kernel/boot/classloader/NameBasedClassLoaderLock@0x00000000FE653070, entry count: 1)
4XESTACKTRACE                at com/ibm/ws/classloading/internal/AppClassLoader.loadClass(AppClassLoader.java:584(Compiled Code))
4XESTACKTRACE                at com/ibm/ws/classloading/internal/AppClassLoader.loadClass(AppClassLoader.java:553(Compiled Code))
4XESTACKTRACE                at java/lang/ClassLoader.loadClass(ClassLoader.java:1093(Compiled Code))
4XESTACKTRACE                at io/micrometer/core/instrument/AbstractTimerBuilder.<init>(AbstractTimerBuilder.java:49)
4XESTACKTRACE                at io/micrometer/core/instrument/Timer$Builder.<init>(Timer.java:351)
4XESTACKTRACE                at io/micrometer/core/instrument/Timer.builder(Timer.java:71)
4XESTACKTRACE                at io/micrometer/core/instrument/binder/jvm/JvmGcMetrics$GcMetricsNotificationListener.handleNotification(JvmGcMetrics.java:208)
4XESTACKTRACE                at javax/management/NotificationBroadcasterSupport.handleNotification(NotificationBroadcasterSupport.java:275)
4XESTACKTRACE                at javax/management/NotificationBroadcasterSupport$SendNotifJob.run(NotificationBroadcasterSupport.java:352)
4XESTACKTRACE                at javax/management/NotificationBroadcasterSupport$1.execute(NotificationBroadcasterSupport.java:337)
4XESTACKTRACE                at javax/management/NotificationBroadcasterSupport.sendNotification(NotificationBroadcasterSupport.java:248)
4XESTACKTRACE                at com/ibm/java/lang/management/internal/LazyDelegatingNotifier.sendNotification(LazyDelegatingNotifier.java:105)
4XESTACKTRACE                at com/ibm/java/lang/management/internal/GarbageCollectorMXBeanImpl.sendNotification(GarbageCollectorMXBeanImpl.java:240)
4XESTACKTRACE                at com/ibm/lang/management/internal/MemoryNotificationThread.dispatchGCNotificationHelper(MemoryNotificationThread.java:104)
4XESTACKTRACE                at com/ibm/lang/management/internal/MemoryNotificationThread.processNotificationLoop(Native Method)
4XESTACKTRACE                at com/ibm/lang/management/internal/MemoryNotificationThread.run(MemoryNotificationThread.java:183)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>