### PR TITLE
Support OpenJCEPlus Keyrep in jce keystore filter

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1612,7 +1612,8 @@ jdk.xml.dsig.secureValidationPolicy=\
 # pattern allows java.lang.Enum, java.security.KeyRep, java.security.KeyRep$Type,
 # and javax.crypto.spec.SecretKeySpec and rejects all the others.
 jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep;\
-  java.base/java.security.KeyRep$Type;java.base/javax.crypto.spec.SecretKeySpec;!*
+  java.base/java.security.KeyRep$Type;java.base/javax.crypto.spec.SecretKeySpec;\
+  com.ibm.crypto.plus.provider.JCEPlusKeyRep;com.ibm.crypto.plus.provider.JCEPlusKeyRep$Type;!*
 
 # The iteration count used for password-based encryption (PBE) in JCEKS
 # keystores. Values in the range 10000 to 5000000 are considered valid.


### PR DESCRIPTION
OpenJCEPlus has its own implementation of KeyRep, append it to the jceks,key.serialFilter in case trying to get a key from JCEKS type keystore when OpenJCEPlus provider is on the top order of the list.

Solve the issue: #22957