### PR TITLE
Allow multiple constraints for each algorithm

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -789,6 +789,7 @@ public final class RestrictedSecurity {
             if (debug != null) {
                 debug.println("Security constraints check of provider.");
             }
+            constraints:
             for (Constraint constraint : constraints) {
                 String cType = constraint.type;
                 String cAlgorithm = constraint.algorithm;
@@ -807,14 +808,14 @@ public final class RestrictedSecurity {
                     if (debug != null) {
                         debug.println("The constraint doesn't apply to the service type.");
                     }
-                    continue;
+                    continue constraints;
                 }
                 if (!isAsterisk(cAlgorithm) && !algorithm.equalsIgnoreCase(cAlgorithm)) {
                     // The constraint doesn't apply to the service algorithm.
                     if (debug != null) {
                         debug.println("The constraint doesn't apply to the service algorithm.");
                     }
-                    continue;
+                    continue constraints;
                 }
 
                 // For type and algorithm match, and attribute is not *.
@@ -836,7 +837,8 @@ public final class RestrictedSecurity {
                                     + "\nagainst the service attribute value: " + sValue);
                         }
                         if ((sValue == null) || !cValue.equalsIgnoreCase(sValue)) {
-                            // If any attribute doesn't match, return service is not allowed.
+                            // If any of the attributes don't match,
+                            // then this constraint doesn't match so move on.
                             if (debug != null) {
                                 debug.println("Attributes don't match!");
                                 debug.println("The following service:"
@@ -845,7 +847,7 @@ public final class RestrictedSecurity {
                                             + "\n\tAttribute: " + cAttribute
                                             + "\nis NOT allowed in provider: " + providerClassName);
                             }
-                            return false;
+                            continue constraints;
                         }
                         if (debug != null) {
                             debug.println("Attributes match!");
@@ -903,7 +905,7 @@ public final class RestrictedSecurity {
                     }
 
                     // If nothing matching the accepted uses is found in the call stack,
-                    // this service is not allowed.
+                    // then this constraint doesn't match so move on.
                     if (!found) {
                         if (debug != null) {
                             debug.println("Classes in call stack are not part of accepted uses!");
@@ -914,7 +916,7 @@ public final class RestrictedSecurity {
                                         + "\n\tAccepted uses: " + cAcceptedUses
                                         + "\nis NOT allowed in provider: " + providerClassName);
                         }
-                        return false;
+                        continue constraints;
                     }
                 }
 

--- a/closed/test/jdk/openj9/internal/security/TestConstraintsSuccess.java
+++ b/closed/test/jdk/openj9/internal/security/TestConstraintsSuccess.java
@@ -77,6 +77,16 @@ public class TestConstraintsSuccess {
         KeyManagerFactory.getInstance("SunX509");
         TrustManagerFactory.getInstance("SunX509");
         SSLContext.getInstance("TLSv1.3");
+
+        // Since there are three constraints for MD5, with only the middle one
+        // allowing for use by this class, successfully getting the algorithm
+        // verifies that all constraints are checked.
+        MessageDigest.getInstance("MD5");
+
+        // Since there are three constraints for SHA512withECDSA, with only the
+        // middle one having the correct attributes, successfully getting the
+        // algorithm verifies that all constraints are checked.
+        Signature.getInstance("SHA512withECDSA");
     }
 
     @Test

--- a/closed/test/jdk/openj9/internal/security/constraints-java.security
+++ b/closed/test/jdk/openj9/internal/security/constraints-java.security
@@ -21,7 +21,7 @@
 RestrictedSecurity.TestConstraints.Version.desc.name = Test Base Profile
 RestrictedSecurity.TestConstraints.Version.desc.default = false
 RestrictedSecurity.TestConstraints.Version.desc.fips = false
-RestrictedSecurity.TestConstraints.Version.desc.hash = SHA256:b7b4188e2932d3c805eacf21a0feaf282a7906743f94e31e0a32641980d6e459
+RestrictedSecurity.TestConstraints.Version.desc.hash = SHA256:7d8c3428804af049afd1841a5f7d238b922670aab04d8dd252319dfbf0fb8f33
 RestrictedSecurity.TestConstraints.Version.desc.number = Certificate #XXX
 RestrictedSecurity.TestConstraints.Version.desc.policy =
 RestrictedSecurity.TestConstraints.Version.fips.mode = test
@@ -33,12 +33,24 @@ RestrictedSecurity.TestConstraints.Version.jce.provider.1 = sun.security.provide
     {CertPathBuilder, PKIX, *, FullClassName:TestConstraintsSuccess}, \
     {CertPathValidator, PKIX, *, FullClassName:TestConstraintsSuccess}, \
     {SecureRandom, SHA1PRNG, *, FullClassName:TestConstraintsSuccess}, \
+    {MessageDigest, MD5, *, FullClassName:NonExistingClass}, \
+    {MessageDigest, MD5, *, FullClassName:TestConstraintsSuccess}, \
+    {MessageDigest, MD5, *, FullClassName:AnotherNonExistingClass}, \
     {MessageDigest, SHA-256, *}, \
     {MessageDigest, SHA-512, *, FullClassName:TestConstraintsSuccess}, \
     {KeyStore, PKCS12, *, FullClassName:TestConstraintsSuccess}]
 RestrictedSecurity.TestConstraints.Version.jce.provider.2 = sun.security.ec.SunEC [ \
     {AlgorithmParameters, EC, *, ModuleAndFullClassName:java.base/java.security.KeyPairGenerator}, \
     {Signature, SHA256withECDSA, *, FullClassName:TestConstraintsSuccess}, \
+    {Signature, SHA512withECDSA, ImplementedIn=Software: \
+        SupportedKeyClasses=java.security.interfaces.ECPublicKey|java.security.interfaces.ECPrivateKey: \
+        KeySize=255, FullClassName:TestConstraintsSuccess}, \
+    {Signature, SHA512withECDSA, ImplementedIn=Software: \
+        SupportedKeyClasses=java.security.interfaces.ECPublicKey|java.security.interfaces.ECPrivateKey: \
+        KeySize=256, FullClassName:TestConstraintsSuccess}, \
+    {Signature, SHA512withECDSA, ImplementedIn=Software: \
+        SupportedKeyClasses=java.security.interfaces.ECPublicKey|java.security.interfaces.ECPrivateKey: \
+        KeySize=257, FullClassName:TestConstraintsSuccess}, \
     {KeyPairGenerator, EC, *, FullClassName:TestConstraintsSuccess}, \
     {KeyAgreement, ECDH, *, FullClassName:TestConstraintsSuccess}, \
     {KeyFactory, EC, *, FullClassName:TestConstraintsSuccess}]


### PR DESCRIPTION
If a constraint for an algorithm is found and the class attempting to utilize it doesn't match the accepted uses, the algorithm is considered not allowed and loading it does not succeed.

Instead, we want to check all available constraints for an algorithm before deciding if it is allowed to be used by a specific module, package and/or class.

Additional test cases are added to check this functionality.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>