### PR TITLE
Preview: 8378823: AIX build fails after zlib updated by JDK-8378631

### DIFF
--- a/make/autoconf/lib-bundled.m4
+++ b/make/autoconf/lib-bundled.m4
@@ -273,7 +273,7 @@ AC_DEFUN_ONCE([LIB_SETUP_ZLIB],
   LIBZ_LIBS=""
   if test "x$USE_EXTERNAL_LIBZ" = "xfalse"; then
     LIBZ_CFLAGS="$LIBZ_CFLAGS -I$TOPDIR/src/java.base/share/native/libzip/zlib"
-    if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+    if test "x$OPENJDK_TARGET_OS" = xmacosx -o "x$OPENJDK_TARGET_OS" = xaix -o "x$OPENJDK_TARGET_OS" = xlinux; then
         LIBZ_CFLAGS="$LIBZ_CFLAGS -DHAVE_UNISTD_H=1 -DHAVE_STDARG_H=1"
     fi
   else


### PR DESCRIPTION
Build errors seen in https://openj9-jenkins.osuosl.org/job/Pipeline-OpenJDK-Acceptance/1185 should be fixed by upstream change:
* [8378823: AIX build fails after zlib updated by JDK-8378631](https://github.com/openjdk/jdk/commit/4e15a4adfc50e37e2be01e90a67fde4b12126abd)