### PR TITLE
Return Thread.State.RUNNABLE for VirtualThread.BLOCKING

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -1134,6 +1134,7 @@ final class VirtualThread extends BaseVirtualThread {
                 }
                 // runnable, mounted
                 return Thread.State.RUNNABLE;
+            case BLOCKING:
             case PARKING:
             case TIMED_PARKING:
             case WAITING:
@@ -1149,7 +1150,6 @@ final class VirtualThread extends BaseVirtualThread {
             case TIMED_PINNED:
             case TIMED_WAIT:
                 return Thread.State.TIMED_WAITING;
-            case BLOCKING:
             case BLOCKED:
                 return Thread.State.BLOCKED;
             case TERMINATED:

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
@@ -20,11 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
- * ===========================================================================
- */
+
 
 /*
  * @test
@@ -80,9 +76,9 @@ public class contmon01 {
     public static volatile boolean waitingBarrier = true;
     static Object lockFld = new Object();
 
-    public static void doSleep(long millis) {
+    public static void doSleep() {
         try {
-            Thread.sleep(millis);
+            Thread.sleep(10);
         } catch (Exception e) {
             throw new Error("Unexpected " + e);
         }
@@ -112,7 +108,7 @@ public class contmon01 {
 
         System.out.println("\nWaiting for auxiliary thread ...");
         while (startingBarrier) {
-            doSleep(10);
+            doSleep();
         }
         System.out.println("Auxiliary thread is ready");
 
@@ -123,19 +119,13 @@ public class contmon01 {
         task.letItGo();
 
         while (waitingBarrier) {
-            doSleep(10);
+            doSleep();
         }
         synchronized (lockFld) {
             System.out.println("\nMain thread entered lockFld's monitor"
                     + "\n\tand calling lockFld.notifyAll() to awake auxiliary thread");
             lockFld.notifyAll();
-
             System.out.println("\nCheck #4: verifying a contended monitor of auxiliary thread ...");
-            while (thread.getState() != Thread.State.BLOCKED) {
-                doSleep(10);
-            }
-            // Wait for 2 seconds to allow the virtual thread to be contended.
-            doSleep(2000);
             checkMonitor(4, thread, lockFld);
             System.out.println("Check #4 done");
         }


### PR DESCRIPTION
VirtualThread.BLOCKING currently maps to Thread.State.BLOCKED. This
confuses tests like StopThreadTest and contmon01, which rely on
Thread.getState() to infer if a virtual thread is fully unmounted.

However, BLOCKING is an intermediate state. Mapping it to BLOCKED can
falsely indicate that a virtual thread is unmounted, leading to
incorrect assumptions and intermittent test failures.

To prevent these false positives, BLOCKING will now return
Thread.State.RUNNABLE. This aligns with other intermediate states such
as PARKING, TIMED_PARKING, WAITING, TIMED_WAITING, and YIELDING, which
also return RUNNABLE. Treating BLOCKING similarly ensures consistency
across intermediate states.

Only VirtualThread.BLOCKED will return Thread.State.BLOCKED, which
accurately reflects a fully unmounted virtual thread.

Related: https://github.com/eclipse-openj9/openj9/issues/21695
Related: https://github.com/eclipse-openj9/openj9/issues/21647

This fix also reverts the below PR:
- https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1029