### PR TITLE
Use sed instead of tr to sanitize the openj9 branch name

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -78,7 +78,7 @@ else
   endif
   # Map characters in the branch name other than [A-Za-z0-9.] to '-' so the resulting
   # version string is acceptable to Runtime.Version.parse().
-  OPENJ9_BRANCH := $(shell $(PRINTF) '%s' '$(OPENJ9_BRANCH)' | $(TR) -c 'A-Za-z0-9.' '-')
+  OPENJ9_BRANCH := $(shell $(PRINTF) '%s' '$(OPENJ9_BRANCH)' | $(SED) -e 's/[^A-Za-z0-9.]/-/g')
   OPENJ9_VERSION_STRING := $(OPENJ9_BRANCH)-$(OPENJ9_SHA)
 endif
 


### PR DESCRIPTION
Not all implementations of `tr` handle a short second string together with the `-c` option.