### PR TITLE
Revert "Allow JDK 24 for boot jdk"

### DIFF
--- a/make/conf/version-numbers.conf
+++ b/make/conf/version-numbers.conf
@@ -22,9 +22,6 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-# ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
-# ===========================================================================
 
 # Default version, product, and vendor information to use,
 # unless overridden by configure
@@ -40,6 +37,6 @@ DEFAULT_VERSION_DATE=2026-03-17
 DEFAULT_VERSION_CLASSFILE_MAJOR=70  # "`$EXPR $DEFAULT_VERSION_FEATURE + 44`"
 DEFAULT_VERSION_CLASSFILE_MINOR=0
 DEFAULT_VERSION_DOCS_API_SINCE=11
-DEFAULT_ACCEPTABLE_BOOT_VERSIONS="24 25 26"
+DEFAULT_ACCEPTABLE_BOOT_VERSIONS="25 26"
 DEFAULT_JDK_SOURCE_TARGET_VERSION=26
 DEFAULT_PROMOTED_VERSION_PRE=ea


### PR DESCRIPTION
This reverts commit b99bd2f3a38992d05af9f0520431a15dbfec3c5f; it depends on https://github.com/eclipse-openj9/openj9/pull/22906.