### PR TITLE
CRIU adds @NotCheckpointSafe for CleanerImpl.CleanableList.insert()

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,7 +51,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/share/classes/java/util/zip/ZipFile.java \
 		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
-		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
+		src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java \
 		src/java.base/share/classes/module-info.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.ref;
 
 import java.lang.ref.Cleaner;
@@ -35,6 +41,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import jdk.internal.misc.InnocuousThread;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * CleanerImpl manages a set of object references and corresponding cleaning actions.
@@ -273,6 +283,9 @@ public final class CleanerImpl implements Runnable {
         /**
          * Insert this PhantomCleanable in the list.
          */
+        /*[IF CRIU_SUPPORT]*/
+        @NotCheckpointSafe
+        /*[ENDIF] CRIU_SUPPORT */
         public synchronized void insert(PhantomCleanable<?> phc) {
             if (head.size == NODE_CAPACITY) {
                 // Head node is full, insert new one.


### PR DESCRIPTION
CRIU adds `@NotCheckpointSafe` for `CleanerImpl.CleanableList.insert()`

Removed `jdk/internal/ref/PhantomCleanable.java` from `COPY_OVERLAY_FILES` list which only applies to JDK21 and earlier versions due to the change of `CleanerImpl.CleanableList` since JDK24.

Related to
* https://github.com/eclipse-openj9/openj9/issues/21111

Signed-off-by: Jason Feng <fengj@ca.ibm.com>