### PR TITLE
Update make path for OpenJCEPlus native files

### DIFF
--- a/closed/custom/Main-pre.gmk
+++ b/closed/custom/Main-pre.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -139,7 +139,7 @@ openjceplus-copy : openjceplus-libs
 
 openjceplus-clean :
 	@$(ECHO) Cleaning OpenJCEPlus native code
-	$(MAKE) -C $(OPENJCEPLUS_TOPDIR)/src/main/native -f $(OPENJCEPLUS_JGSKIT_MAKE) cleanAll
+	$(MAKE) -C $(OPENJCEPLUS_TOPDIR)/src/main/native/ock -f $(OPENJCEPLUS_JGSKIT_MAKE) cleanAll
 
 clean-openjceplus : openjceplus-clean
 

--- a/closed/make/modules/openjceplus/Lib.gmk
+++ b/closed/make/modules/openjceplus/Lib.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -29,7 +29,7 @@ OPENJCEPLUS_GSKIT_HOME := $(OPENJCEPLUS_TOPDIR)/ock/jgsk_sdk
 OPENJCEPLUS_HEADER_FILES := $(SUPPORT_OUTPUTDIR)/headers/openjceplus
 OPENJCEPLUS_JCE_CLASSPATH := $(JDK_OUTPUTDIR)/modules/openjceplus:$(JDK_OUTPUTDIR)/modules/java.base
 OPENJCEPLUS_JGSKIT_MAKE := jgskit.mak
-OPENJCEPLUS_JGSKIT_MAKE_PATH := $(OPENJCEPLUS_TOPDIR)/src/main/native
+OPENJCEPLUS_JGSKIT_MAKE_PATH := $(OPENJCEPLUS_TOPDIR)/src/main/native/ock
 OPENJCEPLUS_JGSKIT_PLATFORM :=
 
 ifeq ($(call isTargetOs, aix), true)


### PR DESCRIPTION
The location of the native files in `OpenJCEPlus` has been updated and the appropriate make files in the JDK need to be updated to reflect that change.

Depends on: https://github.com/IBM/OpenJCEPlus/pull/1123

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>