### PR TITLE
CRIU adds @NotCheckpointSafe for CleanerImpl.CleanableList methods

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,7 +51,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/share/classes/java/util/zip/ZipFile.java \
 		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
-		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
+		src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java \
 		src/java.base/share/classes/module-info.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.ref;
 
 import java.lang.ref.Cleaner;
@@ -35,6 +41,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import jdk.internal.misc.InnocuousThread;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * CleanerImpl manages a set of object references and corresponding cleaning actions.
@@ -265,6 +275,9 @@ public final class CleanerImpl implements Runnable {
          *
          * @return true if the list is empty
          */
+        /*[IF CRIU_SUPPORT]*/
+        @NotCheckpointSafe
+        /*[ENDIF] CRIU_SUPPORT */
         public synchronized boolean isEmpty() {
             // Head node size is zero only when the entire list is empty.
             return head.size == 0;
@@ -273,6 +286,9 @@ public final class CleanerImpl implements Runnable {
         /**
          * Insert this PhantomCleanable in the list.
          */
+        /*[IF CRIU_SUPPORT]*/
+        @NotCheckpointSafe
+        /*[ENDIF] CRIU_SUPPORT */
         public synchronized void insert(PhantomCleanable<?> phc) {
             if (head.size == NODE_CAPACITY) {
                 // Head node is full, insert new one.
@@ -303,6 +319,9 @@ public final class CleanerImpl implements Runnable {
          * @return true if Cleanable was removed or false if not because
          * it had already been removed before
          */
+        /*[IF CRIU_SUPPORT]*/
+        @NotCheckpointSafe
+        /*[ENDIF] CRIU_SUPPORT */
         public synchronized boolean remove(PhantomCleanable<?> phc) {
             if (phc.node == null) {
                 // Not in the list.

--- a/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
+++ b/src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java
@@ -23,22 +23,12 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
- * ===========================================================================
- */
-
 package jdk.internal.ref;
 
 import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
 import java.lang.ref.PhantomReference;
 import java.util.Objects;
-
-/*[IF CRIU_SUPPORT]*/
-import openj9.internal.criu.NotCheckpointSafe;
-/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * PhantomCleanable subclasses efficiently encapsulate cleanup state and
@@ -79,9 +69,6 @@ public abstract class PhantomCleanable<T> extends PhantomReference<T>
      * @param referent the referent to track
      * @param cleaner  the {@code Cleaner} to register with
      */
-    /*[IF CRIU_SUPPORT]*/
-    @NotCheckpointSafe
-    /*[ENDIF] CRIU_SUPPORT */
     @SuppressWarnings("this-escape")
     public PhantomCleanable(T referent, Cleaner cleaner) {
         super(Objects.requireNonNull(referent), CleanerImpl.getCleanerImpl(cleaner).queue);


### PR DESCRIPTION
CRIU adds `@NotCheckpointSafe` for `CleanerImpl.CleanableList` methods

Added `@NotCheckpointSafe` to `CleanerImpl.CleanableList` `isEmpty()`, `insert()` and `remove()`.

Related to 
* https://github.com/eclipse-openj9/openj9/issues/21111#issuecomment-2698203372

The thread `"Common-Cleaner"` entered lock: ` jdk/internal/ref/CleanerImpl$CleanableList@0x000000070A36BCE8`.
```
3XMTHREADINFO      "Common-Cleaner" J9VMThread:0x0000000000172F00, omrthread_t:0x00007F19A4186B60, java/lang/Thread:0x000000070A367470, state:R, prio=8
3XMJAVALTHREAD            (java/lang/Thread getId:0x3, isDaemon:true)
3XMJAVALTHRCCL            No Java context classloader associated with this thread
3XMTHREADINFO1            (native thread ID:0x22BCBB, native priority:0x8, native policy:UNKNOWN, vmstate:CW, vm thread flags:0x00200081)
3XMTHREADINFO2            (native stack address range from:0x00007F1957C8F000, to:0x00007F1957D0F000, size:0x80000)
3XMCPUTIME               CPU usage total: 0.001903862 secs, current category="Application"
3XMHEAPALLOC             Heap bytes allocated since last GC cycle=0 (0x0)
3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at jdk/internal/ref/CleanerImpl$CleanableList.isEmpty(CleanerImpl.java:270)
5XESTACKTRACE                   (entered lock: jdk/internal/ref/CleanerImpl$CleanableList@0x000000070A36BCE8, entry count: 1)
4XESTACKTRACE                at jdk/internal/ref/CleanerImpl.run(CleanerImpl.java:132)
4XESTACKTRACE                at java/lang/Thread.runWith(Thread.java:1471)
4XESTACKTRACE                at java/lang/Thread.run(Thread.java:1458)
4XESTACKTRACE                at jdk/internal/misc/InnocuousThread.run(InnocuousThread.java:148)
```

The following thread is the checkpoint main thread.
```
22:02:54   [OUT] Caused by: openj9.internal.criu.JVMCheckpointException: Blocking operation is not allowed in CRIU single thread mode.
22:02:54   [OUT] 	at java.base/jdk.internal.ref.PhantomCleanable.<init>(PhantomCleanable.java:86)
22:02:54   [OUT] 	at java.base/jdk.internal.ref.CleanerImpl$PhantomCleanableRef.<init>(CleanerImpl.java:164)
22:02:54   [OUT] 	at java.base/java.lang.ref.Cleaner.register(Cleaner.java:225)
22:02:54   [OUT] 	at java.base/java.lang.invoke.MethodHandleNatives$CallSiteContext.make(MethodHandleNatives.java:92)
22:02:54   [OUT] 	at java.base/java.lang.invoke.CallSite.<init>(CallSite.java:145)
22:02:54   [OUT] 	at java.base/java.lang.invoke.ConstantCallSite.<init>(ConstantCallSite.java:50)
22:02:54   [OUT] 	at java.base/java.lang.invoke.InnerClassLambdaMetafactory.buildCallSite(InnerClassLambdaMetafactory.java:229)
```
`PhantomCleanable.<init>` attempts to enter the same lock via `CleanerImpl$CleanableList.insert()`.

The `@NotCheckpointSafe` annotation should be placed at a method invoked by the non-checkpoint thread that entered the lock.
There are other `synchronized` methods within `CleanerImpl$CleanableList` such as `reset()`, `insert()`, and `remove()`. Not adding annotations for these methods for now. The failure was highly intermittent and can't be reproduced in a regular-size grinder.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>