### PR TITLE
Restore "requires jdk.internal.jvmstat" by module jdk.attach

### DIFF
--- a/closed/custom/common/Modules-post.gmk
+++ b/closed/custom/common/Modules-post.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -40,6 +40,7 @@ else
   PLATFORM_MODULES += \
 	ibm.healthcenter \
 	jdk.attach \
+	jdk.internal.jvmstat \
 	#
 endif
 

--- a/src/jdk.attach/share/classes/module-info.java
+++ b/src/jdk.attach/share/classes/module-info.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -38,6 +38,8 @@
  * @since 9
  */
 module jdk.attach {
+    requires jdk.internal.jvmstat;
+
     exports com.sun.tools.attach;
     exports com.sun.tools.attach.spi;
 


### PR DESCRIPTION
Restore `requires jdk.internal.jvmstat` by module `jdk.attach`

Also restored `jdk.internal.jvmstat` as one of `PLATFORM_MODULES`;
This partially reverted 
* https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/489

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1148

Signed-off-by: Jason Feng <fengj@ca.ibm.com>