### PR TITLE
Add compatibility for a key from a different provider

### DIFF
--- a/closed/src/java.base/share/classes/sun/security/ec/NativeXDHKeyAgreement.java
+++ b/closed/src/java.base/share/classes/sun/security/ec/NativeXDHKeyAgreement.java
@@ -160,7 +160,18 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
             }
 
             if (!(key instanceof XDHPublicKeyImpl)) {
-                throw new InvalidKeyException("Unsupported key type");
+                if (!(key instanceof XECPublicKey)) {
+                    throw new InvalidKeyException("Unsupported key type");
+                }
+                try {
+                    XDHKeyFactory kf = new XDHKeyFactory();
+                    key = kf.engineTranslateKey(key);
+                } catch (Exception exception) {
+                    throw new InvalidKeyException("Unable to translate key", exception);
+                }
+                if (!(key instanceof XDHPublicKeyImpl)) {
+                    throw new InvalidKeyException("Unsupported key type");
+                }
             }
 
             XDHPublicKeyImpl publicKey = (XDHPublicKeyImpl) key;


### PR DESCRIPTION
NativeXDHKeyAgreement is updated to support keys created from a different provider than Sun using the XDHKeyFactory.

Signed-off-by: Dev Agarwal dev.agarwal@ibm.com