### PR TITLE
Use native encoded bytes when making a downcall to standard printf 

### DIFF
--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @run testng/othervm --enable-native-access=ALL-UNNAMED StdLibTest
  */
@@ -29,6 +35,7 @@
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.nio.charset.Charset;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -52,6 +59,8 @@ import static org.testng.Assert.*;
 public class StdLibTest extends NativeTestHelper {
 
     final static Linker abi = Linker.nativeLinker();
+
+    final static Charset nativeCharset = Charset.forName(System.getProperty("native.encoding"));
 
     private StdLibHelper stdLibHelper = new StdLibHelper();
 
@@ -306,7 +315,7 @@ public class StdLibTest extends NativeTestHelper {
 
         int printf(String format, List<PrintfArg> args) throws Throwable {
             try (var arena = Arena.ofConfined()) {
-                MemorySegment formatStr = arena.allocateFrom(format);
+                MemorySegment formatStr = arena.allocateFrom(format, nativeCharset);
                 return (int)specializedPrintf(args).invokeExact(formatStr,
                         args.stream().map(a -> a.nativeValue(arena)).toArray());
             }
@@ -387,7 +396,7 @@ public class StdLibTest extends NativeTestHelper {
         INT(int.class, C_INT, "%d", "%d", arena -> 42, 42),
         LONG(long.class, C_LONG_LONG, "%lld", "%d", arena -> 84L, 84L),
         DOUBLE(double.class, C_DOUBLE, "%.4f", "%.4f", arena -> 1.2345d, 1.2345d),
-        STRING(MemorySegment.class, C_POINTER, "%s", "%s", arena -> arena.allocateFrom("str"), "str");
+        STRING(MemorySegment.class, C_POINTER, "%s", "%s", arena -> arena.allocateFrom("str", nativeCharset), "str");
 
         final Class<?> carrier;
         final ValueLayout layout;


### PR DESCRIPTION
When making a downcall to standard printf function, use a memorysegment allocated with native charset for strings.