### PR TITLE
Set AIX executables to have exempt SED status

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -27,7 +27,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2024 All Rights Reserved
 # ===========================================================================
 
 AC_DEFUN([FLAGS_SETUP_LDFLAGS],
@@ -80,12 +80,12 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       UTIL_REQUIRE_PROGS(LLD, lld)
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then
-      BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnolibpath -Wl,-bnoexpall \
+      BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnolibpath -Wl,-bnoexpall -Wl,-brwexec_must \
         -Wl,-bernotok -Wl,-bdatapsize:64k -Wl,-btextpsize:64k -Wl,-bstackpsize:64k"
       BASIC_LDFLAGS_JVM_ONLY="$BASIC_LDFLAGS_JVM_ONLY -Wl,-lC_r -Wl,-bbigtoc"
     fi
   elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    BASIC_LDFLAGS="-b64 -brtl -bnolibpath -bnoexpall -bernotok -btextpsize:64K \
+    BASIC_LDFLAGS="-b64 -brtl -bnolibpath -bnoexpall -bernotok -brwexec_must -btextpsize:64K \
         -bdatapsize:64K -bstackpsize:64K"
     # libjvm.so has gotten too large for normal TOC size; compile with qpic=large and link with bigtoc
     BASIC_LDFLAGS_JVM_ONLY="-Wl,-lC_r -bbigtoc"


### PR DESCRIPTION
Customers complained IBM SDK8 has this status, but Semeru Runtimes don't, such that they cannot run Semeru Runtimes on their systems when migrating from IBM SDK8. This is a temporary fix without any other impacts, while we are investigating a complete solution for a larger issue (HugePages are not used for codeCache even though proper -Xlp option is specified).