### PR TITLE
Update www.eclipse.org/openj9 to eclipse.dev/openj9

### DIFF
--- a/closed/autoconf/version-numbers
+++ b/closed/autoconf/version-numbers
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2025 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,6 @@
 # Default settings unless overridden by configure
 
 COMPANY_NAME="Eclipse OpenJ9"
-VENDOR_URL="http://www.eclipse.org/openj9"
+VENDOR_URL="http://eclipse.dev/openj9"
 VENDOR_URL_BUG="https://github.com/eclipse-openj9/openj9/issues/new?labels=userRaised&template=user-problem.md"
 VENDOR_URL_VM_BUG="https://github.com/eclipse-openj9/openj9/issues/new?labels=userRaised&template=user-problem.md"

--- a/closed/custom/Docs-pre.gmk
+++ b/closed/custom/Docs-pre.gmk
@@ -25,7 +25,7 @@ JVMTI_HTML := $(TOPDIR)/closed/variant-server/gensrc/jvmtifiles/jvmti.html
 ##############################################################################
 # Text for openj9 modules
 
-OPENJ9_BASE_URL := https://www.eclipse.org/openj9/
+OPENJ9_BASE_URL := https://eclipse.dev/openj9/
 OPENJ9_BUG_SUBMIT_URL := https://github.com/eclipse-openj9/openj9/issues
 OPENJ9_JAVADOC_BOTTOM = \
     <a href="$(OPENJ9_BASE_URL)" target="_blank">Eclipse OpenJ9 website.</a><br> \


### PR DESCRIPTION
The old address is currently redirected, but the new address should be used.