### PR TITLE
Work around internal compiler error on Windows

### DIFF
--- a/test/jdk/java/foreign/sharedclosejvmti/libSharedCloseAgent.cpp
+++ b/test/jdk/java/foreign/sharedclosejvmti/libSharedCloseAgent.cpp
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <jvmti.h>
 
 #include <string.h>
@@ -102,7 +108,8 @@ Agent_OnLoad(JavaVM *vm, char *options, void *reserved) {
     return jni_err;
   }
 
-  jvmtiCapabilities capabilities{};
+  jvmtiCapabilities capabilities;
+  memset(&capabilities, 0, sizeof(capabilities));
   capabilities.can_generate_method_exit_events = 1;
 
   jvmtiError err = env->AddCapabilities(&capabilities);


### PR DESCRIPTION
Until build systems can be updated; see https://github.com/eclipse-openj9/openj9/issues/22898.