### PR TITLE
Update ProcessBuilder/Basic regex

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -23,7 +23,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -91,8 +91,8 @@ public class Basic {
     static final String libpath = System.getenv("LIBPATH");
 
     /* Used for regex String matching for long error messages */
-    static final String PERMISSION_DENIED_ERROR_MSG = "(Permission denied|error=13)";
-    static final String NO_SUCH_FILE_ERROR_MSG = "(No such file|error=2)";
+    static final String PERMISSION_DENIED_ERROR_MSG = "(Permission denied|error: 13)";
+    static final String NO_SUCH_FILE_ERROR_MSG = "(No such file|error: 2)";
     static final String SPAWNHELPER_FAILURE_MSG = "(Possible reasons:)";
 
     /**


### PR DESCRIPTION
...to match exception format introduced in 8352533. AIX platform relies on matching the error code.

Port from https://github.com/ibmruntimes/openj9-openjdk-jdk25/pull/40

Fix for https://github.com/eclipse-openj9/openj9/issues/22519