### PR TITLE
CRIU adds @NotCheckpointSafe for PhantomCleanable constructor

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,7 +51,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/share/classes/java/util/zip/ZipFile.java \
 		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
-		src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java \
+		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
 		src/java.base/share/classes/module-info.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -23,12 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
- * ===========================================================================
- */
-
 package jdk.internal.ref;
 
 import java.lang.ref.Cleaner;
@@ -41,10 +35,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import jdk.internal.misc.InnocuousThread;
-
-/*[IF CRIU_SUPPORT]*/
-import openj9.internal.criu.NotCheckpointSafe;
-/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * CleanerImpl manages a set of object references and corresponding cleaning actions.
@@ -283,9 +273,6 @@ public final class CleanerImpl implements Runnable {
         /**
          * Insert this PhantomCleanable in the list.
          */
-        /*[IF CRIU_SUPPORT]*/
-        @NotCheckpointSafe
-        /*[ENDIF] CRIU_SUPPORT */
         public synchronized void insert(PhantomCleanable<?> phc) {
             if (head.size == NODE_CAPACITY) {
                 // Head node is full, insert new one.

--- a/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
+++ b/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
@@ -23,12 +23,22 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.ref;
 
 import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
 import java.lang.ref.PhantomReference;
 import java.util.Objects;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * PhantomCleanable subclasses efficiently encapsulate cleanup state and
@@ -69,6 +79,9 @@ public abstract class PhantomCleanable<T> extends PhantomReference<T>
      * @param referent the referent to track
      * @param cleaner  the {@code Cleaner} to register with
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     @SuppressWarnings("this-escape")
     public PhantomCleanable(T referent, Cleaner cleaner) {
         super(Objects.requireNonNull(referent), CleanerImpl.getCleanerImpl(cleaner).queue);


### PR DESCRIPTION
CRIU adds `@NotCheckpointSafe` for `PhantomCleanable` constructor

`@NotCheckpointSafe` should be added for the caller of the `synchronized` method `list.insert(this)`, i.e., `PhantomCleanable(T referent, Cleaner cleaner)`.

Related to
* https://github.com/eclipse-openj9/openj9/issues/21111

Signed-off-by: Jason Feng <fengj@ca.ibm.com>