### PR TITLE
Remove useless call to ThreadGroup.checkAccess()

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -33,7 +33,6 @@ package java.lang;
 
 import java.lang.ref.Reference;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Map;
 import java.util.HashMap;
@@ -2733,7 +2732,6 @@ public class Thread implements Runnable {
             // default CCL to the system class loader when not inheriting
             this.contextClassLoader = ClassLoader.getSystemClassLoader();
         }
-        threadGroup.checkAccess();
     }
 
     /**


### PR DESCRIPTION
`ThreadGroup.checkAccess()` is final and empty. Related to upstream changes in

- [8343981: Remove usage of security manager from Thread and related classes](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/3fc32e5bf9649969ee3a156efc9c64b760cf889e)

Also remove unused import.