### PR TITLE
Adapt to new java warning suppression mechanism

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -182,6 +182,8 @@ generate : $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)
 
 ifneq (,$(wildcard $(DDR_GENSRC_DIR)))
 
+JAVA_WARNINGS_AS_ERRORS := false
+
 # Compile DDR code again, to ensure compatibility with class files
 # as they would be dynamically generated from the blob.
 $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -56,7 +56,7 @@ WARNING_MODULES := \
 	#
 
 ifneq (,$(filter $(WARNING_MODULES),$(MODULE)))
-  JAVA_WARNINGS_ARE_ERRORS :=
+  JAVA_WARNINGS_AS_ERRORS := false
 endif
 
 # CUDA


### PR DESCRIPTION
A new configuration option (`--disable-java-warnings-as-errors`) was added upstream, which requires this change to the interaction with `JavaCompilation.gmk`.

Notice that this targets the openj9-staging branch - the related change is not yet in the openj9 branch.