### PR TITLE
Update CipherKeyWrapper test

### DIFF
--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
@@ -314,7 +314,7 @@ public class TestCipherKeyWrapperTest {
         Cipher wrapCI = Cipher.getInstance(wrapAlgo);
         if (isPBE && !isAESBlowfish) {
             wrapCI.init(Cipher.WRAP_MODE, initKey, pbeParams);
-        } else if (isAESBlowfish && !wrapCI.getProvider().getName().startsWith("OpenJCEPlus")) {
+        } else if (isAESBlowfish && (!wrapCI.getProvider().getName().startsWith("OpenJCEPlus") || isPBE)) {
             wrapCI.init(Cipher.WRAP_MODE, initKey);
             aps = wrapCI.getParameters();
         } else {


### PR DESCRIPTION
Ensure the same parameters are used for decrypting/unwrapping that were used for encrypting/wrapping for PBE.

Fixes: https://github.com/eclipse-openj9/openj9/issues/22964

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)