### PR TITLE
Revert "Fix compile issues with xlc on AIX"

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -68,7 +68,8 @@ id="toc-native-compiler-toolchain-requirements">Native Compiler
 <li><a href="#apple-xcode" id="toc-apple-xcode">Apple Xcode</a></li>
 <li><a href="#microsoft-visual-studio"
 id="toc-microsoft-visual-studio">Microsoft Visual Studio</a></li>
-<li><a href="#ibm-xl-cc" id="toc-ibm-xl-cc">IBM XL C/C++</a></li>
+<li><a href="#ibm-open-xl-cc" id="toc-ibm-open-xl-cc">IBM Open XL
+C/C++</a></li>
 </ul></li>
 <li><a href="#boot-jdk-requirements" id="toc-boot-jdk-requirements">Boot
 JDK Requirements</a>
@@ -702,11 +703,10 @@ the following line: (note that the " characters are essential)</p>
 version number accordingly. If you have not installed the
 <code>BuildTools</code>, but e.g. <code>Professional</code>, adjust the
 product ID accordingly.</p>
-<h3 id="ibm-xl-cc">IBM XL C/C++</h3>
-<p>Please consult the AIX section of the <a
-href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported
-Build Platforms</a> OpenJDK Build Wiki page for details about which
-versions of XLC are supported.</p>
+<h3 id="ibm-open-xl-cc">IBM Open XL C/C++</h3>
+<p>The minimum accepted version of Open XL is 17.1.1.4. This is in
+essence clang 15, and will be treated as such by the OpenJDK build
+system.</p>
 <h2 id="boot-jdk-requirements">Boot JDK Requirements</h2>
 <p>Paradoxically, building the JDK requires a pre-existing JDK. This is
 called the "boot JDK". The boot JDK does not, however, have to be a JDK

--- a/doc/building.md
+++ b/doc/building.md
@@ -508,11 +508,10 @@ that the " characters are essential)
 accordingly. If you have not installed the `BuildTools`, but e.g.
 `Professional`, adjust the product ID accordingly.
 
-### IBM XL C/C++
+### IBM Open XL C/C++
 
-Please consult the AIX section of the [Supported Build Platforms](
-https://wiki.openjdk.org/display/Build/Supported+Build+Platforms) OpenJDK Build
-Wiki page for details about which versions of XLC are supported.
+The minimum accepted version of Open XL is 17.1.1.4. This is in essence clang
+15, and will be treated as such by the OpenJDK build system.
 
 ## Boot JDK Requirements
 

--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -355,9 +355,6 @@ AC_DEFUN_ONCE([BPERF_SETUP_PRECOMPILED_HEADERS],
   if test "x$ICECC" != "x"; then
     AC_MSG_RESULT([no, does not work effectively with icecc])
     PRECOMPILED_HEADERS_AVAILABLE=false
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    AC_MSG_RESULT([no, does not work with xlc])
-    PRECOMPILED_HEADERS_AVAILABLE=false
   elif test "x$TOOLCHAIN_TYPE" = xgcc; then
     # Check that the compiler actually supports precomp headers.
     echo "int alfa();" > conftest.h

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -23,10 +23,6 @@
 # questions.
 #
 
-# ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
-# ===========================================================================
-
 ################################################################################
 #
 # Setup flags for C/C++ compiler
@@ -55,9 +51,6 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
       # Default works for linux, might work on other platforms as well.
       SHARED_LIBRARY_FLAGS='-shared'
     fi
-
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    SHARED_LIBRARY_FLAGS="-qmkshrobj -bM:SRE -bnoentry"
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     SHARED_LIBRARY_FLAGS="-dll"
@@ -122,8 +115,6 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
 
     CFLAGS_DEBUG_SYMBOLS="-g ${GDWARF_FLAGS}"
     ASFLAGS_DEBUG_SYMBOLS="-g"
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    CFLAGS_DEBUG_SYMBOLS="-g1"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     CFLAGS_DEBUG_SYMBOLS="-Z7"
   fi
@@ -189,11 +180,7 @@ AC_DEFUN([DEBUG_PREFIX_MAP_GCC_INCLUDE_PATHS],
 AC_DEFUN([FLAGS_SETUP_WARNINGS],
 [
   # Set default value.
-  if test "x$TOOLCHAIN_TYPE" != xxlc; then
-    WARNINGS_AS_ERRORS_DEFAULT=true
-  else
-    WARNINGS_AS_ERRORS_DEFAULT=false
-  fi
+  WARNINGS_AS_ERRORS_DEFAULT=true
 
   UTIL_ARG_ENABLE(NAME: warnings-as-errors, DEFAULT: $WARNINGS_AS_ERRORS_DEFAULT,
       RESULT: WARNINGS_AS_ERRORS,
@@ -247,15 +234,6 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       # These warnings will never be turned on, since they generate too many
       # false positives.
       DISABLED_WARNINGS="unknown-warning-option unused-parameter"
-      ;;
-
-    xlc)
-      DISABLE_WARNING_PREFIX="-Wno-"
-      CFLAGS_WARNINGS_ARE_ERRORS="-qhalt=w"
-
-      # Possibly a better subset than "all" is "lan:trx:ret:zea:cmp:ret"
-      WARNINGS_ENABLE_ALL="-qinfo=all -qformat=all"
-      DISABLED_WARNINGS=""
       ;;
   esac
   AC_SUBST(DISABLE_WARNING_PREFIX)
@@ -337,15 +315,6 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
       C_O_FLAG_DEBUG_JVM="${C_O_FLAG_DEBUG_JVM} ${DISABLE_FORTIFY_CFLAGS}"
       C_O_FLAG_NONE="${C_O_FLAG_NONE} ${DISABLE_FORTIFY_CFLAGS}"
     fi
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    C_O_FLAG_HIGHEST_JVM="-O3 -qhot=level=1 -qinline -qinlglue"
-    C_O_FLAG_HIGHEST="-O3 -qhot=level=1 -qinline -qinlglue"
-    C_O_FLAG_HI="-O3 -qinline -qinlglue"
-    C_O_FLAG_NORM="-O2"
-    C_O_FLAG_DEBUG="-qnoopt"
-    # FIXME: Value below not verified.
-    C_O_FLAG_DEBUG_JVM=""
-    C_O_FLAG_NONE="-qnoopt"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     C_O_FLAG_HIGHEST_JVM="-O2 -Oy-"
     C_O_FLAG_HIGHEST="-O2"
@@ -494,13 +463,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   else
     DEBUG_CFLAGS_JDK="-DDEBUG"
 
-    if test "x$TOOLCHAIN_TYPE" = xxlc; then
-      # We need '-qminimaltoc' or '-qpic=large -bbigtoc' if the TOC overflows.
-      # Hotspot now overflows its 64K TOC (currently only for debug),
-      # so for debug we build with '-qpic=large -bbigtoc'.
-      DEBUG_CFLAGS_JVM="-qpic=large"
-    fi
-
     if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang ; then
       INIT_PATTERN_FLAG="-ftrivial-auto-var-init=pattern"
       FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$INIT_PATTERN_FLAG],
@@ -527,9 +489,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     ALWAYS_DEFINES_JVM="-D_GNU_SOURCE -D_REENTRANT"
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     ALWAYS_DEFINES_JVM="-D_GNU_SOURCE"
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    ALWAYS_DEFINES_JVM="-D_REENTRANT"
-    ALWAYS_DEFINES_JDK="-D_GNU_SOURCE -D_REENTRANT -DSTDC"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # _WIN32_WINNT=0x0602 means access APIs for Windows 8 and above. See
     # https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
@@ -594,12 +553,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
 
     TOOLCHAIN_CFLAGS_JDK="$TOOLCHAIN_CFLAGS_JDK -fvisibility=hidden -fstack-protector"
 
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    # Suggested additions: -qsrcmsg to get improved error reporting
-    # set -qtbtable=full for a better traceback table/better stacks in hs_err when xlc16 is used
-    TOOLCHAIN_CFLAGS_JDK="-qtbtable=full -qchars=signed -qfullpath -qsaveopt -qstackprotect"  # add on both CFLAGS
-    TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced -fno-exceptions \
-        -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:inline -Zc:throwingNew -permissive- -MP"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:inline -Zc:throwingNew -permissive- -Zc:wchar_t-"
@@ -616,7 +569,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   TOOLCHAIN_CFLAGS_JDK="$TOOLCHAIN_CFLAGS_JDK $CHARSET_CFLAGS"
 
   # CFLAGS C language level for JDK sources (hotspot only uses C++)
-  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang || test "x$TOOLCHAIN_TYPE" = xxlc; then
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     LANGSTD_CFLAGS="-std=c11"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     LANGSTD_CFLAGS="-std:c11"
@@ -628,8 +581,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     LANGSTD_CXXFLAGS="-std=c++17"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     LANGSTD_CXXFLAGS="-std:c++17"
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    LANGSTD_CXXFLAGS="-std=c++14"
   else
     AC_MSG_ERROR([Cannot enable C++17 for this toolchain])
   fi
@@ -650,8 +601,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     WARNING_CFLAGS="$WARNINGS_ENABLE_ALL"
 
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    WARNING_CFLAGS=""  # currently left empty
   fi
 
   # Set some additional per-OS defines.
@@ -676,31 +625,16 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     PICFLAG="-fPIC"
     PIEFLAG="-fPIE"
-  elif test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
-    JVM_PICFLAG="-fpic -mcmodel=large -Wl,-bbigtoc
-    JDK_PICFLAG="-fpic
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    # '-qpic' defaults to 'qpic=small'. This means that the compiler generates only
-    # one instruction for accessing the TOC. If the TOC grows larger than 64K, the linker
-    # will have to patch this single instruction with a call to some out-of-order code which
-    # does the load from the TOC. This is of course slower, and we also would have
-    # to use '-bbigtoc' for linking anyway so we could also change the PICFLAG to 'qpic=large'.
-    # With 'qpic=large' the compiler will by default generate a two-instruction sequence which
-    # can be patched directly by the linker and does not require a jump to out-of-order code.
-    #
-    # Since large TOC causes perf. overhead, only pay it where we must. Currently this is
-    # for all libjvm variants (both gtest and normal) but no other binaries. So, build
-    # libjvm with -qpic=large and link with -bbigtoc.
-    JVM_PICFLAG="-qpic=large"
-    JDK_PICFLAG="-qpic"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     PICFLAG=""
   fi
 
-  if test "x$TOOLCHAIN_TYPE" != xxlc; then
+  if test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
+    JVM_PICFLAG="-fpic -mcmodel=large"
+  else
     JVM_PICFLAG="$PICFLAG"
-    JDK_PICFLAG="$PICFLAG"
   fi
+  JDK_PICFLAG="$PICFLAG"
 
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
     # Linking is different on macOS
@@ -730,8 +664,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -DARCH='\"$FLAGS_CPU_LEGACY\"' \
       -D$FLAGS_CPU_LEGACY"
 
-  if test "x$FLAGS_CPU_BITS" = x64 && test "x$FLAGS_OS" != xaix; then
-    # xlc on AIX defines _LP64=1 by default and issues a warning if we redefine it.
+  if test "x$FLAGS_CPU_BITS" = x64; then
     $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_LP64=1"
     $1_DEFINES_CPU_JVM="${$1_DEFINES_CPU_JVM} -D_LP64=1"
   fi
@@ -819,11 +752,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then
       $1_CFLAGS_CPU="-mcpu=pwr8"
-    fi
-
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    if test "x$FLAGS_CPU" = xppc64; then
-      $1_CFLAGS_CPU_JVM="-qarch=ppc64"
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then

--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -22,13 +22,12 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2026 All Rights Reserved
+# ===========================================================================
 
 ################################################################################
 #
-
-# ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2024 All Rights Reserved
-# ===========================================================================
 
 AC_DEFUN([FLAGS_SETUP_LDFLAGS],
 [
@@ -90,11 +89,6 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
         -Wl,-bernotok -Wl,-bcdtors:mbr::s -Wl,-bdatapsize:64k -Wl,-btextpsize:64k -Wl,-bstackpsize:64k"
       BASIC_LDFLAGS_JVM_ONLY="$BASIC_LDFLAGS_JVM_ONLY -Wl,-lC_r -Wl,-bbigtoc"
     fi
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    BASIC_LDFLAGS="-b64 -brtl -bnolibpath -bnoexpall -bernotok -brwexec_must -btextpsize:64K \
-        -bdatapsize:64K -bstackpsize:64K"
-    # libjvm.so has gotten too large for normal TOC size; compile with qpic=large and link with bigtoc
-    BASIC_LDFLAGS_JVM_ONLY="-Wl,-lC_r -bbigtoc"
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     BASIC_LDFLAGS="-opt:ref"
@@ -126,14 +120,6 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       if test x$DEBUG_LEVEL = xrelease; then
         DEBUGLEVEL_LDFLAGS_JDK_ONLY="$DEBUGLEVEL_LDFLAGS_JDK_ONLY -Wl,-O1"
       fi
-    fi
-
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    # We need '-qminimaltoc' or '-qpic=large -bbigtoc' if the TOC overflows.
-    # Hotspot now overflows its 64K TOC (currently only for debug),
-    # so we build with '-qpic=large -bbigtoc'.
-    if test "x$DEBUG_LEVEL" != xrelease; then
-      DEBUGLEVEL_LDFLAGS_JVM_ONLY="$DEBUGLEVEL_LDFLAGS_JVM_ONLY -bbigtoc"
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -261,12 +261,9 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
   # The sysroot flags are needed for configure to be able to run the compilers
   FLAGS_SETUP_SYSROOT_FLAGS
 
-  # For xlc, the word size flag is required for correct behavior.
   # For clang/gcc, the flag is only strictly required for reduced builds, but
   # set it always where possible (x86 and ppc).
-  if test "x$TOOLCHAIN_TYPE" = xxlc; then
-    MACHINE_FLAG="-q${OPENJDK_TARGET_CPU_BITS}"
-  elif test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     if test "x$OPENJDK_TARGET_CPU_ARCH" = xx86 &&
         test "x$OPENJDK_TARGET_CPU" != xx32 ||
         test "x$OPENJDK_TARGET_CPU_ARCH" = xppc; then
@@ -321,47 +318,6 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
 
 AC_DEFUN([FLAGS_SETUP_TOOLCHAIN_CONTROL],
 [
-  # COMPILER_TARGET_BITS_FLAG  : option for selecting 32- or 64-bit output
-  # COMPILER_COMMAND_FILE_FLAG : option for passing a command file to the compiler
-  # COMPILER_BINDCMD_FILE_FLAG : option for specifying a file which saves the binder
-  #                              commands produced by the link step (currently AIX only)
-  if test "x$TOOLCHAIN_TYPE" = xxlc; then
-    COMPILER_TARGET_BITS_FLAG="-q"
-    COMPILER_COMMAND_FILE_FLAG="-f"
-    COMPILER_BINDCMD_FILE_FLAG="-bloadmap:"
-  else
-    COMPILER_TARGET_BITS_FLAG="-m"
-    COMPILER_COMMAND_FILE_FLAG="@"
-    COMPILER_BINDCMD_FILE_FLAG=""
-
-    # Check if @file is supported by gcc
-    if test "x$TOOLCHAIN_TYPE" = xgcc; then
-      AC_MSG_CHECKING([if @file is supported by gcc])
-      # Extra empty "" to prevent ECHO from interpreting '--version' as argument
-      $ECHO "" "--version" > command.file
-      # Redirect stderr and stdout to config.log (AS_MESSAGE_LOG_FD) via merge
-      if $CXX @command.file 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD; then
-        AC_MSG_RESULT(yes)
-        COMPILER_COMMAND_FILE_FLAG="@"
-      else
-        AC_MSG_RESULT(no)
-        COMPILER_COMMAND_FILE_FLAG=
-      fi
-      $RM command.file
-    fi
-  fi
-
-  AC_SUBST(COMPILER_TARGET_BITS_FLAG)
-  AC_SUBST(COMPILER_COMMAND_FILE_FLAG)
-  AC_SUBST(COMPILER_BINDCMD_FILE_FLAG)
-
-  # Check that the compiler supports -mX (or -qX on AIX) flags
-  # Set COMPILER_SUPPORTS_TARGET_BITS_FLAG to 'true' if it does
-  FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${COMPILER_TARGET_BITS_FLAG}${OPENJDK_TARGET_CPU_BITS}],
-      IF_TRUE: [COMPILER_SUPPORTS_TARGET_BITS_FLAG=true],
-      IF_FALSE: [COMPILER_SUPPORTS_TARGET_BITS_FLAG=false])
-  AC_SUBST(COMPILER_SUPPORTS_TARGET_BITS_FLAG)
-
   if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     if test "x$OPENJDK_TARGET_CPU" != xaarch64; then
       AS_NON_ASM_EXTENSION_OPTION=-Ta
@@ -374,8 +330,6 @@ AC_DEFUN([FLAGS_SETUP_TOOLCHAIN_CONTROL],
     GENDEPS_FLAGS="-MMD -MF"
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     GENDEPS_FLAGS="-MMD -MF"
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    GENDEPS_FLAGS="-qmakedep=gcc -MF"
   fi
   AC_SUBST(GENDEPS_FLAGS)
 ])

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -504,13 +504,6 @@ CXX_VERSION_NUMBER := @CXX_VERSION_NUMBER@
 # Legacy support
 HOTSPOT_TOOLCHAIN_TYPE := @HOTSPOT_TOOLCHAIN_TYPE@
 
-# Option used to pass a command file to the compiler
-COMPILER_COMMAND_FILE_FLAG := @COMPILER_COMMAND_FILE_FLAG@
-
-# Option for specifying a file which saves the binder commands
-# produced by the link step (for debugging, currently AIX only)
-COMPILER_BINDCMD_FILE_FLAG := @COMPILER_BINDCMD_FILE_FLAG@
-
 AS_NON_ASM_EXTENSION_OPTION := @AS_NON_ASM_EXTENSION_OPTION@
 
 # Flags used for overriding the default opt setting for a C/C++ source file.

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -35,25 +35,23 @@
 m4_include([toolchain_microsoft.m4])
 
 # All valid toolchains, regardless of platform (used by help.m4)
-VALID_TOOLCHAINS_all="gcc clang xlc microsoft"
+VALID_TOOLCHAINS_all="gcc clang microsoft"
 
 # These toolchains are valid on different platforms
 VALID_TOOLCHAINS_linux="gcc clang"
 VALID_TOOLCHAINS_macosx="clang"
-VALID_TOOLCHAINS_aix="xlc clang"
+VALID_TOOLCHAINS_aix="clang"
 VALID_TOOLCHAINS_windows="microsoft"
 
 # Toolchain descriptions
 TOOLCHAIN_DESCRIPTION_clang="clang/LLVM"
 TOOLCHAIN_DESCRIPTION_gcc="GNU Compiler Collection"
 TOOLCHAIN_DESCRIPTION_microsoft="Microsoft Visual Studio"
-TOOLCHAIN_DESCRIPTION_xlc="IBM XL C/C++"
 
 # Minimum supported versions, empty means unspecified
 TOOLCHAIN_MINIMUM_VERSION_clang="13.0"
 TOOLCHAIN_MINIMUM_VERSION_gcc="10.0"
 TOOLCHAIN_MINIMUM_VERSION_microsoft="19.28.0.0" # VS2019 16.8, aka MSVC 14.28
-TOOLCHAIN_MINIMUM_VERSION_xlc="17.1.1.4"
 
 # Minimum supported linker versions, empty means unspecified
 TOOLCHAIN_MINIMUM_LD_VERSION_gcc="2.18"
@@ -217,25 +215,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   # First toolchain type in the list is the default
   DEFAULT_TOOLCHAIN=${VALID_TOOLCHAINS%% *}
 
-  # On AIX the default toolchain depends on the installed (found) compiler
-  #   xlclang++     -> xlc toolchain
-  #   ibm-clang++_r -> clang toolchain
-  # The compiler is searched on the PATH and TOOLCHAIN_PATH
-  # xlclang++ has precedence over ibm-clang++_r if both are installed
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    DEFAULT_TOOLCHAIN="clang"
-    if test "x$TOOLCHAIN_PATH" != x; then
-      if test -e ${TOOLCHAIN_PATH}/xlclang++; then
-        DEFAULT_TOOLCHAIN="xlc"
-      fi
-    else
-      UTIL_LOOKUP_PROGS(XLCLANG_TEST_PATH, xlclang++)
-      if test "x$XLCLANG_TEST_PATH" != x; then
-        DEFAULT_TOOLCHAIN="xlc"
-      fi
-    fi
-  fi
-
   if test "x$with_toolchain_type" = xlist; then
     # List all toolchains
     AC_MSG_NOTICE([The following toolchains are valid on this platform:])
@@ -260,48 +239,13 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   fi
   AC_SUBST(TOOLCHAIN_TYPE)
 
-  # on AIX, check for xlclang++ on the PATH and TOOLCHAIN_PATH and use it if it is available
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    if test "x$TOOLCHAIN_PATH" != x; then
-      XLC_TEST_PATH=${TOOLCHAIN_PATH}/
-    fi
-    if test "x$TOOLCHAIN_TYPE" = xclang; then
-      TOOLCHAIN_DESCRIPTION_clang="IBM Open XL C/C++"
-      XLCLANG_VERSION_OUTPUT=`${XLC_TEST_PATH}ibm-clang++_r --version 2>&1 | $HEAD -n 1`
-      $ECHO "$XLCLANG_VERSION_OUTPUT" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
-      if test $? -eq 0; then
-        AC_MSG_NOTICE([ibm-clang++_r output: $XLCLANG_VERSION_OUTPUT])
-      else
-        AC_MSG_ERROR([ibm-clang++_r version output check failed, output: $XLCLANG_VERSION_OUTPUT])
-      fi
-    else
-      XLCLANG_VERSION_OUTPUT=`${XLC_TEST_PATH}xlclang++ -qversion 2>&1 | $HEAD -n 1`
-      $ECHO "$XLCLANG_VERSION_OUTPUT" | $GREP "IBM XL C/C++ for AIX" > /dev/null
-      if test $? -eq 0; then
-        AC_MSG_NOTICE([xlclang++ output: $XLCLANG_VERSION_OUTPUT])
-      else
-        AC_MSG_ERROR([xlclang++ version output check failed, output: $XLCLANG_VERSION_OUTPUT])
-      fi
-    fi
-  fi
-
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    TOOLCHAIN_CC_BINARY_clang="ibm-clang_r"
-  else
-    TOOLCHAIN_CC_BINARY_clang="clang"
-  fi
+  TOOLCHAIN_CC_BINARY_clang="ibm-clang_r clang"
   TOOLCHAIN_CC_BINARY_gcc="gcc"
   TOOLCHAIN_CC_BINARY_microsoft="cl"
-  TOOLCHAIN_CC_BINARY_xlc="xlclang"
 
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    TOOLCHAIN_CXX_BINARY_clang="ibm-clang++_r"
-  else
-    TOOLCHAIN_CXX_BINARY_clang="clang++"
-  fi
+  TOOLCHAIN_CXX_BINARY_clang="ibm-clang++_r clang++"
   TOOLCHAIN_CXX_BINARY_gcc="g++"
   TOOLCHAIN_CXX_BINARY_microsoft="cl"
-  TOOLCHAIN_CXX_BINARY_xlc="xlclang++"
 
   # Use indirect variable referencing
   toolchain_var_name=TOOLCHAIN_DESCRIPTION_$TOOLCHAIN_TYPE
@@ -383,25 +327,7 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
   COMPILER=[$]$1
   COMPILER_NAME=$2
 
-  if test  "x$TOOLCHAIN_TYPE" = xxlc; then
-    # xlc -qversion output typically looks like
-    #     IBM XL C/C++ for AIX, V11.1 (5724-X13)
-    #     Version: 11.01.0000.0015
-    COMPILER_VERSION_OUTPUT=`$COMPILER -qversion 2>&1`
-    # Check that this is likely to be the IBM XL C compiler.
-    $ECHO "$COMPILER_VERSION_OUTPUT" | $GREP "IBM XL C" > /dev/null
-    if test $? -ne 0; then
-      ALT_VERSION_OUTPUT=`$COMPILER --version 2>&1`
-      AC_MSG_NOTICE([The $COMPILER_NAME compiler (located as $COMPILER) does not seem to be the required $TOOLCHAIN_TYPE compiler.])
-      AC_MSG_NOTICE([The result from running with -qversion was: "$COMPILER_VERSION_OUTPUT"])
-      AC_MSG_NOTICE([The result from running with --version was: "$ALT_VERSION_OUTPUT"])
-      AC_MSG_ERROR([A $TOOLCHAIN_TYPE compiler is required. Try setting --with-tools-dir.])
-    fi
-    # Collapse compiler output into a single line
-    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT`
-    COMPILER_VERSION_NUMBER=`$ECHO $COMPILER_VERSION_OUTPUT | \
-        $SED -e 's/^.*Version: \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
-  elif test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+  if test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # There is no specific version flag, but all output starts with a version string.
     # First line typically looks something like:
     # Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 16.00.40219.01 for 80x86
@@ -446,12 +372,22 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
         $AWK '{print [$]1}'`
   elif test  "x$TOOLCHAIN_TYPE" = xclang; then
     # clang --version output typically looks like
-    #    Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
-    #    clang version 3.3 (tags/RELEASE_33/final)
+    #    Apple clang version 15.0.0 (clang-1500.3.9.4)
+    #    Target: arm64-apple-darwin23.2.0
+    #    Thread model: posix
+    #    InstalledDir: /Library/Developer/CommandLineTools/usr/bin
     # or
-    #    Debian clang version 3.2-7ubuntu1 (tags/RELEASE_32/final) (based on LLVM 3.2)
+    #    clang version 10.0.0-4ubuntu1
     #    Target: x86_64-pc-linux-gnu
     #    Thread model: posix
+    #    InstalledDir: /usr/bin
+    #    Target: x86_64-pc-linux-gnu
+    #    Thread model: posix
+    # or
+    #    IBM Open XL C/C++ for AIX 17.1.0 (5725-C72, 5765-J18), clang version 13.0.0
+    #    Target: powerpc-ibm-aix7.2.0.0
+    #    Thread model: posix
+    #    InstalledDir: /opt/IBM/openxlC/17.1.0/bin
     COMPILER_VERSION_OUTPUT=`$COMPILER --version 2>&1`
     # Check that this is likely to be clang
     $ECHO "$COMPILER_VERSION_OUTPUT" | $GREP "clang" > /dev/null
@@ -460,10 +396,12 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
       AC_MSG_NOTICE([The result from running with --version was: "$COMPILER_VERSION_OUTPUT"])
       AC_MSG_ERROR([A $TOOLCHAIN_TYPE compiler is required. Try setting --with-tools-dir.])
     fi
-    # Collapse compiler output into a single line
-    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT`
+    # Remove "Thread model:" and further details from the version string, and
+    # collapse into a single line
+    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT | \
+        $SED -e 's/ *Thread model: .*//'`
     COMPILER_VERSION_NUMBER=`$ECHO $COMPILER_VERSION_OUTPUT | \
-        $SED -e 's/^.* version \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
+        $SED -e 's/^.*clang version \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
   else
       AC_MSG_ERROR([Unknown toolchain type $TOOLCHAIN_TYPE.])
   fi
@@ -558,10 +496,7 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_LD_VERSION],
   LINKER=[$]$1
   LINKER_NAME="$2"
 
-  if test  "x$TOOLCHAIN_TYPE" = xxlc; then
-    LINKER_VERSION_STRING="Unknown"
-    LINKER_VERSION_NUMBER="0.0"
-  elif test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+  if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # There is no specific version flag, but all output starts with a version string.
     # First line typically looks something like:
     #   Microsoft (R) Incremental Linker Version 12.00.31101.0
@@ -995,6 +930,14 @@ AC_DEFUN_ONCE([TOOLCHAIN_MISC_CHECKS],
       if test "x$COMPILER_CPU_TEST" != "xARM64"; then
         AC_MSG_ERROR([Target CPU mismatch. We are building for $OPENJDK_TARGET_CPU but CL is for "$COMPILER_CPU_TEST"; expected "arm64".])
       fi
+    fi
+  fi
+  if test "x$OPENJDK_TARGET_OS" = xaix; then
+    # Make sure we have the Open XL version of clang on AIX
+
+    $ECHO "$CC_VERSION_STRING" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
+    if test $? -ne 0; then
+      AC_MSG_ERROR([ibm-clang_r version output check failed, output: $CC_VERSION_OUTPUT])
     fi
   fi
 

--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -23,10 +23,6 @@
 # questions.
 #
 
-# ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
-# ===========================================================================
-
 include MakeIncludeStart.gmk
 ifeq ($(INCLUDE), true)
 
@@ -68,7 +64,7 @@ else ifeq ($(call isCompiler, clang), true)
           -Wl,-z,origin -Wl,-rpath,\$(DOLLAR)ORIGIN$1
     endif
   endif
-else ifeq ($(call isCompiler, microsoft xlc), true)
+else ifeq ($(call isCompiler, microsoft), true)
   SetExecutableOrigin =
   SetSharedLibraryOrigin =
 else

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -22,9 +22,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-
 # ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2025, 2026 All Rights Reserved
 # ===========================================================================
 
 include MakeIncludeStart.gmk
@@ -68,7 +67,7 @@ else ifeq ($(call isCompiler, clang), true)
     SetSharedLibraryName = \
         -Wl,-soname=$1
   endif
-else ifeq ($(call isCompiler, microsoft xlc), true)
+else ifeq ($(call isCompiler, microsoft), true)
   SetSharedLibraryName =
 else
   $(error Unknown toolchain)
@@ -157,9 +156,9 @@ define CreateDynamicLibraryOrExecutable
     # Generating a dynamic library.
     $1_EXTRA_LDFLAGS += $$(call SetSharedLibraryName,$$($1_BASENAME))
 
-    # Create loadmap on AIX. Helps in diagnosing some problems.
-    ifneq ($(COMPILER_BINDCMD_FILE_FLAG), )
-      $1_EXTRA_LDFLAGS += $(COMPILER_BINDCMD_FILE_FLAG)$$($1_OBJECT_DIR)/$$($1_NOSUFFIX).loadmap
+    ifeq ($(call isTargetOs, aix), true)
+      # Create loadmap on AIX. Helps in diagnosing some problems.
+      $1_EXTRA_LDFLAGS += -Wl,-bloadmap:$$($1_OBJECT_DIR)/$$($1_NOSUFFIX).loadmap
     endif
   endif
 

--- a/make/common/native/Paths.gmk
+++ b/make/common/native/Paths.gmk
@@ -212,12 +212,7 @@ define SetupObjectFileList
   # If there are many object files, use an @-file...
   ifneq ($$(word 17, $$($1_ALL_OBJS)), )
     $1_OBJ_FILE_LIST := $$($1_OBJECT_DIR)/_$1_objectfilenames.txt
-    ifneq ($(COMPILER_COMMAND_FILE_FLAG), )
-      $1_LD_OBJ_ARG := $(COMPILER_COMMAND_FILE_FLAG)$$($1_OBJ_FILE_LIST)
-    else
-      # ...except for toolchains which don't support them.
-      $1_LD_OBJ_ARG := `cat $$($1_OBJ_FILE_LIST)`
-    endif
+    $1_LD_OBJ_ARG := @$$($1_OBJ_FILE_LIST)
 
     # If we are building static library, 'AR' on macosx/aix may not support @-file.
     ifeq ($$($1_TYPE), STATIC_LIBRARY)

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -114,8 +114,6 @@ ifneq ($(DEBUG_LEVEL), release)
   DISABLED_WARNINGS_gcc += strict-overflow
 endif
 
-DISABLED_WARNINGS_xlc := tautological-compare shift-negative-value
-
 DISABLED_WARNINGS_microsoft := 4624 4244 4291 4146 4127 4722
 
 ################################################################################
@@ -231,7 +229,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_clang_aix_debug.cpp := format-nonliteral, \
     DISABLED_WARNINGS_clang_aix_jvm.cpp := format-nonliteral, \
     DISABLED_WARNINGS_clang_aix_osThread_aix.cpp := tautological-undefined-compare, \
-    DISABLED_WARNINGS_xlc := $(DISABLED_WARNINGS_xlc), \
     DISABLED_WARNINGS_microsoft := $(DISABLED_WARNINGS_microsoft), \
     ASFLAGS := $(JVM_ASFLAGS), \
     LD_SET_ORIGIN := false, \

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2026 All Rights Reserved
 # ===========================================================================
 
 ################################################################################
@@ -78,7 +78,6 @@ TARGETS += $(BUILD_LIBNET)
 $(eval $(call SetupJdkLibrary, BUILD_LIBNIO, \
     NAME := nio, \
     OPTIMIZATION := HIGH, \
-    WARNINGS_AS_ERRORS_xlc := false, \
     Net.c_CFLAGS := \
         -I$(OPENJ9OMR_TOPDIR)/include_core \
         -I$(OPENJ9_VM_BUILD_DIR)/jcl, \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2025, 2026 All Rights Reserved
 # ===========================================================================
 
 include MakeIncludeStart.gmk
@@ -85,7 +85,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
         -I$(OPENJ9_TOPDIR)/runtime/jcl \
         -I$(OPENJ9_TOPDIR)/runtime/util \
         -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
-    WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc_ProcessImpl_md.c := unused-result, \
     DISABLED_WARNINGS_clang_TimeZone_md.c := unused-variable, \
     JDK_LIBS := libjvm, \


### PR DESCRIPTION
This mostly reverts commit 61b1e26c9abeb2d845026f1b7c6e6cacae2d6f1e from https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/757 to reinstate ceeb8571963012d55755ad7d875b5fedb93e7db1.

Conflicts:
	make/autoconf/flags-cflags.m4
	make/autoconf/flags-ldflags.m4
	make/autoconf/spec.gmk.template
	make/common/native/Link.gmk
	make/modules/java.base/Lib.gmk
	make/modules/java.base/lib/CoreLibraries.gmk
	make/modules/java.desktop/lib/Awt2dLibraries.gmk

Testing in https://hyc-runtimes-jenkins.swg-devops.com/job/Build_JDKnext_ppc64_aix_Personal/333/

Issue https://github.com/eclipse-openj9/openj9/issues/19098