### PR TITLE
Stabilize TestSharedCloseJvmti by avoiding latch park

### DIFF
--- a/test/jdk/java/foreign/sharedclosejvmti/TestSharedCloseJvmti.java
+++ b/test/jdk/java/foreign/sharedclosejvmti/TestSharedCloseJvmti.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8370344
  * @library /test/lib
@@ -71,9 +77,9 @@ public class TestSharedCloseJvmti {
         static final int ADDED_FRAMES = 10;
 
         static final CountDownLatch MAIN_LATCH = new CountDownLatch(1);
-        static final CountDownLatch TARGET_LATCH = new CountDownLatch(1);
 
         static volatile int SINK;
+        static volatile boolean CLOSED = false;
 
         public static void main(String[] args) throws Throwable {
             try (Arena arena = Arena.ofShared()) {
@@ -88,8 +94,8 @@ public class TestSharedCloseJvmti {
                 // wait until trigger thread is in JVMTI event callback
                 MAIN_LATCH.await();
             }
-            // Notify trigger thread that arena was closed
-            TARGET_LATCH.countDown();
+            // Publish that the arena has been closed (Trigger thread spins on CLOSED)
+            CLOSED = true;
         }
 
         static boolean reentrant = false;
@@ -121,11 +127,8 @@ public class TestSharedCloseJvmti {
             if (depth >= ADDED_FRAMES) {
                 // notify main thread to close the arena
                 MAIN_LATCH.countDown();
-                try {
-                    // wait here until main thread has closed arena
-                    TARGET_LATCH.await();
-                } catch (InterruptedException ex) {
-                    throw new RuntimeException("Unexpected interruption");
+                while (!CLOSED) {
+                    Thread.onSpinWait();
                 }
                 return;
             }


### PR DESCRIPTION
Update TestSharedCloseJvmti to remove CountDownLatch.await() from the
JVMTI re-entrant callback path and replace it with a spin wait on a
volatile flag.

The previous test parked the Trigger thread while executing re-entrantly
from a JVMTI MethodExit callback during a scoped access. On OpenJ9,
shared scope close relies on async polling (javaCheckAsyncMessages) for
close-scope acknowledgement. Parking the thread in this path can prevent
polling and cause intermittent hangs.

The test intent is to exercise additional stack frames during scoped
access, not thread parking inside JVMTI callbacks. Using a spin loop
keeps the thread runnable and preserves the stack-shape stress scenario
while avoiding the hang.

Scoped close/exception handling differs across JVMs. The RI uses a
per-thread handshake and deopt-based approach, while OpenJ9 uses a
flag-and-polling model. This change keeps the test portable across both.

Remove the unused TARGET_LATCH and add a volatile CLOSED flag for
cross-thread visibility.

Related: https://github.com/eclipse-openj9/openj9/issues/22934

JDK26 backport: https://github.com/ibmruntimes/openj9-openjdk-jdk26/pull/22