### PR TITLE
Target z10 architecture for OpenSSL Linux on z

### DIFF
--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -92,6 +92,11 @@ ifeq (,$(OPENSSL_TARGET))
   $(error Unsupported platform $(OPENJDK_TARGET_OS)-$(OPENJDK_TARGET_CPU))
 endif # OPENSSL_TARGET
 
+OPENSSL_CFLAGS :=
+ifeq ($(OPENJDK_TARGET_CPU), s390x)
+  OPENSSL_CFLAGS := -march=z10
+endif
+
 ifneq (,$(CCACHE))
   # If ccache is enabled and the environment contains either CC or CXX, their
   # values (as defined in this make) are propagated to the instance of make
@@ -101,8 +106,8 @@ ifneq (,$(CCACHE))
 endif # CCACHE
 
 build_openssl :
-	@$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR) for $(OPENSSL_TARGET)
-	( $(OPENSSL_CONFIG_SETUP) $(CD) $(OPENSSL_DIR) && $(PERL) Configure $(OPENSSL_TARGET) shared )
+	@$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR) for $(OPENSSL_TARGET) with additional CFLAGS $(OPENSSL_CFLAGS)
+	( $(OPENSSL_CONFIG_SETUP) $(CD) $(OPENSSL_DIR) && $(PERL) Configure $(OPENSSL_CFLAGS) $(OPENSSL_TARGET) shared )
 	$(OPENSSL_PATCH)
 	( $(OPENSSL_MAKE_SETUP) $(CD) $(OPENSSL_DIR) && $(OPENSSL_MAKE) )
 


### PR DESCRIPTION
This update is to prepare for migrating to `OpenSSL` version `3.5.0`.
`OpenSSL` requires `z10` or higher architectures specified for the
compiler.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>