### PR TITLE
Remove 24 as an acceptable boot version

### DIFF
--- a/make/conf/version-numbers.conf
+++ b/make/conf/version-numbers.conf
@@ -22,9 +22,6 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-# ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
-# ===========================================================================
 
 # Default version, product, and vendor information to use,
 # unless overridden by configure
@@ -40,6 +37,6 @@ DEFAULT_VERSION_DATE=2026-09-15
 DEFAULT_VERSION_CLASSFILE_MAJOR=71  # "`$EXPR $DEFAULT_VERSION_FEATURE + 44`"
 DEFAULT_VERSION_CLASSFILE_MINOR=0
 DEFAULT_VERSION_DOCS_API_SINCE=11
-DEFAULT_ACCEPTABLE_BOOT_VERSIONS="24 25 26 27"
+DEFAULT_ACCEPTABLE_BOOT_VERSIONS="25 26 27"
 DEFAULT_JDK_SOURCE_TARGET_VERSION=27
 DEFAULT_PROMOTED_VERSION_PRE=ea


### PR DESCRIPTION
This reverts the file to be unmodifed from OpenJDK.

Related to https://github.com/eclipse-openj9/openj9/pull/23086