### PR TITLE
Add isFIPS1402Enabled() to determine whether FIPS 140-2 mode is enabled

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,18 +236,29 @@ public final class RestrictedSecurity {
     }
 
     /**
-     * Check if the FIPS mode is enabled.
+     * Check if a FIPS mode is enabled.
      *
-     * FIPS mode will be enabled when the semeru.fips system property is
-     * true, and the RestrictedSecurity mode has been successfully initialized.
+     * FIPS mode will be enabled when the semeru.fips system property
+     * is true, and a FIPS profile is successfully initialized in
+     * RestrictedSecurity mode.
      *
      * @return true if FIPS is enabled
      */
     public static boolean isFIPSEnabled() {
-        if (securityEnabled) {
-            return isFIPSEnabled;
-        }
-        return false;
+        return securityEnabled && isFIPSEnabled;
+    }
+
+    /**
+     * Check if the FIPS 140-2 mode is enabled.
+     *
+     * FIPS 140-2 mode will be enabled when the semeru.fips system property
+     * is true, and a FIPS 140-2 profile is successfully initialized in
+     * RestrictedSecurity mode.
+     *
+     * @return true if FIPS 140-2 is enabled
+     */
+    public static boolean isFIPS1402Enabled() {
+        return securityEnabled && isFIPSEnabled && "140-2".equals(restricts.jdkFipsMode);
     }
 
     /**

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -445,7 +445,7 @@ public final class SunPKCS11 extends AuthProvider {
 
             // When FIPS mode is enabled, configure p11 object to FIPS mode
             // and pass the parent object so it can callback.
-            if (RestrictedSecurity.isFIPSEnabled()) {
+            if (RestrictedSecurity.isFIPS1402Enabled()) {
                 if (debug != null) {
                     debug.println("FIPS mode in SunPKCS11");
                 }


### PR DESCRIPTION
This PR introduces isFIPS1402Enabled() to explicitly indicate whether the runtime is running in FIPS 140-2 mode.

Issue: https://github.com/eclipse-openj9/openj9/issues/23300

Previously, isFIPSEnabled() was the only available flag and returned true for both FIPS 140-2 and FIPS 140-3 profiles. This lack of distinction could lead to incorrect behavior in FIPS 140-2–specific code paths.

In particular, when running with a customized extended FIPS 140-3 profile that also uses the SunPKCS11 provider, the FIPS 140-2 specific logic in SunPKCS11 could be unintentionally activated, resulting in unexpected issues.

The new isFIPS1402Enabled() flag returns true only when:
 1. A FIPS 140-2 profile is in use, and
 2. RestrictedSecurity has been successfully initialized.

This change prevents accidental execution of FIPS 140-2 specific code paths when using a customized extended FIPS 140-3 profile.