### PR TITLE
Increase timeout for java/beans/XMLDecoder/8028054/TestMethodFinder.java

### DIFF
--- a/test/jdk/java/beans/XMLDecoder/8028054/TestMethodFinder.java
+++ b/test/jdk/java/beans/XMLDecoder/8028054/TestMethodFinder.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 import com.sun.beans.finder.MethodFinder;
 
 import java.lang.reflect.Method;
@@ -35,7 +41,7 @@ import java.util.List;
  * @author Sergey Malenkov
  * @modules java.desktop/com.sun.beans.finder
  * @compile -XDignore.symbol.file TestMethodFinder.java
- * @run main TestMethodFinder
+ * @run main/timeout=300 TestMethodFinder
  */
 
 public class TestMethodFinder {


### PR DESCRIPTION
Increase timeout for `java/beans/XMLDecoder/8028054/TestMethodFinder.java`

Related to 
* https://github.com/eclipse-openj9/openj9/issues/21457

Signed-off-by: Jason Feng <fengj@ca.ibm.com>