### PR TITLE
Update OpenJ9 shared classes references from path to searchPath

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 1997, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 1997, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -189,7 +189,7 @@ public class URLClassPath {
             sharedClassServiceProvider = helper;                                //OpenJ9-shared_classes_misc
         }                                                                       //OpenJ9-shared_classes_misc
         if (usingSharedClasses() && null == loaderURLs) {                       //OpenJ9-shared_classes_misc
-            loaderURLs = new ArrayList<>(path.size());                          //OpenJ9-shared_classes_misc
+            loaderURLs = new ArrayList<>(searchPath.size());                    //OpenJ9-shared_classes_misc
         }                                                                       //OpenJ9-shared_classes_misc
     }                                                                           //OpenJ9-shared_classes_misc
                                                                                 //OpenJ9-shared_classes_misc
@@ -549,7 +549,7 @@ public class URLClassPath {
                      * update loaderURLs in this case.                                   //OpenJ9-shared_classes_misc
                      */                                                                  //OpenJ9-shared_classes_misc
                     if (null == loaderURLs) {                                            //OpenJ9-shared_classes_misc
-                        loaderURLs = new ArrayList<>(path.size());                       //OpenJ9-shared_classes_misc
+                        loaderURLs = new ArrayList<>(searchPath.size());                 //OpenJ9-shared_classes_misc
                     }                                                                    //OpenJ9-shared_classes_misc
                     loaderURLs.add(url);                                                 //OpenJ9-shared_classes_misc
                 }                                                                        //OpenJ9-shared_classes_misc


### PR DESCRIPTION
Update OpenJ9 `shared classes` references from `path` to `searchPath`

Related to https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/24f991d2daa39c199918805e4553efed047e573d

This address the compilation failure at https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_linux_OpenJDK/961/consoleFull
```
01:12:05  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java:192: error: cannot find symbol
01:12:05              loaderURLs = new ArrayList<>(path.size());                          //OpenJ9-shared_classes_misc
01:12:05                                           ^
01:12:05    symbol:   variable path
01:12:05    location: class URLClassPath
01:12:05  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java:552: error: cannot find symbol
01:12:05                          loaderURLs = new ArrayList<>(path.size());                       //OpenJ9-shared_classes_misc
01:12:05                                                       ^
01:12:05    symbol:   variable path
01:12:05    location: class URLClassPath
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>