### PR TITLE
Reduce LotsOfContendedMonitorEnter test size

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java
@@ -25,7 +25,7 @@
  * @test id=default
  * @summary Test virtual threads entering a lot of monitors with contention
  * @library /test/lib
- * @run main LotsOfContendedMonitorEnter
+ * @run main/othervm -Xiss32K -XX:ContinuationCache:t1=8,t2=64 LotsOfContendedMonitorEnter
  */
 
 import java.util.concurrent.CountDownLatch;
@@ -38,7 +38,7 @@ public class LotsOfContendedMonitorEnter {
         if (args.length > 0) {
             depth = Integer.parseInt(args[0]);
         } else {
-            depth = 1024;
+            depth = 128;
         }
         VThreadRunner.run(() -> testContendedEnter(depth));
     }


### PR DESCRIPTION
There is a known performance issue with OpenJ9 causing this test to
timeout, this change is to temporarily reduce the size of the test to
retain test coverage while the perf issue is being addressed.

Tracking issue: eclipse-openj9/openj9#22153

JDK24 extension repo: https://github.com/ibmruntimes/openj9-openjdk-jdk24/pull/114
JDK25 entension repo: https://github.com/ibmruntimes/openj9-openjdk-jdk25/pull/14

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>