### PR TITLE
Increase Java heap memory limit to accommodate AIX footprint spike

### DIFF
--- a/test/jdk/java/util/concurrent/Executors/UnreferencedExecutor.java
+++ b/test/jdk/java/util/concurrent/Executors/UnreferencedExecutor.java
@@ -22,11 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8308235
  * @summary Unreference ExecutorService objects returned by the Executors without shutdown
  *    and termination, this should not leak memory
- * @run main/othervm -Xmx32m UnreferencedExecutor
+ * @run main/othervm -Xmx64m UnreferencedExecutor
  */
 
 import java.time.Duration;


### PR DESCRIPTION
Increase Java heap memory limit to accommodate AIX footprint spike

Changed `-Xmx32m` to `-Xmx64m`.

Related to https://github.com/eclipse-openj9/openj9/issues/22665

Signed-off-by: Jason Feng <fengj@ca.ibm.com>