### PR TITLE
Disable use of zlibNX by default

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -355,7 +355,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
          *     o          $JVMPATH (directory portion only)
          *     o          $JRE/lib
          *     o          $JRE/../lib
-         *     o          ZLIBNX_PATH (for AIX P9 or newer systems with NX, unless -XX:-UseZlibNX is set)
+         *     o          ZLIBNX_PATH (for AIX P9 or newer systems with NX, when enabled)
          *
          * followed by the user's previous effective LD_LIBRARY_PATH, if
          * any.
@@ -365,7 +365,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
         int aixargc = *pargc - 1; // skip the launcher name
         char **aixargv = *pargv + 1;
         const char *aixarg = NULL;
-        jboolean useZlibNX = JNI_TRUE;
+        jboolean useZlibNX = JNI_FALSE;
         while (aixargc > 0 && *(aixarg = *aixargv) == '-') {
             if (JLI_StrCmp(aixarg, "-XX:+UseZlibNX") == 0) {
                 useZlibNX = JNI_TRUE;


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/20324

Backports
https://github.com/ibmruntimes/openj9-openjdk-jdk23/pull/55
https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/209
https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/396
https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/823
https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/768