### PR TITLE
Remove unnecessary condition in IncludeCustomExtension definition

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -24,11 +24,9 @@
 # arguments:
 # $1 the name of the makefile
 define IncludeCustomExtension
-  ifndef OPENJDK
-    custom_include_file := $(TOPDIR)/closed/custom/$(strip $1)
-    ifneq ($$(wildcard $$(custom_include_file)), )
-      include $$(custom_include_file)
-    endif
+  custom_include_file := $(TOPDIR)/closed/custom/$(strip $1)
+  ifneq ($$(wildcard $$(custom_include_file)), )
+    include $$(custom_include_file)
   endif
 endef
 


### PR DESCRIPTION
The word `OPENJDK` only appeared in this file there's no was need to check whether it's defined (builds would fail if it were).