### PR TITLE
Increase time out for java/lang/Thread/virtual/SynchronizedNative.java

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/SynchronizedNative.java
+++ b/test/jdk/java/lang/Thread/virtual/SynchronizedNative.java
@@ -28,7 +28,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm/native --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/native/timeout=300 --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -36,7 +36,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm/native -Xint --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/native/timeout=300 -Xint --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -44,7 +44,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm/native -Xcomp -XX:TieredStopAtLevel=1 --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/native/timeout=300 -Xcomp -XX:TieredStopAtLevel=1 --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -52,7 +52,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm/native -Xcomp -XX:-TieredCompilation --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/native/timeout=300 -Xcomp -XX:-TieredCompilation --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
Increase time out for `java/lang/Thread/virtual/SynchronizedNative.java`

Related to 
* https://github.com/eclipse-openj9/openj9/issues/21727

[Timed out with default settings](https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdk24_j9_sanity.openjdk_x86-64_windows/37/)
[Passed with increased timeout value](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/50050/console)

FYI @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>