### PR TITLE
Stop ignoring tests when checking copyright notices

### DIFF
--- a/.copyrightignore
+++ b/.copyrightignore
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2026 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,14 +31,12 @@
 # 8. *job* # all things at contains characters in between stars
 # ===========================================================================
 
-/closed/test/
 /src/bsd/doc/
 /src/hotspot/share/jfr/metadata/metadata.xml
 /src/hotspot/share/jfr/metadata/metadata.xsd
 /src/jdk.crypto.ec/share/native/libsunec/impl/
 /src/linux/doc/
 /src/solaris/doc/
-/test/
 
 .copyrightignore
 /LICENSE

--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheck
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheck
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2026 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,7 +168,7 @@ timeout(time: 6, unit: 'HOURS') {
                             } else {
                                 String[] fileLines = theFile.split("\n")
                                 if ("${file}".startsWith("LICENSE")) {
-                                    maxLines=400
+                                    maxLines = 400
                                 }
                                 toLines = fileLines.size()
                                 if (toLines > maxLines) {
@@ -461,7 +461,7 @@ def get_files() {
     return sh (
         script: "git diff -C --diff-filter=ACM --name-only origin/${ghprbTargetBranch} HEAD",
         returnStdout: true
-        ).trim()
+    ).trim()
 }
 
 def get_file_content(inFile) {

--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.groovy
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2026 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,13 @@ timeout(time: 6, unit: 'HOURS') {
         timestamps {
             node ('worker') {
                 try {
-                    if ( params.ghprbGhRepository == "") {
+                    if (params.ghprbGhRepository == "") {
                         error("Repository to check not specified.  Rerun with the ghprbGhRepository parameter pointing to a valid git repository.")
                     }
-                    if ( params.verbose == true) {
+                    if (params.verbose == true) {
                         VERBOSE="VERBOSE=1"
                     }
-                    if ( params.rootDir != "") {
+                    if (params.rootDir != "") {
                         ROOTDIR="ROOTDIR=${params.rootDir}"
                     }
                     checkout changelog: false, poll: false,

--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2026 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -114,7 +114,6 @@ ignored=(
   "closed/jfr-metadata.blob"
   "src/hotspot/share/jfr/metadata/metadata.xml"
   "src/hotspot/share/jfr/metadata/metadata.xsd"
-  "test/*"
 )
 
 # Patterns of file names not built into a JDK.


### PR DESCRIPTION
Most modified test files have IBM copyright notices; this will help ensure they stay up-to-date.
It will also help identify files that should have such notices as files are changed in the future.