### PR TITLE
Update SSLLogger.isOn() API usage

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -440,7 +440,7 @@ enum SignatureScheme {
                     schemesToCheck.add(scheme);
                 } else {
                     if (SSLLogger.isOn() &&
-                            SSLLogger.isOn("ssl,handshake,verbose")) {
+                            SSLLogger.isOn(SSLLogger.Opt.HANDSHAKE_VERBOSE)) {
                         SSLLogger.finest("Ignore " + ECDSA_BRAINPOOLP512R1TLS13_SHA512.name
                                 + " from supported signature schemes");
                     }


### PR DESCRIPTION
Update `SSLLogger.isOn()` API usage

This fixes the abuild compilation failure at https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_linux_OpenJDK/969/consoleFull
```
01:38:29  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java:443: error: incompatible types: String cannot be converted to Opt
01:38:29                              SSLLogger.isOn("ssl,handshake,verbose")) {
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>