### PR TITLE
Update CheckPBEKeySize test to use the correct provider

### DIFF
--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/CheckPBEKeySize.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/CheckPBEKeySize.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 /**
  * @test
  * @bug 8151149
@@ -47,7 +53,7 @@ public class CheckPBEKeySize {
             skFac.generateSecret(new PBEKeySpec("test123".toCharArray()));
 
         // Initialize the PBE cipher
-        Cipher cipher = Cipher.getInstance(ALGO);
+        Cipher cipher = Cipher.getInstance(ALGO, "SunJCE");
         cipher.init(Cipher.ENCRYPT_MODE, skey);
 
         // Permit access to the Cipher.spi field (a CipherSpi object)


### PR DESCRIPTION
Ensure the Cipher instance is obtained from SunJCE provider, as the class PKCS12PBECipherCore$PBEWithSHA1AndDESede is specific to it.

Signed-off-by: Dev Agarwal dev.agarwal@ibm.com