### PR TITLE
Adapt UTIL_ADD_JVM_ARG_IF_OK for OpenJ9

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
 # ===========================================================================
 
 m4_include([util_paths.m4])
@@ -333,7 +333,7 @@ AC_DEFUN([UTIL_ADD_JVM_ARG_IF_OK],
   $ECHO "Check if jvm arg is ok: $1" >&AS_MESSAGE_LOG_FD
   $ECHO "Command: $3 $1 -version" >&AS_MESSAGE_LOG_FD
   OUTPUT=`$3 $1 $USER_BOOT_JDK_OPTIONS -version 2>&1`
-  FOUND_WARN=`$ECHO "$OUTPUT" | $GREP -i warn`
+  FOUND_WARN=`$ECHO "$OUTPUT" | $GREP -i "warn\|unrecognised"`
   FOUND_VERSION=`$ECHO $OUTPUT | $GREP " version \""`
   if test "x$FOUND_VERSION" != x && test "x$FOUND_WARN" = x; then
     $2="[$]$2 $1"


### PR DESCRIPTION
OpenJ9 does not "warn" about bad arguments, instead it says they're "unrecognised".

Numerous warnings appear in the latest acceptance build:
```
JVMJ9VM007W Command-line option unrecognised: -Xlog:all=off:stdout
```
Due to an upstream change:
* [8368960: Adjust java UL logging in the build](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/ef9f3d3081e4590fcb8f65375ddea1312c57a1fe)