### PR TITLE
Add @JvmtiMountTransition to VThread mount() and unmount()

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
  * ===========================================================================
  */
 package java.lang;
@@ -490,6 +490,7 @@ final class VirtualThread extends BaseVirtualThread {
      * return, the current thread is the virtual thread.
      */
     @ChangesCurrentThread
+    @JvmtiMountTransition
     @ReservedStackAccess
     private void mount() {
         // notify JVMTI before mount
@@ -520,6 +521,7 @@ final class VirtualThread extends BaseVirtualThread {
      * current thread is the current platform thread.
      */
     @ChangesCurrentThread
+    @JvmtiMountTransition
     @ReservedStackAccess
     private void unmount() {
         assert !Thread.holdsLock(interruptLock);


### PR DESCRIPTION
Hide JVMTI events of VirtualThread mount() and unmount() during virtual thread mount state transitions. This matches the reference implementation's behaviour.

Issue: https://github.com/eclipse-openj9/openj9/issues/21399