### PR TITLE
Use default charset for PrintWriter on z/OS to avoid hardcoded UTF-8

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Print.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.jfr.internal.tool;
 
 import java.io.IOException;
@@ -105,7 +111,18 @@ final class Print extends Command {
     @Override
     public void execute(Deque<String> options) throws UserSyntaxException, UserDataException {
         Path file = getJFRInputFile(options);
-        PrintWriter pw = new PrintWriter(System.out, false, UTF_8);
+        String osName = System.getProperty("os.name");
+        PrintWriter pw;
+        if (osName.contains("z/OS")) {
+            /*[IF JAVA_SPEC_VERSION >= 18]*/
+            pw = new PrintWriter(System.out, false, UTF_8);
+            /*[ELSE] JAVA_SPEC_VERSION >= 18 */
+            pw = new PrintWriter(System.out);
+            /*[ENDIF] JAVA_SPEC_VERSION >= 18 */
+        }
+        else {
+            pw = new PrintWriter(System.out, false, UTF_8);
+        }
         List<Predicate<EventType>> eventFilters = new ArrayList<>();
         int stackDepth = 5;
         EventPrintWriter eventWriter = null;


### PR DESCRIPTION
Modified JFR tool `print` suboption to use the platform's default charset when printing to System.out on z/OS systems, for Java level below 18. This avoids forcing UTF-8 output on EBCDIC-based consoles, ensuring proper encoding and display.

For Java21 on zos I don't see any issue - https://www.ibm.com/docs/en/semeru-runtime-ce-z/21.0.0?topic=guide-file-encoding-utf-8-as-default-charset