### PR TITLE
Add OpenJCEPlus as an expected provider for CheckSecurityProvider test

### DIFF
--- a/test/jdk/java/lang/SecurityManager/CheckSecurityProvider.java
+++ b/test/jdk/java/lang/SecurityManager/CheckSecurityProvider.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 6997010 7191662
  * @summary Consolidate java.security files into one file with modifications
@@ -81,6 +87,7 @@ public class CheckSecurityProvider {
         }
         layer.findModule("jdk.crypto.cryptoki")
             .ifPresent(m -> expected.add("sun.security.pkcs11.SunPKCS11"));
+        expected.add("com.ibm.crypto.plus.provider.OpenJCEPlus");
 
         List<String> actual = Stream.of(Security.getProviders())
             .map(p -> p.getClass().getName())


### PR DESCRIPTION
Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)