### PR TITLE
Add openjceplus module to NATIVE_ACCESS_MODULES

### DIFF
--- a/closed/custom/common/Modules-post.gmk
+++ b/closed/custom/common/Modules-post.gmk
@@ -60,4 +60,5 @@ MODULES_FILTER += \
 NATIVE_ACCESS_MODULES += \
 	openj9.cuda \
 	openj9.dtfj \
+	$(if $(call equals, $(BUILD_OPENJCEPLUS), true), openjceplus) \
 	#


### PR DESCRIPTION
The openjceplus module makes use of native code which results in a warning message being printed on Java 24 and higher. This update adds the openjceplus module to the NATIVE_ACCESS_MODULES which suppresses this warning message.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>