### PR TITLE
Don't regenerate J9JCL source after 'make clean'

### DIFF
--- a/closed/custom/Main-pre.gmk
+++ b/closed/custom/Main-pre.gmk
@@ -39,7 +39,10 @@ OPENJ9_MAKE := $(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/OpenJ9.gmk
 # modules specific to OpenJ9 will be found and included in that set. The next two
 # rules make that happen.
 
-create-main-targets-include java.base-gensrc : generate-j9jcl-sources
+# We don't need to build the preprocessor and generate j9jcl code when cleaning.
+ifeq (,$(filter clean dist-clean, $(SEQUENTIAL_TARGETS)))
+  create-main-targets-include java.base-gensrc : generate-j9jcl-sources
+endif
 
 j9vm-build : buildtools-langtools
   ifeq ($(BUILD_OPENSSL), true)

--- a/closed/custom/common/Modules-pre.gmk
+++ b/closed/custom/common/Modules-pre.gmk
@@ -28,13 +28,17 @@ endif
 
 .PHONY : generate-j9jcl-sources
 
-generate-j9jcl-sources $(J9JCL_SOURCES_DONEFILE) :
+generate-j9jcl-sources :
+
+ifeq (,$(filter clean dist-clean, $(SEQUENTIAL_TARGETS)))
+  generate-j9jcl-sources $(J9JCL_SOURCES_DONEFILE) :
 	@+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/GensrcJ9JCL.gmk
 
-# When building multiple configurations at once (e.g. 'make CONF= images')
-# the 'create-main-targets-include' target will only be considered for the
-# first configuration; J9JCL source generation will be delayed for other
-# configurations. In order to produce a complete module-deps.gmk, we need
-# to ensure that the J9JCL source has been generated.
+  # When building multiple configurations at once (e.g. 'make CONF= images')
+  # the 'create-main-targets-include' target will only be considered for the
+  # first configuration; J9JCL source generation will be delayed for other
+  # configurations. In order to produce a complete module-deps.gmk, we need
+  # to ensure that the J9JCL source has been generated.
 
--include $(J9JCL_SOURCES_DONEFILE)
+  -include $(J9JCL_SOURCES_DONEFILE)
+endif


### PR DESCRIPTION
An [upstream change](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/460b985048c7e0f72770ff64b5b29b8d91c1f32b) introduced a new use of `create-main-targets-include` which would cause the preprocessor to be rebuilt and J9JCL source to be regenerated _after_ cleaning; so the output directory would contain many derived artifacts after `make clean` completes.