### PR TITLE
Remove unnecessary export of OPENJ9_BUILD=true

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -396,7 +396,7 @@ endif # OPENJ9_ENABLE_DDR
 build-j9 : run-preprocessors-j9
 	@$(ECHO) "Compiling OpenJ9 in $(OUTPUTDIR)/vm"
 	$(call ShowVersions)
-	+OPENJ9_BUILD=true $(EXPORT_COMPILER_ENV_VARS) $(CUSTOM_COMPILER_ENV_VARS) \
+	+$(EXPORT_COMPILER_ENV_VARS) $(CUSTOM_COMPILER_ENV_VARS) \
 		$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm all
 	@$(ECHO) OpenJ9 compile complete
 	+$(DDR_COMMAND)


### PR DESCRIPTION
See https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/832#pullrequestreview-2871736796.