### PR TITLE
Simplify constructor of NativeReferenceQueue

### DIFF
--- a/closed/src/java.base/share/classes/java/lang/ref/NativeReferenceQueue.java
+++ b/closed/src/java.base/share/classes/java/lang/ref/NativeReferenceQueue.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 package java.lang.ref;
@@ -37,6 +37,6 @@ package java.lang.ref;
  */
 final class NativeReferenceQueue<T> extends ReferenceQueue<T> {
 	public NativeReferenceQueue() {
-		super(0);
+		super();
 	}
 }


### PR DESCRIPTION
`ReferenceQueue(int)` simply delegates to `ReferenceQueue()`: this change will allow the delegating constructor to be removed from OpenJ9.

Noticed while reviewing https://github.com/eclipse-openj9/openj9/pull/20694.