### PR TITLE
Define test property vm.jvmci as false

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -85,6 +85,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
         map.put("vm.gc.ZSinglegen", "false");
         map.put("vm.graal.enabled", "false");
         map.put("vm.hasJFR", "false");
+        map.put("vm.jvmci", "false");
         map.put("vm.jvmti", "true");
         map.put("vm.musl", "false");
         map.put("vm.openj9", "true");


### PR DESCRIPTION
The Java Virtual Machine Compiler Interface isn't supported by OpenJ9.

Reference https://github.ibm.com/runtimes/openj9-openjdk-jdk25-zos/issues/133