### PR TITLE
Filter brainpool signature schemes by default

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2024, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -706,6 +706,27 @@ enum SignatureScheme {
                 .filter(ss -> ss.isAvailable
                         && ss.isPermitted(
                         SSLAlgorithmConstraints.DEFAULT, null))
+                .filter(brainpoolFilter())
                 .map(ss -> ss.name).toArray(String[]::new);
+
+        private static java.util.function.Predicate<SignatureScheme> brainpoolFilter() {
+            // Check if ecdsa_brainpoolP512r1tls13_sha512 was explicitly
+            // configured via system properties. If any of the properties
+            // indicate the user wants to use ecdsa_brainpoolP512r1tls13_sha512,
+            // then allow for this.
+            if (propertyContainsBrainpool("jdk.tls.client.SignatureSchemes")
+            ||  propertyContainsBrainpool("jdk.tls.server.SignatureSchemes")
+            ) {
+                return ss -> true;
+            } else {
+                return ss -> ss != ECDSA_BRAINPOOLP512R1TLS13_SHA512;
+            }
+        }
+
+        private static boolean propertyContainsBrainpool(String propertyName) {
+            return System.getProperty(propertyName, "")
+                    .toLowerCase()
+                    .contains("ecdsa_brainpoolp512r1tls13_sha512");
+        }
     }
 }


### PR DESCRIPTION
Semeru supports the brainpool `ecdsa_brainpoolP512r1tls13_sha512`
signature scheme. The expectation is that users must explicitly enable
this feature in order to enable this signature scheme. This
must be done using either the `jdk.tls.client.SignatureSchemes` or
`jdk.tls.server.SignatureSchemes` properties. By default no brainpool
signature schemes are enabled.

Fixes: https://github.com/eclipse-openj9/openj9/issues/23177

Signed-off-by: Jason Katonica <katonica@us.ibm.com>