### PR TITLE
OpenJCEPlus KeyDestructionTest Toleration

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -715,7 +715,6 @@ javax/net/ssl/sanity/interop/ClientJSSEServerJSSE.java https://github.com/eclips
 javax/net/ssl/sanity/pluggability/CheckSSLContextExport.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/templates/SSLEngineTemplate.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/templates/SSLSocketTemplate.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/security/auth/Destroyable/KeyDestructionTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/PrivateCredentialPermission/MoreThenOnePrincipals.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/Subject/Compat.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/Subject/SubjectNullTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -657,7 +657,6 @@ javax/net/ssl/sanity/interop/ClientJSSEServerJSSE.java https://github.com/eclips
 javax/net/ssl/sanity/pluggability/CheckSSLContextExport.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/templates/SSLEngineTemplate.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/templates/SSLSocketTemplate.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-javax/security/auth/Destroyable/KeyDestructionTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/security/auth/PrivateCredentialPermission/MoreThenOnePrincipals.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/security/auth/login/Configuration/GetInstance.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/security/sasl/Sasl/ClientServerTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all

--- a/test/jdk/javax/security/auth/Destroyable/KeyDestructionTest.java
+++ b/test/jdk/javax/security/auth/Destroyable/KeyDestructionTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 6263419
  * @library /test/lib
@@ -44,9 +50,21 @@ public class KeyDestructionTest {
         testKeyDestruction(new MyDestroyableSecretKey());
         testKeyDestruction(new MyDestroyablePrivateKey());
 
-        // Check keys that support but have not implemented key destruction
-        testNoKeyDestruction(generateSecretKey("AES", 128));
-        testNoKeyDestruction(keypair.getPrivate());
+        // AES key implementations, from providers OpenJCEPlus and OpenJCEPlusFIPS,
+        // do implement destroyable for AES keys, other providers do not.
+        if (KeyGenerator.getInstance("AES").getProvider().getName().startsWith("OpenJCEPlus")) {
+            testKeyDestruction(generateSecretKey("AES", 128));
+        } else {
+            testNoKeyDestruction(generateSecretKey("AES", 128));
+        }
+
+        // RSA key implementations, from providers OpenJCEPlus and OpenJCEPlusFIPS,
+        // do implement destroyable for RSA keys, other providers do not.
+        if (KeyPairGenerator.getInstance(kpgAlgorithm).getProvider().getName().startsWith("OpenJCEPlus")) {
+            testKeyDestruction(keypair.getPrivate());
+        } else {
+            testNoKeyDestruction(keypair.getPrivate());
+        }
 
         // Check keys that do not support key destruction
         try {


### PR DESCRIPTION
OpenJCEPlus and OpenJCEPlusFIPS providers support key destruction for the key material being tested by KeyDestructionTest. The test is being adjusted accordingly.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>