### PR TITLE
Update copyright check to better handle files in closed/test

### DIFF
--- a/.copyrightignore
+++ b/.copyrightignore
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
 # 8. *job* # all things at contains characters in between stars
 # ===========================================================================
 
+/closed/test/
 /src/bsd/doc/
 /src/hotspot/share/jfr/metadata/metadata.xml
 /src/hotspot/share/jfr/metadata/metadata.xsd

--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
@@ -378,24 +378,26 @@ check () {
           ERROR=1
         fi
       else
-        # The file is in the 'closed' directory and doesn't contain
-        # Oracle copyright with GPLv2 and Classpath Exception so should
-        # have IBM copyright with GPLv2 and CE at the top of the file
-        if [ "$FOUND_IBM_COPYRIGHT" -gt 5 ]; then
-          log "E003: $1: IBM Copyright with GPLv2 and IBM Classpath Exception should be at the top of the file"
-          ERROR=1
-        fi
         if [ "$FOUND_GPLV2" -eq 0 ]; then
           log "E004: $1: IBM Copyright should contain the GPLv2 license"
           ERROR=1
         fi
-        if [ "$FOUND_IBM_CPE" -eq 0 ]; then
-          log "E005: $1: IBM Copyright should contain the IBM Classpath Exception"
-          ERROR=1
-        fi
-        if [ "$FOUND_ORACLE_CPE" -gt 0 ]; then
-          log "E006: $1: IBM Copyright should not contain the Oracle Classpath Exception"
-          ERROR=1
+        if [ "$IN_JDK" -eq 1 ]; then
+          # The file is in the 'closed' directory and doesn't contain
+          # Oracle copyright with GPLv2 and Classpath Exception so should
+          # have IBM copyright with GPLv2 and CE at the top of the file.
+          if [ "$FOUND_IBM_COPYRIGHT" -gt 5 ]; then
+            log "E003: $1: IBM Copyright with GPLv2 and IBM Classpath Exception should be at the top of the file"
+            ERROR=1
+          fi
+          if [ "$FOUND_IBM_CPE" -eq 0 ]; then
+            log "E005: $1: IBM Copyright should contain the IBM Classpath Exception"
+            ERROR=1
+          fi
+          if [ "$FOUND_ORACLE_CPE" -gt 0 ]; then
+            log "E006: $1: IBM Copyright should not contain the Oracle Classpath Exception"
+            ERROR=1
+          fi
         fi
       fi
     fi


### PR DESCRIPTION
Files in closed/test don't need a CPE.

Failing build https://openj9-jenkins.osuosl.org/job/CopyrightCheck-OpenJDK/1514/
Passing build with this change https://openj9-jenkins.osuosl.org/job/CopyrightCheck-OpenJDK/1515/