### PR TITLE
Add dependency module java.management.rmi for ibm.healthcenter

### DIFF
--- a/closed/src/ibm.healthcenter/share/classes/module-info.java
+++ b/closed/src/ibm.healthcenter/share/classes/module-info.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2024 All Rights Reserved
  * ===========================================================================
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -26,6 +26,7 @@
 module ibm.healthcenter {
   requires java.logging;
   requires java.management;
+  requires java.management.rmi;
   requires java.naming;
   requires java.prefs;
   requires java.rmi;


### PR DESCRIPTION
This change is to avoid HealthCenterException thrown when HC client using healthcenter API’s tries to connect to target JVM running on Semeru JDK11+

Exception details when Semeru Java11 client tries connecting to Java 11 HC target

Exception in thread "main" com.ibm.java.diagnostics.healthcenter.api.HealthCenterException: Unable to connect to agent, check authentication details are correct
at ibm.healthcenter/com.ibm.java.diagnostics.healthcenter.api.factory.HealthCenterFactory.connect(Unknown Source)
at WorkingCase.main(WorkingCase.java:29)