### PR TITLE
Add OpenJCEPlus as an expected provider for ProviderFiltering test

### DIFF
--- a/test/jdk/java/security/Security/ProviderFiltering.java
+++ b/test/jdk/java/security/Security/ProviderFiltering.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @library /test/lib
  * @bug 6447816
@@ -84,10 +90,10 @@ public class ProviderFiltering {
                     InvalidParameterException.class);
         }
 
-        String p = "SUN";
+        String p = "SUN", p2 = "OpenJCEPlus";
 
         // test alias
-        doit("Signature.NONEwithDSA", p);
+        doit("Signature.NONEwithDSA", p, p2);
 
         String sigService = "Signature.SHA256withDSA";
         // javadoc allows extra spaces in between
@@ -117,7 +123,7 @@ public class ProviderFiltering {
         // try non-attribute filters
         filters.clear();
         filters.put(sigService, "");
-        doit(filters, p);
+        doit(filters, p, p2);
         filters.put("Cipher.RC2", "");
         doit(filters);
 
@@ -130,9 +136,9 @@ public class ProviderFiltering {
                 customValue);
         Security.insertProviderAt(testProv, 1);
         // should find both TestProv and SUN and in this order
-        doit(sigService, pName, "SUN");
+        doit(sigService, pName, "SUN", p2);
         filters.put(sigService, "");
-        doit(filters, pName, "SUN");
+        doit(filters, pName, "SUN", p2);
 
         String specAttr = sigService + "  " + customKey + ":" + customValue;
         // should find only TestProv


### PR DESCRIPTION
OpenJCEPlus is an expected security provider for certain services for which the test validates the number of available providers.

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)