### PR TITLE
Sync up Native* classes with upstream equivalents

### DIFF
--- a/closed/src/java.base/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
+++ b/closed/src/java.base/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -45,6 +45,7 @@ import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.EllipticCurve;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -348,7 +349,12 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
             throw new NoSuchAlgorithmException(
                     "Unsupported secret key algorithm: " + algorithm);
         }
-        return new SecretKeySpec(engineGenerateSecret(), algorithm);
+        byte[] bytes = engineGenerateSecret();
+        try {
+            return new SecretKeySpec(bytes, algorithm);
+        } finally {
+            Arrays.fill(bytes, (byte)0);
+        }
     }
 
     /**

--- a/closed/src/java.base/share/classes/sun/security/ec/NativeXDHKeyAgreement.java
+++ b/closed/src/java.base/share/classes/sun/security/ec/NativeXDHKeyAgreement.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -41,6 +41,7 @@ import java.security.interfaces.XECPrivateKey;
 import java.security.interfaces.XECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.NamedParameterSpec;
+import java.util.Arrays;
 
 import javax.crypto.KeyAgreementSpi;
 import javax.crypto.SecretKey;
@@ -56,8 +57,7 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
     private static NativeCrypto nativeCrypto;
     private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
 
-    private XECPrivateKey xecPrivateKey;
-    private byte[] privateKey;
+    private XECPrivateKey privateKey;
     private byte[] secret;
     private XECOperations ops;
     private final XECParameters lockedParams;
@@ -101,17 +101,18 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
         if (!(key instanceof XECPrivateKey)) {
             throw new InvalidKeyException("Unsupported key type");
         }
-        xecPrivateKey = (XECPrivateKey) key;
+        privateKey = (XECPrivateKey) key;
         XECParameters xecParams = XECParameters.get(
-            InvalidKeyException::new, xecPrivateKey.getParams());
+            InvalidKeyException::new, privateKey.getParams());
 
         if ((lockedParams != null) && (lockedParams != xecParams)) {
             throw new InvalidKeyException("Parameters must be " + lockedParams.getName());
         }
 
         ops = new XECOperations(xecParams);
-        privateKey = xecPrivateKey.getScalar()
+        byte[] tmp = privateKey.getScalar()
                 .orElseThrow(() -> new InvalidKeyException("No private key value"));
+        Arrays.fill(tmp, (byte)0);
         secret = null;
 
         if (!NativeCrypto.isAllowedAndLoaded()) {
@@ -192,17 +193,22 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
                 curveType = NativeCrypto.X448;
             }
 
-            byte[] publicKeyArray = publicKey.getKeyAsByteArray();
-            computedSecret = new byte[ops.getParameters().getBytes()];
+            int result;
+            byte[] scalar = this.privateKey.getScalar().get();
+            try {
+                byte[] publicKeyArray = publicKey.getKeyAsByteArray();
+                computedSecret = new byte[ops.getParameters().getBytes()];
 
-            if (nativeCrypto == null) {
-                nativeCrypto = NativeCrypto.getNativeCrypto();
-            }
-            int result = nativeCrypto.XDHGenerateSecret(privateKey, privateKey.length,
+                if (nativeCrypto == null) {
+                    nativeCrypto = NativeCrypto.getNativeCrypto();
+                }
+                result = nativeCrypto.XDHGenerateSecret(scalar, scalar.length,
                                                         publicKeyArray, publicKeyArray.length,
                                                         computedSecret, computedSecret.length,
                                                         curveType);
-
+            } finally {
+                Arrays.fill(scalar, (byte)0);
+            }
             if (result == -1) {
                 if (nativeCryptTrace) {
                     System.err.println("Shared secret generation by OpenSSL failed," +
@@ -217,7 +223,8 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
             throw new InvalidKeyException("Point has small order");
         }
 
-        secret = computedSecret;
+        this.secret = computedSecret;
+
         return null;
     }
 
@@ -275,7 +282,12 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
             throw new NoSuchAlgorithmException(
                     "Unsupported secret key algorithm: " + algorithm);
         }
-        return new SecretKeySpec(engineGenerateSecret(), algorithm);
+        byte[] bytes = engineGenerateSecret();
+        try {
+            return new SecretKeySpec(bytes, algorithm);
+        } finally {
+            Arrays.fill(bytes, (byte)0);
+        }
     }
 
     /*
@@ -296,7 +308,7 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
                     javaImplementation = new XDHKeyAgreement.X448();
                 }
             }
-            javaImplementation.engineInit(xecPrivateKey, null);
+            javaImplementation.engineInit(privateKey, null);
         }
     }
 


### PR DESCRIPTION
Apply changes introduced to upstream classes `ECDHKeyAgreement` and `XDHKeyAgreement` through commit 3801aa96f889968eeba0047b4a8d4567be2bc45a in equivalent `NativeECDHKeyAgreeement` and `NativeXDHKeyAgreement` classes utilizing the `OpenSSL` native library.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>