### PR TITLE
Increase Deadlock test timeout for FIPS

### DIFF
--- a/test/jdk/java/security/Security/ClassLoaderDeadlock/Deadlock.java
+++ b/test/jdk/java/security/Security/ClassLoaderDeadlock/Deadlock.java
@@ -22,11 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 4944382
  * @summary make sure we do not deadlock loading signed JAR with getInstance()
  * @library ./Deadlock.jar
- * @run main/othervm/timeout=30 Deadlock
+ * @run main/othervm/timeout=60 Deadlock
  */
 
 import java.security.*;


### PR DESCRIPTION
Increase `Deadlock` test timeout for FIPS

In weak fips mode `-Dsemeru.fips=true` `-Dsemeru.customprofile=OpenJCEPlusFIPS` there is a bit more processing to
be done during startup to load and read the FIPS profiles from the `java.security` file and setup the JCE algorithms and providers available according to the profile.

Related to 
* https://github.com/eclipse-openj9/openj9/issues/21919

Signed-off-by: Jason Feng <fengj@ca.ibm.com>