### PR TITLE
Exclude renamed test ResolveReferenceURIs

### DIFF
--- a/test/jdk/ProblemList-FIPS140_2.txt
+++ b/test/jdk/ProblemList-FIPS140_2.txt
@@ -273,7 +273,7 @@ javax/xml/crypto/dsig/SecureValidation.java https://github.com/ibmruntimes/openj
 javax/xml/crypto/dsig/SecurityManager/XMLDSigWithSecMgr.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64,linux-ppc64le,linux-s390x
 javax/xml/crypto/dsig/TransformService/NullParent.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64,linux-ppc64le,linux-s390x
 javax/xml/crypto/dsig/ValidationTests.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64,linux-ppc64le,linux-s390x
-javax/xml/crypto/dsig/FileSocketPermissions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64,linux-ppc64le,linux-s390x
+javax/xml/crypto/dsig/ResolveReferenceURIs.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64,linux-ppc64le,linux-s390x
 
 # Related to SunJCE or SunRsaSign, no such provider: SunJCE or no such provider: SunRsaSign
 javax/crypto/Cipher/CipherInputStreamExceptions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64,linux-ppc64le,linux-s390x

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -337,7 +337,7 @@ javax/security/auth/Subject/UnsupportedSV.java https://github.com/eclipse-openj9
 javax/xml/crypto/dsig/BadXPointer.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/xml/crypto/dsig/Basic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/xml/crypto/dsig/ErrorHandlerPermissions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/xml/crypto/dsig/FileSocketPermissions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/xml/crypto/dsig/ResolveReferenceURIs.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/xml/crypto/dsig/GenerationTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/xml/crypto/dsig/GetInstanceTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/xml/crypto/dsig/HereFunction.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -324,7 +324,7 @@ javax/security/auth/kerberos/StandardNames.java https://github.com/eclipse-openj
 javax/xml/crypto/dsig/BadXPointer.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/xml/crypto/dsig/Basic.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/xml/crypto/dsig/ErrorHandlerPermissions.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-javax/xml/crypto/dsig/FileSocketPermissions.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+javax/xml/crypto/dsig/ResolveReferenceURIs.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/xml/crypto/dsig/GenerationTests.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/xml/crypto/dsig/GetInstanceTests.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/xml/crypto/dsig/HereFunction.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
The test FileSocketPermissions.java has been renamed
ResolveReferenceURIs in Java 24 and higher. This updates various
excludes lists accordingly.

Issue https://github.com/eclipse-openj9/openj9/issues/22376

Signed-off-by: Jason Katonica <katonica@us.ibm.com>