### PR TITLE
Exclude ReplayCacheTestProc from FIPS 140-3

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -569,6 +569,7 @@ sun/security/krb5/auto/RefreshKrb5Config.java https://github.com/eclipse-openj9/
 sun/security/krb5/auto/Renew.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/auto/Renewal.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/auto/ReplayCacheTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/krb5/auto/ReplayCacheTestProc.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/auto/RRC.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/auto/S4U2proxy.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all


### PR DESCRIPTION
The test ReplayCacheTestProc is excluded in various other FIPS profiles and should also be excluded here in the Strongly-Enforced profile.