### PR TITLE
Enable HKDF in OpenJCEPlus restrict Profile

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -212,7 +212,7 @@ RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = false
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:165e640b29e9a250409e353039f735c47dcd1043b056fb5ccd224698d9ae8a1e
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:cd6be2cd5df075c7963e553172e7f92536382c5cc8ef804d62c596fe228e586d
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
@@ -262,6 +262,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.1 = com.ibm.crypto.plu
     {Cipher, AES/CCM/NoPadding, *}, \
     {Cipher, AES/GCM/NoPadding, *}, \
     {KeyAgreement, ECDH, *}, \
+    {KDF, HKDF-SHA256, *}, \
+    {KDF, HKDF-SHA384, *}, \
+    {KDF, HKDF-SHA512, *}, \
     {KeyFactory, DSA, *}, \
     {KeyFactory, EC, *}, \
     {KeyFactory, RSA, *}, \


### PR DESCRIPTION
Starting in Java25, key derivation functions can be registered as services extending the KDFSpi, and OpenJCEPlus refactors KDF from KeyGeneratorSpi to KDFSpi. So we need to explicitly register KDF in OpenJCEPlusFIPS restrict profile.