### PR TITLE
Add sleep in StopThreadTest to ensure virtual thread unmounts

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
@@ -113,6 +113,8 @@ public class StopThreadTest {
                 testTaskThread = Thread.ofPlatform().name("TestTaskThread").start(testTask);
             }
             TestTask.ensureBlockedAfterPointA(testTaskThread);
+            /* Sleep for 2 seconds to allow the virtual thread to preempt and unmount. */
+            TestTask.sleep(2000);
 
             if (is_virtual) { // this check is for virtual target thread only
                 log("\nMain #A.1: unsuspended");


### PR DESCRIPTION
The test blocks a virtual thread on monitorenter, expecting it to be
preempted and unmounted before JVMTI functions are invoked. These JVMTI
calls require the virtual thread to be fully unmounted. Without a delay,
the thread may still be in transition, causing intermittent failures.
Adding a 2-second sleep ensures the vthread has time to preempt and
unmount, improving test reliability.

Related: https://github.com/eclipse-openj9/openj9/issues/21695