### PR TITLE
Update the exclusion list for the FIPS tests

### DIFF
--- a/test/jdk/ProblemList-FIPS140_2.txt
+++ b/test/jdk/ProblemList-FIPS140_2.txt
@@ -940,6 +940,7 @@ sun/security/provider/PolicyFile/TrustedCert.java https://github.com/ibmruntimes
 
 # NoSuchAlgorithmException: DRBG, SHA1PRNG, NativePRNG SecureRandom not available.
 
+java/security/Security/ClassLoaderDeadlock/Deadlock.java https://github.com/eclipse-openj9/openj9/issues/21919 linux-x64,linux-ppc64le,linux-s390x
 java/security/Security/ClassLoaderDeadlock/Deadlock.sh https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
 sun/security/ec/ed/TestEdOps.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
 sun/security/provider/SecureRandom/AutoReseed.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -242,6 +242,7 @@ java/security/SecureRandom/SerializedSeedTest.java https://github.com/eclipse-op
 java/security/SecureRandom/ThreadSafe.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/AddProvider.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/CaseInsensitiveAlgNames.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/Security/ClassLoaderDeadlock/Deadlock.java https://github.com/eclipse-openj9/openj9/issues/21919 generic-all
 java/security/Security/ClassLoaderDeadlock/Deadlock.sh https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/ProviderFiltering.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -240,6 +240,7 @@ java/security/SecureRandom/SerializedSeedTest.java https://github.com/eclipse-op
 java/security/SecureRandom/ThreadSafe.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/AddProvider.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/CaseInsensitiveAlgNames.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/Security/ClassLoaderDeadlock/Deadlock.java https://github.com/eclipse-openj9/openj9/issues/21919 generic-all
 java/security/Security/ClassLoaderDeadlock/Deadlock.sh https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/ProviderFiltering.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -226,6 +226,7 @@ java/security/SecureRandom/Serialize.java https://github.com/eclipse-openj9/open
 java/security/SecureRandom/SerializedSeedTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/SecureRandom/ThreadSafe.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/CaseInsensitiveAlgNames.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+java/security/Security/ClassLoaderDeadlock/Deadlock.java https://github.com/eclipse-openj9/openj9/issues/21919 generic-all
 java/security/Security/ClassLoaderDeadlock/Deadlock.sh https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/ProviderFiltering.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
This PR temporarily adds one test to the exclusion list for the FIPS tests due to an issue with the RestrictedSecurity code. The test will be removed from the exclusion list once the RestrictedSecurity issue is solved.