### PR TITLE
Add provider check for Cipher unwrapping operation

### DIFF
--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 import static java.lang.System.out;
 
 import java.lang.Integer;
@@ -308,7 +314,7 @@ public class TestCipherKeyWrapperTest {
         Cipher wrapCI = Cipher.getInstance(wrapAlgo);
         if (isPBE && !isAESBlowfish) {
             wrapCI.init(Cipher.WRAP_MODE, initKey, pbeParams);
-        } else if (isAESBlowfish) {
+        } else if (isAESBlowfish && !wrapCI.getProvider().getName().startsWith("OpenJCEPlus")) {
             wrapCI.init(Cipher.WRAP_MODE, initKey);
             aps = wrapCI.getParameters();
         } else {


### PR DESCRIPTION
In OpenJCEPlus, [engineInit](https://github.com/ibmruntimes/OpenJCEPlus/blob/semeru-main/src/main/java/com/ibm/crypto/plus/provider/AESKeyWrapCipher.java#L227C9-L230C10) throws an error when `AlgorithmParameters` is not null. This update changes the else-if logic so it will pass null params to engineInit in the provider OpenJCEPlus/OpenJCEPlusFIPS.

Signed-off-by: Tom Ginader <thomas.ginader@ibm.com>