### PR TITLE
Correct expected error message for invalid JVM option -W in Arrrghs.java

### DIFF
--- a/test/jdk/tools/launcher/Arrrghs.java
+++ b/test/jdk/tools/launcher/Arrrghs.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
 
 /**
  * @test
@@ -473,7 +478,7 @@ public class Arrrghs extends TestHelper {
         // command line, '% java -jar -W', note the bogus -W
         tr = doExec(javaCmd, "-jar", "-W");
         tr.checkNegative();
-        tr.contains("Unrecognized option: -W");
+        tr.contains("Command-line option unrecognised: -W");
         if (!tr.testStatus)
             System.out.println(tr);
     }


### PR DESCRIPTION
The error message was updated to reflect the exact format of the JVM’s error output. The original message, Unrecognized option: -W, did not match the JVM error, which states: Command-line option unrecognised: -W

Signed-off-by: Amulya Mallola [Amulya.Mallola@ibm.com](mailto:Amulya.Mallola@ibm.com)