### PR TITLE
Enable aarch64 linux bundling OpenJCEPlus

### DIFF
--- a/closed/make/modules/openjceplus/Lib.gmk
+++ b/closed/make/modules/openjceplus/Lib.gmk
@@ -35,7 +35,9 @@ OPENJCEPLUS_JGSKIT_PLATFORM :=
 ifeq ($(call isTargetOs, aix), true)
   OPENJCEPLUS_JGSKIT_PLATFORM := ppc-aix64
 else ifeq ($(call isTargetOs, linux), true)
-  ifeq ($(call isTargetCpu, ppc64le), true)
+  ifeq ($(call isTargetCpu, aarch64), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := arm-linux64
+  else ifeq ($(call isTargetCpu, ppc64le), true)
     OPENJCEPLUS_JGSKIT_PLATFORM := ppcle-linux64
   else ifeq ($(call isTargetCpu, s390x), true)
     OPENJCEPLUS_JGSKIT_PLATFORM := s390-linux64


### PR DESCRIPTION
Non-FIPS OpenJCEPlus provider is supported on the Linux aarch64. This PR aims to add aarch64-linux to platform bundling OpenJCEPlus.