### PR TITLE
Removed unnamed variables to accommodate JDK21 boot sdk

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package com.sun.tools.javac.comp;
 
 import java.util.*;
@@ -1323,7 +1329,7 @@ public class Check {
     private void warnOnExplicitStrictfp(DiagnosticPosition pos) {
         DiagnosticPosition prevLintPos = deferredLintHandler.setPos(pos);
         try {
-            deferredLintHandler.report(_ -> lint.logIfEnabled(log, pos, LintWarnings.Strictfp));
+            deferredLintHandler.report(_l -> lint.logIfEnabled(log, pos, LintWarnings.Strictfp));
         } finally {
             deferredLintHandler.setPos(prevLintPos);
         }
@@ -4113,7 +4119,7 @@ public class Check {
             int opc = ((OperatorSymbol)operator).opcode;
             if (opc == ByteCodes.idiv || opc == ByteCodes.imod
                 || opc == ByteCodes.ldiv || opc == ByteCodes.lmod) {
-                deferredLintHandler.report(_ -> lint.logIfEnabled(log, pos, LintWarnings.DivZero));
+                deferredLintHandler.report(_l -> lint.logIfEnabled(log, pos, LintWarnings.DivZero));
             }
         }
     }
@@ -4126,7 +4132,7 @@ public class Check {
      */
     void checkLossOfPrecision(final DiagnosticPosition pos, Type found, Type req) {
         if (found.isNumeric() && req.isNumeric() && !types.isAssignable(found, req)) {
-            deferredLintHandler.report(_ ->
+            deferredLintHandler.report(_l ->
                 lint.logIfEnabled(log, pos, LintWarnings.PossibleLossOfPrecision(found, req)));
         }
     }
@@ -4326,7 +4332,7 @@ public class Check {
                             // Warning may be suppressed by
                             // annotations; check again for being
                             // enabled in the deferred context.
-                            deferredLintHandler.report(_ ->
+                            deferredLintHandler.report(_l ->
                                 lint.logIfEnabled(log, pos, LintWarnings.MissingExplicitCtor(c, pkg, modle)));
                         } else {
                             return;
@@ -4661,7 +4667,7 @@ public class Check {
 
     void checkModuleExists(final DiagnosticPosition pos, ModuleSymbol msym) {
         if (msym.kind != MDL) {
-            deferredLintHandler.report(_ ->
+            deferredLintHandler.report(_l ->
                 lint.logIfEnabled(log, pos, LintWarnings.ModuleNotFound(msym)));
         }
     }
@@ -4669,14 +4675,14 @@ public class Check {
     void checkPackageExistsForOpens(final DiagnosticPosition pos, PackageSymbol packge) {
         if (packge.members().isEmpty() &&
             ((packge.flags() & Flags.HAS_RESOURCE) == 0)) {
-            deferredLintHandler.report(_ ->
+            deferredLintHandler.report(_l ->
                 lint.logIfEnabled(log, pos, LintWarnings.PackageEmptyOrNotFound(packge)));
         }
     }
 
     void checkModuleRequires(final DiagnosticPosition pos, final RequiresDirective rd) {
         if ((rd.module.flags() & Flags.AUTOMATIC_MODULE) != 0) {
-            deferredLintHandler.report(_ -> {
+            deferredLintHandler.report(_l -> {
                 if (rd.isTransitive() && lint.isEnabled(LintCategory.REQUIRES_TRANSITIVE_AUTOMATIC)) {
                     log.warning(pos, LintWarnings.RequiresTransitiveAutomatic);
                 } else {


### PR DESCRIPTION
Removed unnamed variables to accommodate JDK21 boot SDK

Fix Java next compilation failure - https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_linux_OpenJDK/695/consoleFull
```
00:47:16  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java:1326: error: unnamed variables are a preview feature and are disabled by default.
00:47:16              deferredLintHandler.report(_ -> lint.logIfEnabled(log, pos, LintWarnings.Strictfp));
00:47:16                                         ^
00:47:16    (use --enable-preview to enable unnamed variables)
00:47:18  1 error
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>