### PR TITLE
Temporarily restore PreviewFeature.Feature.FOREIGN & STRING_TEMPLATES

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -90,6 +90,9 @@ public @interface PreviewFeature {
         // Not used, but required by interim javac with Java 21 bootjdk.
         @JEP(number=445, title="Unnamed Classes and Instance Main Methods", status="Deprecated")
         UNNAMED_CLASSES,
+        FOREIGN,
+        @JEP(number=459, title="String Templates", status="Second Preview")
+        STRING_TEMPLATES,
         /**
          * A key for testing.
          */


### PR DESCRIPTION
Temporarily restore `PreviewFeature.Feature.FOREIGN` & `STRING_TEMPLATES`

To allow a Java 21 bootjdk.

Issue https://github.com/eclipse-openj9/openj9/issues/20402

Signed-off-by: Jason Feng <fengj@ca.ibm.com>