### PR TITLE
Prohibit the insertion of 3rd-party provider

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -500,11 +500,24 @@ public final class Security {
     public static synchronized int insertProviderAt(Provider provider,
             int position) {
 
+        ProviderList list = Providers.getFullProviderList();
+
         /*[IF CRIU_SUPPORT]*/
+        if (InternalCRIUSupport.enableCRIUSecProvider()) {
+            for (Provider existingProvider : list.providers()) {
+                if ("CRIUSEC".equals(existingProvider.getName())) {
+                    if (criuDebug) {
+                        System.out.println("Trying to insert + " + provider.getName()
+                                + " during the pre-checkpoint which is not allowed.");
+                    }
+                    throw new RuntimeException("Inserting " + provider.getName()
+                            + " during the pre-checkpoint is not allowed");
+                }
+            }
+        }
         CRIUConfigurator.invalidateAlgorithmCache();
         /*[ENDIF] CRIU_SUPPORT */
 
-        ProviderList list = Providers.getFullProviderList();
         ProviderList newList = ProviderList.insertAt(list, provider, position - 1);
         if (list == newList) {
             return -1;


### PR DESCRIPTION
Some applications want to use CRIU and enable the -XX:CRIUSecProvider JVM option. That's being said only CRIUSec provider can be used during the pre checkpoint phase of CRIU. However, some non-CRIUSec providers might be inserted, which contradicts the purpose of our -XX:CRIUSecProvider JVM option. Therefore, we added a check in the insertProviderAt function to prevent the addition of non-CRIUSec providers.

Depends on https://github.com/eclipse-openj9/openj9/pull/21176