### PR TITLE
Remove redundant definition of CMAKE

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -87,7 +87,6 @@ J9JDK_EXT_VERSION       := $(VERSION_NUMBER_FOUR_POSITIONS)-ea
 J9JDK_EXT_NAME          := Extensions for OpenJDK for Eclipse OpenJ9
 
 # required by CMake
-CMAKE                   := @CMAKE@
 OPENJ9_ENABLE_CMAKE     := @OPENJ9_ENABLE_CMAKE@
 
 # required by UMA


### PR DESCRIPTION
CMAKE is defined in `spec.gmk` since
* [8329816: Add SLEEF version 3.6.1](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/63237415e7f4cc5b8ea27fa379a9b2ae167021c8)