### PR TITLE
Avoid unnecessary recompiles of DDR code

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -34,8 +34,8 @@
 no_default :
 	$(error DDR.gmk has no default target)
 
-# ignore warnings in Java code - see JavaCompilation.gmk
-JAVA_WARNINGS_ARE_ERRORS :=
+# Read by custom-spec.gmk to disable JAVA_WARNINGS_AS_ERRORS.
+MODULE = openj9.dtfj
 
 include $(SPEC)
 include $(TOPDIR)/make/common/MakeBase.gmk
@@ -180,8 +180,6 @@ generate : $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)
 # which creates $(DDR_GENSRC_DIR), must have been built previously.
 
 ifneq (,$(wildcard $(DDR_GENSRC_DIR)))
-
-JAVA_WARNINGS_AS_ERRORS := false
 
 # Compile DDR code again, to ensure compatibility with class files
 # as they would be dynamically generated from the blob.

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -237,7 +237,7 @@ $(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h : $(TOPDIR)/closed/openj9_v
 OPENJ9_VERSION_MAP := $(foreach var,$(sort $(OPENJ9_VERSION_VARS)),$(var)='$(value $(var))')
 
 # update if the map changes
-$(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h : $(call DependOnVariable,OPENJ9_VERSION_MAP)
+$(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h : $(call DependOnVariable, OPENJ9_VERSION_MAP)
 
 # Only update version files when the SHAs change.
 $(OPENJ9_VM_BUILD_DIR)/compiler/jit.version : $(call DependOnVariable, OPENJ9_SHA)


### PR DESCRIPTION
`JAVA_WARNINGS_AS_ERRORS` is disabled in `custom-spec.gmk.in` for certain modules, but that was not being applied consistently for `BUILD_DDR_TOOLS_BOOT` and `BUILD_DDR_TOOLS_NEW` targets, which were being built alternatively with and without `-Werror`, resulting in dependencies always being out-of-date.

`DDR.gmk` now sets `MODULE = openj9.dtfj` for consistent treatment.