### PR TITLE
Add tests for property file list and RestrictedSecurity service checks

### DIFF
--- a/closed/test/jdk/openj9/internal/security/TestConstraintsFailure.java
+++ b/closed/test/jdk/openj9/internal/security/TestConstraintsFailure.java
@@ -167,6 +167,17 @@ public class TestConstraintsFailure {
         } catch (NoSuchAlgorithmException nsae) {
             // Do nothing. This is expected.
         }
+        try {
+            Cipher.getInstance("PBEWithMD5AndDES");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            String msg = nsae.getMessage();
+            String expected = "Cannot find any provider supporting PBEWithMD5AndDES";
+            if (msg == null || !msg.contains(expected)) {
+                throw new RuntimeException(
+                        "\"" + expected + "\" is expected, but got: " + msg);
+            }
+        }
     }
 
     @Test

--- a/closed/test/jdk/openj9/internal/security/propertyListA-java.security
+++ b/closed/test/jdk/openj9/internal/security/propertyListA-java.security
@@ -1,0 +1,26 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+RestrictedSecurity.Test-Profile-Property-List.A.desc.name = List A Cryptographic Module
+RestrictedSecurity.Test-Profile-Property-List.A.desc.default = true
+RestrictedSecurity.Test-Profile-Property-List.A.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+
+RestrictedSecurity.Test-Profile-Property-List.A.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile-Property-List.A.jce.provider.4 = sun.security.ec.SunEC

--- a/closed/test/jdk/openj9/internal/security/propertyListB-java.security
+++ b/closed/test/jdk/openj9/internal/security/propertyListB-java.security
@@ -1,0 +1,25 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+RestrictedSecurity.Test-Profile-Property-List.B.desc.name = List B Cryptographic Module
+RestrictedSecurity.Test-Profile-Property-List.B.desc.default = false
+RestrictedSecurity.Test-Profile-Property-List.B.extends = RestrictedSecurity.Test-Profile-Property-List.A
+
+RestrictedSecurity.Test-Profile-Property-List.B.jce.provider.5 = com.sun.crypto.provider.SunJCE


### PR DESCRIPTION
This PR adds test coverage for 2 PRs:

1. https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1069

2. https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1078