### PR TITLE
Add a check to detect the OpenJCEPlus module

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -67,6 +68,7 @@ public final class RestrictedSecurity {
 
     private static final boolean isNSSSupported;
     private static final boolean isOpenJCEPlusSupported;
+    private static boolean isOpenJCEPlusModuleExist;
 
     private static final boolean userSetProfile;
     private static final boolean shouldEnableSecurity;
@@ -136,6 +138,14 @@ public final class RestrictedSecurity {
             }
         }
         isOpenJCEPlusSupported = isOsSupported && isArchSupported;
+
+        // Check whether the OpenJCEPlus module exists.
+        isOpenJCEPlusModuleExist = false;
+        ModuleLayer layer = ModuleLayer.boot();
+        Optional<Module> module = layer.findModule("openjceplus");
+        if (module.isPresent()) {
+            isOpenJCEPlusModuleExist = true;
+        }
 
         // Check the default solution to see if FIPS is supported.
         isFIPSSupported = isNSSSupported;
@@ -385,6 +395,11 @@ public final class RestrictedSecurity {
         if (profileID.contains("OpenJCEPlus") && !isOpenJCEPlusSupported) {
             printStackTraceAndExit("OpenJCEPlus RestrictedSecurity profiles are not supported"
                     + " on this platform.");
+        }
+
+        if (profileID.contains("OpenJCEPlus") && !isOpenJCEPlusModuleExist) {
+            printStackTraceAndExit("FIPS 140-3 profile specified. Required OpenJCEPlus"
+                    + " module not found.");
         }
 
         if (debug != null) {


### PR DESCRIPTION
Add a check to detect the OpenJCEPlus module. If the module is missing but the restricted security profile requires it, print an error message and exit.

Signed-off-by: Tao Liu <tao.liu@ibm.com>