### PR TITLE
Exclude FragmentedFinished for FIPS 140-3 strong profile

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2025, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -424,6 +424,7 @@ javax/net/ssl/DTLS/DTLSSequenceNumberTest.java https://github.com/eclipse-openj9
 javax/net/ssl/DTLS/DTLSSignatureSchemes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSWontNegotiateV10.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/net/ssl/DTLS/FragmentedFinished.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/InvalidCookie.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/InvalidRecords.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/NoMacInitialClientHello.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all


### PR DESCRIPTION
The reason this is failing is that the Sun provider registers the PKCS12
algorithm which uses the `DualFormatPKCS12` class.

The loading logic for the `DualFormatPKCS12` class trys PKCS12 first
and gets the der encoding error, then attempts to use JKS.

In our case JKS is not found and the original error treating the JKS
file as a PKCS12 and returns the error to the user. The test fails with:

```
java.io.IOException: DerInputStream.getLength(): lengthTag=109, too big.
	at java.base/sun.security.util.DerInputStream.getLength(DerInputStream.java:251)
	at java.base/sun.security.util.DerValue.<init>(DerValue.java:444)
	at java.base/sun.security.util.DerValue.<init>(DerValue.java:487)
	at java.base/sun.security.pkcs12.PKCS12KeyStore.engineLoad(PKCS12KeyStore.java:2012)
	at java.base/sun.security.util.KeyStoreDelegator.engineLoad(KeyStoreDelegator.java:221)
	at java.base/java.security.KeyStore.load(KeyStore.java:1473)
	at jdk.test.lib.security.KeyStoreUtils.loadKeyStore(KeyStoreUtils.java:58)
	at jdk.test.lib.security.KeyStoreUtils.loadKeyStore(KeyStoreUtils.java:106)
	at jdk.test.lib.security.KeyStoreUtils.loadKeyStore(KeyStoreUtils.java:119)
	at DTLSOverDatagram.getDTLSContext(DTLSOverDatagram.java:513)
	at DTLSOverDatagram.createSSLEngine(DTLSOverDatagram.java:135)
	at FragmentedFinished.createSSLEngine(FragmentedFinished.java:53)
	at DTLSOverDatagram.doClientSide(DTLSOverDatagram.java:118)
	at DTLSOverDatagram.runClient(DTLSOverDatagram.java:582)
	at DTLSOverDatagram.runTest(DTLSOverDatagram.java:552)
	at FragmentedFinished.main(FragmentedFinished.java:48)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:575)
	at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	at java.base/java.lang.Thread.run(Thread.java:854)
```

By testing the same test as above with a custom profile that extends the
Strongly-Enforced profile and has JKS allowable the error no longer
occurs.

The only profile that allows for PKCS12 algorithms yet not JKS is the
strongly enforced profile. Loading a JKS file results in the error.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>