### PR TITLE
Block all properties that can be set by profile

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -404,8 +404,8 @@ public final class RestrictedSecurity {
     /**
      * Check whether a security property can be set.
      *
-     * A security property that is set by a RestrictedSecurity profile,
-     * while FIPS security mode is enabled, cannot be reset programmatically.
+     * A security property that is FIPS related and can be set by a RestrictedSecurity
+     * profile, while FIPS security mode is enabled, cannot be reset programmatically.
      *
      * Every time an attempt to set a security property is made, a check is
      * performed. If the above scenario holds true, a SecurityException is
@@ -426,7 +426,7 @@ public final class RestrictedSecurity {
         }
 
         /*
-         * Only disallow setting of security properties that are set by the active profile,
+         * Only disallow setting of security properties that are FIPS related,
          * if FIPS has been enabled.
          *
          * Allow any change, if the 'semeru.fips.allowsetproperties' flag is set to true.
@@ -438,8 +438,8 @@ public final class RestrictedSecurity {
                         + "properties to be set, use '-Dsemeru.fips.allowsetproperties=true'.");
                 debug.println("BEWARE: You might not be FIPS compliant if you select to override!");
             }
-            throw new SecurityException("FIPS mode: User-specified '" + key
-                    + "' cannot override profile definition.");
+            throw new SecurityException("FIPS mode: Property '" + key
+                    + "' cannot be set programmatically when in FIPS mode.");
         }
 
         if (debug != null) {
@@ -556,14 +556,14 @@ public final class RestrictedSecurity {
             printStackTraceAndExit("Property com.ibm.fips.mode is incompatible with semeru.customprofile and semeru.fips properties");
         }
 
+        if (userEnabledFIPS && !allowSetProperties) {
+            // Add all properties that cannot be modified.
+            unmodifiableProperties.addAll(propsMapping.keySet());
+        }
+
         for (Map.Entry<String, String> entry : propsMapping.entrySet()) {
             String jdkPropsName = entry.getKey();
             String propsNewValue = entry.getValue();
-
-            if ((propsNewValue != null) && userEnabledFIPS && !allowSetProperties) {
-                // Add to set of properties set by the active profile.
-                unmodifiableProperties.add(jdkPropsName);
-            }
 
             if (!isNullOrBlank(propsNewValue)) {
                 props.setProperty(jdkPropsName, propsNewValue);


### PR DESCRIPTION
Instead of just blocking the properties that are set by the loaded profile, block all properties that can potentially be set by any `RestrictedSecurity` profile.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>