### PR TITLE
Update Cipher GetInstance test

### DIFF
--- a/test/jdk/javax/crypto/Cipher/TestGetInstance.java
+++ b/test/jdk/javax/crypto/Cipher/TestGetInstance.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 4898428 8368984
  * @summary test that the new getInstance() implementation works correctly
@@ -55,7 +61,8 @@ public class TestGetInstance {
 
         Cipher c;
 
-        c = Cipher.getInstance(pbeAlgo);
+        c = Cipher.getInstance(pbeAlgo,
+                System.getProperty("test.provider.name", "SunJCE"));
         same(p, c.getProvider());
 
         c = Cipher.getInstance(algoLC,


### PR DESCRIPTION
Ensure SunJCE is compared with itself and not the first provider in the list supporting PBECipher.

Fixes: https://github.com/eclipse-openj9/openj9/issues/22956

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)