### PR TITLE
Fix race between notifyAll and GetCurrentContendedMonitor

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
@@ -20,7 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * @test
@@ -76,9 +80,9 @@ public class contmon01 {
     public static volatile boolean waitingBarrier = true;
     static Object lockFld = new Object();
 
-    public static void doSleep() {
+    public static void doSleep(long millis) {
         try {
-            Thread.sleep(10);
+            Thread.sleep(millis);
         } catch (Exception e) {
             throw new Error("Unexpected " + e);
         }
@@ -108,7 +112,7 @@ public class contmon01 {
 
         System.out.println("\nWaiting for auxiliary thread ...");
         while (startingBarrier) {
-            doSleep();
+            doSleep(10);
         }
         System.out.println("Auxiliary thread is ready");
 
@@ -119,13 +123,19 @@ public class contmon01 {
         task.letItGo();
 
         while (waitingBarrier) {
-            doSleep();
+            doSleep(10);
         }
         synchronized (lockFld) {
             System.out.println("\nMain thread entered lockFld's monitor"
                     + "\n\tand calling lockFld.notifyAll() to awake auxiliary thread");
             lockFld.notifyAll();
+
             System.out.println("\nCheck #4: verifying a contended monitor of auxiliary thread ...");
+            while (thread.getState() != Thread.State.BLOCKED) {
+                doSleep(10);
+            }
+            // Wait for 2 seconds to allow the virtual thread to be contended.
+            doSleep(2000);
             checkMonitor(4, thread, lockFld);
             System.out.println("Check #4 done");
         }


### PR DESCRIPTION
contmon01 intermittently fails due to a race condition between
notifyAll and JVMTI GetCurrentContendedMonitor, caused by the
asynchronous scheduling of virtual threads. After being notified, a
virtual thread may not immediately contend for the monitor, resulting
in unexpected null values from GetCurrentContendedMonitor.

To mitigate this, a controlled delay is added after the virtual
thread reaches the BLOCKED state. This provides enough time for the
thread to become contended on the monitor before inspection, making
the test behavior more deterministic.

Related: https://github.com/eclipse-openj9/openj9/issues/21647