### PR TITLE
Fix minimum allocation size

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.foreign;
 
 import jdk.internal.access.foreign.UnmapperProxy;
@@ -198,7 +204,7 @@ public class SegmentFactories {
         }
         // Always allocate at least some memory so that zero-length segments have distinct
         // non-zero addresses.
-        alignedSize = Math.max(1, alignedSize);
+        alignedSize = Math.max(Long.BYTES, alignedSize);
 
         long allocationSize;
         long allocationBase;


### PR DESCRIPTION
Fix for Issue eclipse-openj9/openj9#22219
Ensure minimum allocation size of Long.BYTES.
initNativeMemory() writes a full long (Long.BYTES). 
1-byte allocation is not enough and can corrupt the footer added by OMR.