### PR TITLE
Update monitorwaited01 and VThreadEventTest to work with OpenJ9

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
@@ -89,7 +89,7 @@ static void check_stack_trace(JNIEnv* jni, jthread thr) {
   check_jvmti_status(jni, err, "event handler: error in JVMTI GetStackTrace call");
 
   const int expected_count = 8;
-  const char* expected_methods[expected_count] = {"wait0", "wait", "run", "runWith", "run", "run", "enter0", "enter"};
+  const char* expected_methods[expected_count] = {"waitImpl", "wait", "wait", "run", "runWith", "run", "run", "enter"};
 
   if (count != expected_count) {
     LOG("Expected 8 methods in the stack but found %d", count);

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadEventTest/libVThreadEventTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadEventTest/libVThreadEventTest.cpp
@@ -95,8 +95,8 @@ void JNICALL VirtualThreadUnmount(jvmtiEnv* jvmti, ...) {
   check_jvmti_status(jni, err, "event handler: error in JVMTI GetStackTrace call");
 
   // Verify top 3 methods to filter events from Continuation::try_preempt().
-  const int verification_count = 3;
-  const char* expected_methods[verification_count] = {"run", "enter0", "enter"};
+  const int verification_count = 2;
+  const char* expected_methods[verification_count] = {"run", "enter"};
 
   if (count < verification_count) return;
 


### PR DESCRIPTION
OpenJ9 has its own implementation of virtual threads in the JVM.

Due to differences in implementation, the `monitorwaited01` and
`VThreadEventTest` tests have been updated to check the function names
used in OpenJ9's virtual thread implementation.

Related: https://github.com/eclipse-openj9/openj9/issues/19191
Related: https://github.com/eclipse-openj9/openj9/issues/20707