### PR TITLE
Hold the testLoader reference to prevent GC

### DIFF
--- a/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
+++ b/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
@@ -97,6 +97,8 @@ public class NativeLibraryTest {
             throw new RuntimeException("should fail to load the native library" +
                     " by another class loader");
         } catch (UnsatisfiedLinkError e) {}
+        // keep Runnable r strongly reachable so that it is not reclaimable by GC
+        java.lang.ref.Reference.reachabilityFence(r);
     }
 
     /*


### PR DESCRIPTION
Hold the `testLoader` reference to prevent GC

The GC might occur before the second native library loading by another class loader, hold the first `testLoader` reference to prevent GC, and ensure `UnsatisfiedLinkError`.

Related to
* https://github.com/eclipse-openj9/openj9/pull/20265

Signed-off-by: Jason Feng <fengj@ca.ibm.com>