### PR TITLE
Modify StopThreadTest to work with OpenJ9's JEP491 implementation

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
@@ -36,13 +36,6 @@
  */
 
 /*
- * @test id=no-vmcontinuations
- * @summary Verifies JVMTI StopThread support for bound virtual threads.
- * @library /test/lib
- * @run main/othervm/native -agentlib:StopThreadTest -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations -DboundVThread=true StopThreadTest
- */
-
-/*
  * @test id=platform
  * @summary Verifies JVMTI StopThread support for platform threads.
  * @library /test/lib
@@ -283,7 +276,6 @@ public class StopThreadTest {
     }
 
     static boolean preemptableVirtualThread() {
-        boolean legacyLockingMode = true;
-        return is_virtual && !isBoundVThread && !legacyLockingMode;
+        return is_virtual && !isBoundVThread;
     }
 }


### PR DESCRIPTION
OpenJ9 only supports a single implementation; so, the code related to the legacy locking mode has been removed.

OpenJ9 does not support the below options:
```
-XX:+UnlockExperimentalVMOptions -XX:-VMContinuations
```

The test mode that uses the above options has been removed.

Related: https://github.com/eclipse-openj9/openj9/issues/21413.