### PR TITLE
Update HKDF constraints in RestrictedSecurity profile

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -212,7 +212,7 @@ RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = false
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:165e640b29e9a250409e353039f735c47dcd1043b056fb5ccd224698d9ae8a1e
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:3e1f64454532961b2f8346bc32561ff8ec753744b9343e9f6ee16f083fb6a84d
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
@@ -271,10 +271,6 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.1 = com.ibm.crypto.plu
     {KeyGenerator, HmacSHA256, *}, \
     {KeyGenerator, HmacSHA384, *}, \
     {KeyGenerator, HmacSHA512, *}, \
-    {KeyGenerator, kda-hkdf-with-sha224, *}, \
-    {KeyGenerator, kda-hkdf-with-sha256, *}, \
-    {KeyGenerator, kda-hkdf-with-sha384, *}, \
-    {KeyGenerator, kda-hkdf-with-sha512, *}, \
     {KeyGenerator, SunTls12KeyMaterial, *}, \
     {KeyGenerator, SunTls12MasterSecret, *}, \
     {KeyGenerator, SunTls12Prf, *}, \
@@ -286,6 +282,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.1 = com.ibm.crypto.plu
     {KeyPairGenerator, EC, *}, \
     {KeyPairGenerator, RSA, *}, \
     {KeyPairGenerator, RSAPSS, *}, \
+    {KDF, HKDF-SHA256, *}, \
+    {KDF, HKDF-SHA384, *}, \
+    {KDF, HKDF-SHA512, *}, \
     {Mac, HmacSHA224, *}, \
     {Mac, HmacSHA256, *}, \
     {Mac, HmacSHA3-224, *}, \


### PR DESCRIPTION
In the `RestrictedSecurity` profile that includes the `OpenJCEPlusFIPS` provider, the constraints that pertain to the `HKDF` services are updated to the new implementation.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>