### PR TITLE
Fix two deadlocks in RestrictedSecurity mode DeadLock test

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -135,15 +136,22 @@ public final class RestrictedSecurity {
     }
 
     private static boolean isJarVerifierInStackTrace() {
-        java.util.function.Predicate<Class<?>> isJarVerifier =
-                clazz -> "java.util.jar.JarVerifier".equals(clazz.getName())
-                      && "java.base".equals(clazz.getModule().getName());
+        final String targetClass = "java.util.jar.JarVerifier";
+        final String targetModule = "java.base";
 
-        java.util.function.Function<Stream<StackWalker.StackFrame>, Boolean> matcher =
-                stream -> stream.map(StackWalker.StackFrame::getDeclaringClass)
-                                .anyMatch(isJarVerifier);
-
-        return StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).walk(matcher);
+        for (java.util.Map.Entry<Thread, StackTraceElement[]> e : Thread.getAllStackTraces().entrySet()) {
+            StackTraceElement[] stack = e.getValue();
+            if (stack == null)
+                continue;
+            for (StackTraceElement ste : stack) {
+                if (targetClass.equals(ste.getClassName())) {
+                    if (targetModule.equals(ste.getModuleName())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -640,7 +648,7 @@ public final class RestrictedSecurity {
         if (!isNullOrBlank(descSunsetDate)) {
             try {
                 isSunset = LocalDate.parse(descSunsetDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-                        .isBefore(LocalDate.now());
+                        .isBefore(getTodayWithoutUsingZoneID());
             } catch (DateTimeParseException except) {
                 printStackTraceAndExit(
                         "Restricted security policy sunset date is incorrect, the correct format is yyyy-MM-dd.");
@@ -651,6 +659,12 @@ public final class RestrictedSecurity {
             debug.println("Restricted security policy is sunset: " + isSunset);
         }
         return isSunset;
+    }
+
+    private static LocalDate getTodayWithoutUsingZoneID() {
+        long nowMillis = System.currentTimeMillis();
+        int offsetMillis = TimeZone.getDefault().getOffset(nowMillis);
+        return LocalDate.ofEpochDay(Math.floorDiv(nowMillis + offsetMillis, 86_400_000L));
     }
 
     /**


### PR DESCRIPTION
This PR fixes two issues when running DeadLock test in RestrictedSecurity mode.

One issue arises from the RestrictedSecurity.isPolicySunset() method.

In the Deadlock test, thread 1 attempts to obtain a SecureRandom instance. As part of this process, it calls into the RestrictedSecurity code, which invokes isPolicySunset(). This method uses LocalDate() to retrieve the current date, which in turn triggers the loading of time zone data (tzdb) from JAR files.

At the same time, thread 2 in the same test is attempting to load a JAR file to verify a signed class. The JAR loading process acquires a lock, and thread 2 is left waiting to obtain the signature verification algorithm.

This leads to a deadlock. Thread 2 holds the lock on JAR loading, waiting for the provider to initialize so it can perform signature verification. Thread 1 is blocked in RestrictedSecurity.isPolicySunset(), attempting to load tzdb from the JAR, which is already locked by thread 2.

As a result, both threads wait indefinitely, causing the test to hang. This issue is fixed by avoiding to use the LocalDate() method.

Another deadlock occurs in ProfileParser.checkHashValues().

In thread 1, when attempting to obtain a SecureRandom instance, the call proceeds past isPolicySunset() and into checkHashValues(). This method tries to obtain a MessageDigest from OpenJCEPlusFIPS. However, since OpenJCEPlusFIPS resides in a module that must be loaded, the loading process is blocked—because thread 2 has already locked the JAR loader while waiting for the signature verification algorithms to verify a signed class. As a result, the deadlock occurs.

We already had a method, isJarVerifierInStackTrace(), designed to skip the hash check if the JAR verifier is present in the stack trace. However, this method only checked the current thread’s stack. I updated it to check the stack traces of all threads, which resolves the issue.