### PR TITLE
Adapt to New AES implementation

### DIFF
--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -35,7 +35,7 @@ import java.security.ProviderException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 
-import com.sun.crypto.provider.AESCrypt;
+import com.sun.crypto.provider.AES_Crypt;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 import jdk.internal.ref.CleanerFactory;
@@ -205,7 +205,7 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
             throw new InvalidKeyException("Internal error");
         }
 
-        if (!AESCrypt.isKeySizeValid(key.length)) {
+        if (!AES_Crypt.isKeySizeValid(key.length)) {
             throw new InvalidKeyException("Invalid AES key length: " +
                 key.length + " bytes");
         }

--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
@@ -24,13 +24,13 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
  * ===========================================================================
  */
 
 package com.sun.crypto.provider;
 
-import com.sun.crypto.provider.AESCrypt;
+import com.sun.crypto.provider.AES_Crypt;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -273,7 +273,7 @@ abstract class NativeGaloisCounterMode extends CipherSpi {
     protected int engineGetKeySize(Key key) throws InvalidKeyException {
         byte[] encoded = key.getEncoded();
         Arrays.fill(encoded, (byte)0);
-        if (!AESCrypt.isKeySizeValid(encoded.length)) {
+        if (!AES_Crypt.isKeySizeValid(encoded.length)) {
             throw new InvalidKeyException("Invalid key length: " +
                                           encoded.length + " bytes");
         }
@@ -1089,25 +1089,25 @@ abstract class NativeGaloisCounterMode extends CipherSpi {
 
     public static final class AESGCM extends NativeGaloisCounterMode {
         public AESGCM() {
-            super(-1, new AESCrypt());
+            super(-1, new AES_Crypt());
         }
     }
 
     public static final class AES128 extends NativeGaloisCounterMode {
         public AES128() {
-            super(16, new AESCrypt());
+            super(16, new AES_Crypt());
         }
     }
 
     public static final class AES192 extends NativeGaloisCounterMode {
         public AES192() {
-            super(24, new AESCrypt());
+            super(24, new AES_Crypt());
         }
     }
 
     public static final class AES256 extends NativeGaloisCounterMode {
         public AES256() {
-            super(32, new AESCrypt());
+            super(32, new AES_Crypt());
         }
     }
 }


### PR DESCRIPTION
AESCrypt was renamed AES_Crypt upstream:
* [8326609: New AES implementation with updates specified in FIPS 197](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/1745cf04cc347690aa26a587c48a20925f1f4d64)

Acceptance builds are failing; e.g. https://openj9-jenkins.osuosl.org/job/Build_JDKnext_x86-64_linux_OpenJDK/1024.