### PR TITLE
Exclude CheckLeaseLeak from FIPS 140-3 strict

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -273,6 +273,7 @@ java/rmi/server/Unreferenced/marshalledObjectGet/MarshalledObjectGet.java https:
 java/rmi/server/Unreferenced/unreferencedContext/UnreferencedContext.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/server/useCustomRef/UseCustomRef.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/transport/checkFQDN/CheckFQDN.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/transport/closeServerSocket/CloseServerSocket.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/transport/dgcDeadLock/DGCDeadLock.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/transport/pinClientSocketFactory/PinClientSocketFactory.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all


### PR DESCRIPTION
The test `CheckLeaseLeak` fails with the following exception:

```
java.lang.SecurityException: SHA MessageDigest not available
	at java.rmi/sun.rmi.server.Util.computeMethodHash(Util.java:383)
	at java.rmi/sun.rmi.server.UnicastServerRef$HashToMethod_Maps.computeValue(UnicastServerRef.java:602)
	at java.rmi/sun.rmi.server.UnicastServerRef$HashToMethod_Maps.computeValue(UnicastServerRef.java:574)
	at java.rmi/sun.rmi.server.WeakClassHashMap.get(WeakClassHashMap.java:74)
	at java.rmi/sun.rmi.server.UnicastServerRef.exportObject(UnicastServerRef.java:236)
	at java.rmi/sun.rmi.registry.RegistryImpl.setup(RegistryImpl.java:223)
	at java.rmi/sun.rmi.registry.RegistryImpl.<init>(RegistryImpl.java:208)
	at java.rmi/java.rmi.registry.LocateRegistry.createRegistry(LocateRegistry.java:203)
	at TestLibrary.createRegistryOnEphemeralPort(TestLibrary.java:418)
	at CheckLeaseLeak.main(CheckLeaseLeak.java:93)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:575)
	at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	at java.base/java.lang.Thread.run(Thread.java:854)
TestFailedException: TEST FAILED: ; nested exception is:
	java.lang.SecurityException: SHA MessageDigest not available
java.lang.SecurityException: SHA MessageDigest not available
	at java.rmi/sun.rmi.server.Util.computeMethodHash(Util.java:383)
	at java.rmi/sun.rmi.server.UnicastServerRef$HashToMethod_Maps.computeValue(UnicastServerRef.java:602)
	at java.rmi/sun.rmi.server.UnicastServerRef$HashToMethod_Maps.computeValue(UnicastServerRef.java:574)
	at java.rmi/sun.rmi.server.WeakClassHashMap.get(WeakClassHashMap.java:74)
	at java.rmi/sun.rmi.server.UnicastServerRef.exportObject(UnicastServerRef.java:236)
	at java.rmi/sun.rmi.registry.RegistryImpl.setup(RegistryImpl.java:223)
	at java.rmi/sun.rmi.registry.RegistryImpl.<init>(RegistryImpl.java:208)
	at java.rmi/java.rmi.registry.LocateRegistry.createRegistry(LocateRegistry.java:203)
	at TestLibrary.createRegistryOnEphemeralPort(TestLibrary.java:418)
	at CheckLeaseLeak.main(CheckLeaseLeak.java:93)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:575)
	at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	at java.base/java.lang.Thread.run(Thread.java:854)
```

This restriction is known and accounted for in the `java.security` file for the strongly enforced profile as follows:
```
RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS [+ \
    {MessageDigest, MD5, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.rmi/sun.rmi.server.Util}]
```

However in this case the strict profile universally does NOT allow SHA-1 since this algorithm is not allowed under FIPS 140-3.