### PR TITLE
Check services in legacy security providers

### DIFF
--- a/closed/test/jdk/openj9/internal/security/TestLegacyProviders.java
+++ b/closed/test/jdk/openj9/internal/security/TestLegacyProviders.java
@@ -1,0 +1,248 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+/*
+ * @test
+ * @summary Test Restricted Security Mode with Legacy Providers
+ * @library /test/lib
+ * @run junit TestLegacyProviders
+ */
+import org.junit.jupiter.api.Test;
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jdk.test.lib.LegacyProvider;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestLegacyProviders {
+    private static Provider legacyProvider;
+
+    private static void useLegacyPaths() throws Exception {
+        // Check get operation.
+        String response = (String) legacyProvider.get("Signature.Test");
+        if (!"example.class.MyClass".equals(response)) {
+            throw new RuntimeException("Incorrect response for get()");
+        }
+
+        response = (String) legacyProvider.get("Signature.Test2");
+        if (!"example.class.MyClass2".equals(response)) {
+            throw new RuntimeException("Incorrect response for get()");
+        }
+
+        response = (String) legacyProvider.get("Signature.Test3");
+        if (response != null) {
+            throw new RuntimeException("Incorrect response for get()");
+        }
+
+        response = (String) legacyProvider.get("Signature.Test4");
+        if (!"example.class.MyClass4".equals(response)) {
+            throw new RuntimeException("Incorrect response for get()");
+        }
+
+        response = (String) legacyProvider.get("Signature.Test5");
+        if (!"example.class.MyClass5".equals(response)) {
+            throw new RuntimeException("Incorrect response for get()");
+        }
+
+        String[] acceptedValues = {"example.class.MyClass",
+                                   "example.class.MyClass2",
+                                   "example.class.MyClass4",
+                                   "example.class.MyClass5"};
+
+        // Check entrySet operation.
+        Set<Map.Entry<Object, Object>> es = legacyProvider.entrySet();
+        for (Map.Entry<Object, Object> entry : es) {
+            String stringValue = (String) entry.getValue();
+            boolean found = false;
+            for (String acceptedValue : acceptedValues) {
+                if (stringValue.equals(acceptedValue)
+                    || "1".equals(stringValue)                                      // Version from constructor
+                    || "jdk.test.lib.LegacyProvider".equals(stringValue)            // Classname from constructor
+                    || "LegacyProvider".equals(stringValue)                         // Provider name from constructor
+                    || "Test provider".equals(stringValue)                          // Info from constructor
+                ) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new RuntimeException("Incorrect values returned from entrySet()");
+            }
+        }
+
+        // Check values operation.
+        Collection<Object> values = legacyProvider.values();
+        for (Object value : values) {
+            String stringValue = (String) value;
+            boolean found = false;
+            for (String acceptedValue : acceptedValues) {
+                if (stringValue.equals(acceptedValue)
+                    || "1".equals(stringValue)                                      // Version from constructor
+                    || "jdk.test.lib.LegacyProvider".equals(stringValue)            // Classname from constructor
+                    || "LegacyProvider".equals(stringValue)                         // Provider name from constructor
+                    || "Test provider".equals(stringValue)                          // Info from constructor
+                ) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new RuntimeException("Incorrect values returned from values()");
+            }
+        }
+
+        // Check elements operation.
+        Enumeration<Object> elements = legacyProvider.elements();
+        while (elements.hasMoreElements()) {
+            String stringElement = (String) elements.nextElement();
+            boolean found = false;
+            for (String acceptedValue : acceptedValues) {
+                if (stringElement.equals(acceptedValue)
+                    || "1".equals(stringElement)                                    // Version from constructor
+                    || "jdk.test.lib.LegacyProvider".equals(stringElement)          // Classname from constructor
+                    || "LegacyProvider".equals(stringElement)                       // Provider name from constructor
+                    || "Test provider".equals(stringElement)                        // Info from constructor
+                ) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new RuntimeException("Incorrect values returned from elements()");
+            }
+        }
+
+        // Check getProperty operation.
+        response = (String) legacyProvider.getProperty("Signature.Test");
+        if (!"example.class.MyClass".equals(response)) {
+            throw new RuntimeException("Incorrect response for getProperty()");
+        }
+
+        response = (String) legacyProvider.getProperty("Signature.Test2");
+        if (!"example.class.MyClass2".equals(response)) {
+            throw new RuntimeException("Incorrect response for getProperty()");
+        }
+
+        response = (String) legacyProvider.getProperty("Signature.Test3");
+        if (response != null) {
+            throw new RuntimeException("Incorrect response for getProperty()");
+        }
+
+        response = (String) legacyProvider.getProperty("Signature.Test4");
+        if (!"example.class.MyClass4".equals(response)) {
+            throw new RuntimeException("Incorrect response for getProperty()");
+        }
+
+        response = (String) legacyProvider.getProperty("Signature.Test5");
+        if (!"example.class.MyClass5".equals(response)) {
+            throw new RuntimeException("Incorrect response for getProperty()");
+        }
+
+        // Check compute operation.
+        response = (String) legacyProvider.compute("Signature.Test", (a, b) -> (b + "New"));
+        if (!"example.class.MyClassNew".equals(response)) {
+            throw new RuntimeException("Incorrect response for compute()");
+        }
+
+        response = (String) legacyProvider.compute("Signature.Test3", (a, b) -> (b + "New"));
+        if (response != null) {
+            throw new RuntimeException("Incorrect response for compute()");
+        }
+
+        // Check computeIfAbsent operation.
+        legacyProvider.remove("Signature.Test");
+        response = (String) legacyProvider.computeIfAbsent("Signature.Test", a -> "example.class.MyClass");
+        if (!"example.class.MyClass".equals(response)) {
+            throw new RuntimeException("Incorrect response for computeIfAbsent()");
+        }
+
+        response = (String) legacyProvider.computeIfAbsent("Signature.Test3", a -> "example.class.MyClass3");
+        if (response != null) {
+            throw new RuntimeException("Incorrect response for computeIfAbsent()");
+        }
+
+        // Check computeIfPresent operation.
+        response = (String) legacyProvider.computeIfPresent("Signature.Test", (a, b) -> (b + "New"));
+        if (!"example.class.MyClassNew".equals(response)) {
+            throw new RuntimeException("Incorrect response for computeIfPresent()");
+        }
+
+        response = (String) legacyProvider.computeIfPresent("Signature.Test3", (a, b) -> (b + "New"));
+        if (response != null) {
+            throw new RuntimeException("Incorrect response for computeIfPresent()");
+        }
+
+        String[] acceptedKeys = {"Signature.Test",
+                                 "Signature.Test2",
+                                 "Signature.Test4",
+                                 "Signature.Test5"};
+
+        // Check keys operation.
+        Enumeration<Object> keys = legacyProvider.keys();
+        while (keys.hasMoreElements()) {
+            String stringKey = (String) keys.nextElement();
+            boolean found = false;
+            for (String acceptedKey : acceptedKeys) {
+                if (stringKey.equals(acceptedKey)
+                    || "Provider.id version".equals(stringKey)      // Version from constructor
+                    || "Provider.id className".equals(stringKey)    // Provider classname from constructor
+                    || "Provider.id info".equals(stringKey)         // Info from constructor
+                    || "Provider.id name".equals(stringKey)         // Provider name from constructor
+                ) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new RuntimeException("Incorrect values returned from keys()");
+            }
+        }
+    }
+
+    @Test
+    public void runWithConstraints() throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.customprofile=TestLegacyProviders.Version",
+                "-Djava.security.properties=" + System.getProperty("test.src") + "/legacy-java.security",
+                "TestLegacyProviders"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(0);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Security.getProviders();
+        Security.addProvider(new LegacyProvider());
+        legacyProvider = Security.getProvider("LegacyProvider");
+        useLegacyPaths();
+    }
+}

--- a/closed/test/jdk/openj9/internal/security/TestLegacyProviders.java
+++ b/closed/test/jdk/openj9/internal/security/TestLegacyProviders.java
@@ -73,71 +73,39 @@ public class TestLegacyProviders {
             throw new RuntimeException("Incorrect response for get()");
         }
 
-        String[] acceptedValues = {"example.class.MyClass",
-                                   "example.class.MyClass2",
-                                   "example.class.MyClass4",
-                                   "example.class.MyClass5"};
+        Set<String> acceptedValues = Set.of(
+                "example.class.MyClass",
+                "example.class.MyClass2",
+                "example.class.MyClass4",
+                "example.class.MyClass5",
+                "1",                                                         // version from constructor
+                "jdk.test.lib.LegacyProvider",                               // class name from constructor
+                "LegacyProvider",                                            // provider name from constructor
+                "Test provider");                                            // info from constructor
 
         // Check entrySet operation.
         Set<Map.Entry<Object, Object>> es = legacyProvider.entrySet();
         for (Map.Entry<Object, Object> entry : es) {
-            String stringValue = (String) entry.getValue();
-            boolean found = false;
-            for (String acceptedValue : acceptedValues) {
-                if (stringValue.equals(acceptedValue)
-                    || "1".equals(stringValue)                                      // Version from constructor
-                    || "jdk.test.lib.LegacyProvider".equals(stringValue)            // Classname from constructor
-                    || "LegacyProvider".equals(stringValue)                         // Provider name from constructor
-                    || "Test provider".equals(stringValue)                          // Info from constructor
-                ) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                throw new RuntimeException("Incorrect values returned from entrySet()");
+            Object value = entry.getValue();
+            if (!acceptedValues.contains(value)) {
+                throw new RuntimeException("Incorrect value returned from entrySet()");
             }
         }
 
         // Check values operation.
         Collection<Object> values = legacyProvider.values();
         for (Object value : values) {
-            String stringValue = (String) value;
-            boolean found = false;
-            for (String acceptedValue : acceptedValues) {
-                if (stringValue.equals(acceptedValue)
-                    || "1".equals(stringValue)                                      // Version from constructor
-                    || "jdk.test.lib.LegacyProvider".equals(stringValue)            // Classname from constructor
-                    || "LegacyProvider".equals(stringValue)                         // Provider name from constructor
-                    || "Test provider".equals(stringValue)                          // Info from constructor
-                ) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                throw new RuntimeException("Incorrect values returned from values()");
+            if (!acceptedValues.contains(value)) {
+                throw new RuntimeException("Incorrect value returned from values()");
             }
         }
 
         // Check elements operation.
         Enumeration<Object> elements = legacyProvider.elements();
         while (elements.hasMoreElements()) {
-            String stringElement = (String) elements.nextElement();
-            boolean found = false;
-            for (String acceptedValue : acceptedValues) {
-                if (stringElement.equals(acceptedValue)
-                    || "1".equals(stringElement)                                    // Version from constructor
-                    || "jdk.test.lib.LegacyProvider".equals(stringElement)          // Classname from constructor
-                    || "LegacyProvider".equals(stringElement)                       // Provider name from constructor
-                    || "Test provider".equals(stringElement)                        // Info from constructor
-                ) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                throw new RuntimeException("Incorrect values returned from elements()");
+            Object value = elements.nextElement();
+            if (!acceptedValues.contains(value)) {
+                throw new RuntimeException("Incorrect value returned from elements()");
             }
         }
 
@@ -201,29 +169,22 @@ public class TestLegacyProviders {
             throw new RuntimeException("Incorrect response for computeIfPresent()");
         }
 
-        String[] acceptedKeys = {"Signature.Test",
-                                 "Signature.Test2",
-                                 "Signature.Test4",
-                                 "Signature.Test5"};
+        Set<String> acceptedKeys = Set.of(
+                "Signature.Test",
+                "Signature.Test2",
+                "Signature.Test4",
+                "Signature.Test5",
+                "Provider.id version",                                       // version from constructor
+                "Provider.id className",                                     // provider classname from constructor
+                "Provider.id info",                                          // info from constructor
+                "Provider.id name");                                         // provider name from constructor
 
         // Check keys operation.
         Enumeration<Object> keys = legacyProvider.keys();
         while (keys.hasMoreElements()) {
-            String stringKey = (String) keys.nextElement();
-            boolean found = false;
-            for (String acceptedKey : acceptedKeys) {
-                if (stringKey.equals(acceptedKey)
-                    || "Provider.id version".equals(stringKey)      // Version from constructor
-                    || "Provider.id className".equals(stringKey)    // Provider classname from constructor
-                    || "Provider.id info".equals(stringKey)         // Info from constructor
-                    || "Provider.id name".equals(stringKey)         // Provider name from constructor
-                ) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                throw new RuntimeException("Incorrect values returned from keys()");
+            Object key = keys.nextElement();
+            if (!acceptedKeys.contains(key)) {
+                throw new RuntimeException("Incorrect value returned from keys()");
             }
         }
     }
@@ -240,7 +201,6 @@ public class TestLegacyProviders {
     }
 
     public static void main(String[] args) throws Exception {
-        Security.getProviders();
         Security.addProvider(new LegacyProvider());
         legacyProvider = Security.getProvider("LegacyProvider");
         useLegacyPaths();

--- a/closed/test/jdk/openj9/internal/security/TestLegacyProviders.java
+++ b/closed/test/jdk/openj9/internal/security/TestLegacyProviders.java
@@ -79,7 +79,7 @@ public class TestLegacyProviders {
                 "Signature.Test4",
                 "Signature.Test5",
                 "Provider.id version",          // version from constructor
-                "Provider.id className",        // provider classname from constructor
+                "Provider.id className",        // provider class name from constructor
                 "Provider.id name",             // provider name from constructor
                 "Provider.id info");            // info from constructor
 

--- a/closed/test/jdk/openj9/internal/security/TestLegacyProviders.java
+++ b/closed/test/jdk/openj9/internal/security/TestLegacyProviders.java
@@ -73,19 +73,34 @@ public class TestLegacyProviders {
             throw new RuntimeException("Incorrect response for get()");
         }
 
+        Set<String> acceptedKeys = Set.of(
+                "Signature.Test",
+                "Signature.Test2",
+                "Signature.Test4",
+                "Signature.Test5",
+                "Provider.id version",          // version from constructor
+                "Provider.id className",        // provider classname from constructor
+                "Provider.id name",             // provider name from constructor
+                "Provider.id info");            // info from constructor
+
         Set<String> acceptedValues = Set.of(
                 "example.class.MyClass",
                 "example.class.MyClass2",
                 "example.class.MyClass4",
                 "example.class.MyClass5",
-                "1",                                                         // version from constructor
-                "jdk.test.lib.LegacyProvider",                               // class name from constructor
-                "LegacyProvider",                                            // provider name from constructor
-                "Test provider");                                            // info from constructor
+                "1",                            // version from constructor
+                "jdk.test.lib.LegacyProvider",  // provider class name from constructor
+                "LegacyProvider",               // provider name from constructor
+                "Test provider");               // info from constructor
 
         // Check entrySet operation.
         Set<Map.Entry<Object, Object>> es = legacyProvider.entrySet();
         for (Map.Entry<Object, Object> entry : es) {
+            Object key = entry.getKey();
+            if (!acceptedKeys.contains(key)) {
+                throw new RuntimeException("Incorrect key returned from entrySet()");
+            }
+
             Object value = entry.getValue();
             if (!acceptedValues.contains(value)) {
                 throw new RuntimeException("Incorrect value returned from entrySet()");
@@ -168,16 +183,6 @@ public class TestLegacyProviders {
         if (response != null) {
             throw new RuntimeException("Incorrect response for computeIfPresent()");
         }
-
-        Set<String> acceptedKeys = Set.of(
-                "Signature.Test",
-                "Signature.Test2",
-                "Signature.Test4",
-                "Signature.Test5",
-                "Provider.id version",                                       // version from constructor
-                "Provider.id className",                                     // provider classname from constructor
-                "Provider.id info",                                          // info from constructor
-                "Provider.id name");                                         // provider name from constructor
 
         // Check keys operation.
         Enumeration<Object> keys = legacyProvider.keys();

--- a/closed/test/jdk/openj9/internal/security/legacy-java.security
+++ b/closed/test/jdk/openj9/internal/security/legacy-java.security
@@ -1,0 +1,30 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+RestrictedSecurity.TestLegacyProviders.Version.desc.name = Test legacy profile
+RestrictedSecurity.TestLegacyProviders.Version.desc.hash = SHA256:de71a92df01ffe359cbac3920b98cba9d8ac6017dcba4184ef7ef0b069a07ff8
+RestrictedSecurity.TestLegacyProviders.Version.jce.provider.1 = jdk.test.lib.LegacyProvider [ \
+    {Signature, Test, *}, \
+    {Signature, Test2, *, FullClassName:TestLegacyProviders}, \
+    {Signature, Test4, *, FullClassName:TestLegacyProviders}, \
+    {Signature, Test5, *, FullClassName:TestLegacyProviders}]
+RestrictedSecurity.TestLegacyProviders.Version.jce.provider.2 = sun.security.provider.Sun [{MessageDigest, SHA-256, *}]
+RestrictedSecurity.TestLegacyProviders.Version.securerandom.provider = SUN
+RestrictedSecurity.TestLegacyProviders.Version.securerandom.algorithm = SHA512DRBG

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1109,7 +1109,7 @@ public abstract class Provider extends Properties {
     }
 
     /*
-     * Creates a Service instance based on the provided key.
+     * Creates a service instance based on the provided key.
      */
     private Service createServiceFromKey(Object key) {
         if (key instanceof String sk) {
@@ -1126,10 +1126,9 @@ public abstract class Provider extends Properties {
 
     /*
      * Checks if the provided key is one of the following:
-     *  - One that cannot be used to create a service
-     *  - Pertaining to information about the provider
-     *  - Corresponding to a service that is allowed
-     *    by the active RestrictedSecurity profile
+     *  - one that cannot be used to create a service
+     *  - pertains to information about the provider
+     *  - corresponds to a service that is allowed
      *
      * In any of this cases, the method returns true,
      * indicating that the key and associated value can

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -162,11 +162,11 @@ public abstract class Provider extends Properties {
 
     private static final Object[] EMPTY = new Object[0];
 
-    private static final List<String> providerInfoKeys = new ArrayList<>(Arrays.asList(
-                                                                    "Provider.id name",
-                                                                    "Provider.id version",
-                                                                    "Provider.id info",
-                                                                    "Provider.id className"));
+    private static final Set<String> providerInfoKeys = Set.of(
+            "Provider.id name",
+            "Provider.id version",
+            "Provider.id info",
+            "Provider.id className");
 
     private static double parseVersionStr(String s) {
         try {
@@ -485,11 +485,12 @@ public abstract class Provider extends Properties {
         if (RestrictedSecurity.isEnabled()) {
             Set<Map.Entry<Object, Object>> entrySet = entrySet();
             for (Map.Entry<Object, Object> entry : entrySet) {
-                if (isProviderInfoKey(entry.getKey())) {
+                Object key = entry.getKey();
+                if (isProviderInfoKey(key)) {
                     // This is a value pertaining to provider info.
                     continue;
                 }
-                Service service = createServiceFromKey(entry.getKey());
+                Service service = createServiceFromKey(key);
                 if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
                     // We're in restricted security mode which does not allow this service,
                     // remove it from returned collection.
@@ -750,8 +751,9 @@ public abstract class Provider extends Properties {
             List<Object> list = new ArrayList<>();
             Set<Map.Entry<Object, Object>> entrySet = entrySet();
             for (Map.Entry<Object, Object> entry : entrySet) {
-                Service service = createServiceFromKey(entry.getKey());
-                if ((service == null) || isProviderInfoKey(entry.getKey())
+                Object key = entry.getKey();
+                Service service = createServiceFromKey(key);
+                if ((service == null) || isProviderInfoKey(key)
                         || RestrictedSecurity.isServiceAllowed(service)) {
                     // We're in restricted security mode which allows this service
                     // or provider info, so add it to list to be returned.

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -161,6 +161,12 @@ public abstract class Provider extends Properties {
     private transient boolean initialized;
 
     private static final Object[] EMPTY = new Object[0];
+
+    private static final List<String> providerInfoKeys = new ArrayList<>(Arrays.asList(
+                                                                    "Provider.id name",
+                                                                    "Provider.id version",
+                                                                    "Provider.id info",
+                                                                    "Provider.id className"));
 
     private static double parseVersionStr(String s) {
         try {
@@ -428,6 +434,28 @@ public abstract class Provider extends Properties {
         if (entrySetCallCount != 2)
             throw new RuntimeException("Internal error.");
 
+        if (RestrictedSecurity.isEnabled()) {
+            Set<Map.Entry<Object, Object>> toRemove = new HashSet<>();
+            for (Map.Entry<Object, Object> entry : entrySet) {
+                Object key = entry.getKey();
+                if (isProviderInfoKey(key)) {
+                    // This is a value pertaining to provider info.
+                    continue;
+                }
+                Service service = createServiceFromKey(key);
+                if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+                    // We're in restricted security mode which does not allow this service,
+                    // mark it to be removed from returned set.
+                    toRemove.add(entry);
+                }
+            }
+            if (!toRemove.isEmpty()) {
+                Set<Map.Entry<Object, Object>> modifiableSet = new HashSet<>(entrySet);
+                modifiableSet.removeAll(toRemove);
+                entrySet = Collections.unmodifiableSet(modifiableSet);
+            }
+        }
+
         return entrySet;
     }
 
@@ -452,7 +480,25 @@ public abstract class Provider extends Properties {
     @Override
     public Collection<Object> values() {
         checkInitialized();
-        return Collections.unmodifiableCollection(super.values());
+        Collection<Object> values = super.values();
+
+        if (RestrictedSecurity.isEnabled()) {
+            Set<Map.Entry<Object, Object>> entrySet = entrySet();
+            for (Map.Entry<Object, Object> entry : entrySet) {
+                if (isProviderInfoKey(entry.getKey())) {
+                    // This is a value pertaining to provider info.
+                    continue;
+                }
+                Service service = createServiceFromKey(entry.getKey());
+                if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+                    // We're in restricted security mode which does not allow this service,
+                    // remove it from returned collection.
+                    values.remove(entry.getValue());
+                }
+            }
+        }
+
+        return Collections.unmodifiableCollection(values);
     }
 
     /**
@@ -645,6 +691,16 @@ public abstract class Provider extends Properties {
     @Override
     public Object get(Object key) {
         checkInitialized();
+
+        if (RestrictedSecurity.isEnabled() && !isProviderInfoKey(key)) {
+            // This is not a value pertaining to provider info.
+            Service service = createServiceFromKey(key);
+            if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+                // We're in restricted security mode which does not allow this service,
+                // return null.
+                return null;
+            }
+        }
         return super.get(key);
     }
     /**
@@ -653,6 +709,17 @@ public abstract class Provider extends Properties {
     @Override
     public synchronized Object getOrDefault(Object key, Object defaultValue) {
         checkInitialized();
+
+        if (RestrictedSecurity.isEnabled() && !isProviderInfoKey(key)) {
+            // This is not a value pertaining to provider info.
+            Service service = createServiceFromKey(key);
+            if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+                // We're in restricted security mode which does not allow this service,
+                // return null.
+                return null;
+            }
+        }
+
         return super.getOrDefault(key, defaultValue);
     }
 
@@ -677,12 +744,42 @@ public abstract class Provider extends Properties {
     @Override
     public Enumeration<Object> elements() {
         checkInitialized();
-        return super.elements();
+        Enumeration<Object> elements;
+
+        if (RestrictedSecurity.isEnabled()) {
+            List<Object> list = new ArrayList<>();
+            Set<Map.Entry<Object, Object>> entrySet = entrySet();
+            for (Map.Entry<Object, Object> entry : entrySet) {
+                Service service = createServiceFromKey(entry.getKey());
+                if ((service == null) || isProviderInfoKey(entry.getKey())
+                        || RestrictedSecurity.isServiceAllowed(service)) {
+                    // We're in restricted security mode which allows this service
+                    // or provider info, so add it to list to be returned.
+                    list.add(entry.getValue());
+                }
+            }
+            elements = Collections.enumeration(list);
+        } else {
+            elements = super.elements();
+        }
+
+        return elements;
     }
 
     // let javadoc show doc from superclass
     public String getProperty(String key) {
         checkInitialized();
+
+        if (RestrictedSecurity.isEnabled() && !isProviderInfoKey(key)) {
+            // This is not a value pertaining to provider info.
+            Service service = createServiceFromKey(key);
+            if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+                // We're in restricted security mode which does not allow this service,
+                // return null.
+                return null;
+            }
+        }
+
         return super.getProperty(key);
     }
 
@@ -808,6 +905,13 @@ public abstract class Provider extends Properties {
     private boolean implReplace(Object key, Object oldValue, Object newValue) {
         if (!checkLegacy(key)) return false;
 
+        Service service = createServiceFromKey(key);
+        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+            // We're in restricted security mode which does not allow this service,
+            // return without replacing anything.
+            return false;
+        }
+
         boolean result = super.replace(key, oldValue, newValue);
         if (result && key instanceof String sk) {
             if (newValue instanceof String sv) {
@@ -821,6 +925,13 @@ public abstract class Provider extends Properties {
 
     private Object implReplace(Object key, Object value) {
         if (!checkLegacy(key)) return null;
+
+        Service service = createServiceFromKey(key);
+        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+            // We're in restricted security mode which does not allow this service,
+            // return without replacing anything.
+            return null;
+        }
 
         Object o = super.replace(key, value);
         if (key instanceof String sk) {
@@ -850,6 +961,14 @@ public abstract class Provider extends Properties {
                 if (!checkLegacy(sk)) {
                     continue;
                 }
+
+                Service service = createServiceFromKey(key);
+                if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+                    // We're in restricted security mode which does not allow this service,
+                    // return without replacing anything.
+                    continue;
+                }
+
                 parseLegacy(sk, sv, OPType.ADD);
             }
         }
@@ -860,6 +979,13 @@ public abstract class Provider extends Properties {
             BiFunction<? super Object, ? super Object, ? extends Object>
             remappingFunction) {
         if (!checkLegacy(key)) return null;
+
+        Service service = createServiceFromKey(key);
+        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+            // We're in restricted security mode which does not allow this service,
+            // return without merging anything.
+            return null;
+        }
 
         Object o = super.merge(key, value, remappingFunction);
         if (key instanceof String sk) {
@@ -878,6 +1004,13 @@ public abstract class Provider extends Properties {
 
         if (!checkLegacy(key)) return null;
 
+        Service service = createServiceFromKey(key);
+        if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+            // We're in restricted security mode which does not allow this service,
+            // return without computing anything.
+            return null;
+        }
+
         Object o = super.compute(key, remappingFunction);
         if (key instanceof String sk) {
             if (o == null) {
@@ -894,6 +1027,13 @@ public abstract class Provider extends Properties {
             ? extends Object> mappingFunction) {
         if (!checkLegacy(key)) return null;
 
+        Service service = createServiceFromKey(key);
+        if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+            // We're in restricted security mode which does not allow this service,
+            // return without computing anything.
+            return null;
+        }
+
         Object o = super.computeIfAbsent(key, mappingFunction);
         if (o instanceof String so && key instanceof String sk) {
             parseLegacy(sk, so, OPType.ADD);
@@ -906,6 +1046,13 @@ public abstract class Provider extends Properties {
             ? super Object, ? extends Object> remappingFunction) {
         if (!checkLegacy(key)) return null;
 
+        Service service = createServiceFromKey(key);
+        if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+            // We're in restricted security mode which does not allow this service,
+            // return without computing anything.
+            return null;
+        }
+
         Object o = super.computeIfPresent(key, remappingFunction);
         if (o instanceof String so && key instanceof String sk) {
             parseLegacy(sk, so, OPType.ADD);
@@ -916,6 +1063,13 @@ public abstract class Provider extends Properties {
     private Object implPut(Object key, Object value) {
         if (!checkLegacy(key)) return null;
 
+        Service service = createServiceFromKey(key);
+        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+            // We're in restricted security mode which does not allow this service,
+            // return without putting.
+            return null;
+        }
+
         Object o = super.put(key, value);
         if (key instanceof String sk && value instanceof String sv) {
             parseLegacy(sk, sv, OPType.ADD);
@@ -925,6 +1079,13 @@ public abstract class Provider extends Properties {
 
     private Object implPutIfAbsent(Object key, Object value) {
         if (!checkLegacy(key)) return null;
+
+        Service service = createServiceFromKey(key);
+        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+            // We're in restricted security mode which does not allow this service,
+            // return without putting.
+            return null;
+        }
 
         Object o = super.putIfAbsent(key, value);
         if (o == null && key instanceof String sk &&
@@ -943,6 +1104,26 @@ public abstract class Provider extends Properties {
         prngAlgos.clear();
         super.clear();
         putId();
+    }
+
+    private static boolean isProviderInfoKey(Object key) {
+        if (key instanceof String sk) {
+            return providerInfoKeys.contains(sk);
+        }
+        return false;
+    }
+
+    private Service createServiceFromKey(Object key) {
+        if (key instanceof String sk) {
+            String[] typeAndAlg = getTypeAndAlgorithm(sk);
+            if (typeAndAlg != null) {
+                String type = typeAndAlg[0];
+                String algorithm = typeAndAlg[1];
+                return new Service(this, type, algorithm);
+            }
+        }
+
+        return null;
     }
 
     // used as key in the serviceMap and legacyMap HashMaps

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -437,22 +437,16 @@ public abstract class Provider extends Properties {
         if (RestrictedSecurity.isEnabled()) {
             Set<Map.Entry<Object, Object>> toRemove = new HashSet<>();
             for (Map.Entry<Object, Object> entry : entrySet) {
-                Object key = entry.getKey();
-                if (isProviderInfoKey(key)) {
-                    // This is a value pertaining to provider info.
-                    continue;
-                }
-                Service service = createServiceFromKey(key);
-                if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
-                    // We're in restricted security mode which does not allow this service,
-                    // mark it to be removed from returned set.
+                if (!checkRestrictedSecurityKey(entry.getKey())) {
+                    // We're in restricted security mode which  disallows this service,
+                    // so add it to list of values to be removed from the entrySet.
                     toRemove.add(entry);
                 }
             }
             if (!toRemove.isEmpty()) {
                 Set<Map.Entry<Object, Object>> modifiableSet = new HashSet<>(entrySet);
                 modifiableSet.removeAll(toRemove);
-                entrySet = Collections.unmodifiableSet(modifiableSet);
+                return Collections.unmodifiableSet(modifiableSet);
             }
         }
 

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -480,26 +480,21 @@ public abstract class Provider extends Properties {
     @Override
     public Collection<Object> values() {
         checkInitialized();
-        Collection<Object> values = super.values();
 
         if (RestrictedSecurity.isEnabled()) {
             Set<Map.Entry<Object, Object>> entrySet = entrySet();
+            Collection<Object> valuesToReturn = new ArrayList<>(entrySet.size());
             for (Map.Entry<Object, Object> entry : entrySet) {
-                Object key = entry.getKey();
-                if (isProviderInfoKey(key)) {
-                    // This is a value pertaining to provider info.
-                    continue;
-                }
-                Service service = createServiceFromKey(key);
-                if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
-                    // We're in restricted security mode which does not allow this service,
-                    // remove it from returned collection.
-                    values.remove(entry.getValue());
+                if (checkRestrictedSecurityKey(entry.getKey())) {
+                    // We're in restricted security mode which allows this service
+                    // or provider info, so add it to list of values to be returned.
+                    valuesToReturn.add(entry.getValue());
                 }
             }
+            return Collections.unmodifiableCollection(valuesToReturn);
         }
 
-        return Collections.unmodifiableCollection(values);
+        return Collections.unmodifiableCollection(super.values());
     }
 
     /**
@@ -745,28 +740,21 @@ public abstract class Provider extends Properties {
     @Override
     public Enumeration<Object> elements() {
         checkInitialized();
-        Enumeration<Object> elements;
 
         if (RestrictedSecurity.isEnabled()) {
-            List<Object> list = new ArrayList<>();
             Set<Map.Entry<Object, Object>> entrySet = entrySet();
+            List<Object> list = new ArrayList<>(entrySet.size());
             for (Map.Entry<Object, Object> entry : entrySet) {
-                Object key = entry.getKey();
-                Service service = createServiceFromKey(key);
-                if ((service == null) || isProviderInfoKey(key)
-                    || RestrictedSecurity.isServiceAllowed(service)
-                ) {
+                if (checkRestrictedSecurityKey(entry.getKey())) {
                     // We're in restricted security mode which allows this service
                     // or provider info, so add it to list to be returned.
                     list.add(entry.getValue());
                 }
             }
-            elements = Collections.enumeration(list);
-        } else {
-            elements = super.elements();
+            return Collections.enumeration(list);
         }
 
-        return elements;
+        return super.elements();
     }
 
     // let javadoc show doc from superclass
@@ -1109,6 +1097,10 @@ public abstract class Provider extends Properties {
         putId();
     }
 
+    /*
+     * Checks whether the key pertains to an entry about
+     * provider information.
+     */
     private static boolean isProviderInfoKey(Object key) {
         if (key instanceof String sk) {
             return providerInfoKeys.contains(sk);
@@ -1116,6 +1108,9 @@ public abstract class Provider extends Properties {
         return false;
     }
 
+    /*
+     * Creates a Service instance based on the provided key.
+     */
     private Service createServiceFromKey(Object key) {
         if (key instanceof String sk) {
             String[] typeAndAlg = getTypeAndAlgorithm(sk);
@@ -1127,6 +1122,24 @@ public abstract class Provider extends Properties {
         }
 
         return null;
+    }
+
+    /*
+     * Checks if the provided key is one of the following:
+     *  - One that cannot be used to create a service
+     *  - Pertaining to information about the provider
+     *  - Corresponding to a service that is allowed
+     *    by the active RestrictedSecurity profile
+     *
+     * In any of this cases, the method returns true,
+     * indicating that the key and associated value can
+     * be returned.
+     */
+    private boolean checkRestrictedSecurityKey(Object key) {
+        Service service = createServiceFromKey(key);
+        return (service == null)
+                || isProviderInfoKey(key)
+                || RestrictedSecurity.isServiceAllowed(service);
     }
 
     // used as key in the serviceMap and legacyMap HashMaps

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -754,7 +754,8 @@ public abstract class Provider extends Properties {
                 Object key = entry.getKey();
                 Service service = createServiceFromKey(key);
                 if ((service == null) || isProviderInfoKey(key)
-                        || RestrictedSecurity.isServiceAllowed(service)) {
+                    || RestrictedSecurity.isServiceAllowed(service)
+                ) {
                     // We're in restricted security mode which allows this service
                     // or provider info, so add it to list to be returned.
                     list.add(entry.getValue());

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -44,6 +44,7 @@ import java.lang.reflect.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.concurrent.ConcurrentHashMap;
 
 import openj9.internal.security.RestrictedSecurity;
@@ -419,6 +420,13 @@ public abstract class Provider extends Properties {
     @Override
     public synchronized Set<Map.Entry<Object,Object>> entrySet() {
         checkInitialized();
+
+        if (RestrictedSecurity.isEnabled()) {
+            return super.entrySet().stream()
+                        .filter(entry -> checkRestrictedSecurityKey(entry.getKey()))
+                        .collect(Collectors.toUnmodifiableSet());
+        }
+
         if (entrySet == null) {
             if (entrySetCallCount++ == 0)  // Initial call
                 entrySet = Collections.unmodifiableMap(this).entrySet();
@@ -433,22 +441,6 @@ public abstract class Provider extends Properties {
         // which is unlikely to change.
         if (entrySetCallCount != 2)
             throw new RuntimeException("Internal error.");
-
-        if (RestrictedSecurity.isEnabled()) {
-            Set<Map.Entry<Object, Object>> toRemove = new HashSet<>();
-            for (Map.Entry<Object, Object> entry : entrySet) {
-                if (!checkRestrictedSecurityKey(entry.getKey())) {
-                    // We're in restricted security mode which  disallows this service,
-                    // so add it to list of values to be removed from the entrySet.
-                    toRemove.add(entry);
-                }
-            }
-            if (!toRemove.isEmpty()) {
-                Set<Map.Entry<Object, Object>> modifiableSet = new HashSet<>(entrySet);
-                modifiableSet.removeAll(toRemove);
-                return Collections.unmodifiableSet(modifiableSet);
-            }
-        }
 
         return entrySet;
     }
@@ -476,16 +468,7 @@ public abstract class Provider extends Properties {
         checkInitialized();
 
         if (RestrictedSecurity.isEnabled()) {
-            Set<Map.Entry<Object, Object>> entrySet = entrySet();
-            Collection<Object> valuesToReturn = new ArrayList<>(entrySet.size());
-            for (Map.Entry<Object, Object> entry : entrySet) {
-                if (checkRestrictedSecurityKey(entry.getKey())) {
-                    // We're in restricted security mode which allows this service
-                    // or provider info, so add it to list of values to be returned.
-                    valuesToReturn.add(entry.getValue());
-                }
-            }
-            return Collections.unmodifiableCollection(valuesToReturn);
+            return entrySet().stream().map(entry -> entry.getValue()).collect(Collectors.toUnmodifiableList());
         }
 
         return Collections.unmodifiableCollection(super.values());
@@ -682,14 +665,9 @@ public abstract class Provider extends Properties {
     public Object get(Object key) {
         checkInitialized();
 
-        if (RestrictedSecurity.isEnabled() && !isProviderInfoKey(key)) {
-            // This is not a value pertaining to provider info.
-            Service service = createServiceFromKey(key);
-            if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
-                // We're in restricted security mode which does not allow this service,
-                // return null.
-                return null;
-            }
+        if (RestrictedSecurity.isEnabled() && !checkRestrictedSecurityKey(key)) {
+            // We're in restricted security mode which does not allow this service.
+            return null;
         }
         return super.get(key);
     }
@@ -700,14 +678,9 @@ public abstract class Provider extends Properties {
     public synchronized Object getOrDefault(Object key, Object defaultValue) {
         checkInitialized();
 
-        if (RestrictedSecurity.isEnabled() && !isProviderInfoKey(key)) {
-            // This is not a value pertaining to provider info.
-            Service service = createServiceFromKey(key);
-            if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
-                // We're in restricted security mode which does not allow this service,
-                // return null.
-                return null;
-            }
+        if (RestrictedSecurity.isEnabled() && !checkRestrictedSecurityKey(key)) {
+            // We're in restricted security mode which does not allow this service.
+            return defaultValue;
         }
 
         return super.getOrDefault(key, defaultValue);
@@ -736,16 +709,7 @@ public abstract class Provider extends Properties {
         checkInitialized();
 
         if (RestrictedSecurity.isEnabled()) {
-            Set<Map.Entry<Object, Object>> entrySet = entrySet();
-            List<Object> list = new ArrayList<>(entrySet.size());
-            for (Map.Entry<Object, Object> entry : entrySet) {
-                if (checkRestrictedSecurityKey(entry.getKey())) {
-                    // We're in restricted security mode which allows this service
-                    // or provider info, so add it to list to be returned.
-                    list.add(entry.getValue());
-                }
-            }
-            return Collections.enumeration(list);
+            return Collections.enumeration(values());
         }
 
         return super.elements();
@@ -755,14 +719,9 @@ public abstract class Provider extends Properties {
     public String getProperty(String key) {
         checkInitialized();
 
-        if (RestrictedSecurity.isEnabled() && !isProviderInfoKey(key)) {
-            // This is not a value pertaining to provider info.
-            Service service = createServiceFromKey(key);
-            if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
-                // We're in restricted security mode which does not allow this service,
-                // return null.
-                return null;
-            }
+        if (RestrictedSecurity.isEnabled() && !checkRestrictedSecurityKey(key)) {
+            // We're in restricted security mode which does not allow this service.
+            return null;
         }
 
         return super.getProperty(key);
@@ -890,8 +849,7 @@ public abstract class Provider extends Properties {
     private boolean implReplace(Object key, Object oldValue, Object newValue) {
         if (!checkLegacy(key)) return false;
 
-        Service service = createServiceFromKey(key);
-        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+        if (!canRestrictedSecurityServiceBeRegistered(key)) {
             // We're in restricted security mode which does not allow this service,
             // return without replacing anything.
             return false;
@@ -911,8 +869,7 @@ public abstract class Provider extends Properties {
     private Object implReplace(Object key, Object value) {
         if (!checkLegacy(key)) return null;
 
-        Service service = createServiceFromKey(key);
-        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+        if (!canRestrictedSecurityServiceBeRegistered(key)) {
             // We're in restricted security mode which does not allow this service,
             // return without replacing anything.
             return null;
@@ -947,10 +904,9 @@ public abstract class Provider extends Properties {
                     continue;
                 }
 
-                Service service = createServiceFromKey(key);
-                if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+                if (!canRestrictedSecurityServiceBeRegistered(key)) {
                     // We're in restricted security mode which does not allow this service,
-                    // return without replacing anything.
+                    // continue to the next entry without replacing anything.
                     continue;
                 }
 
@@ -965,8 +921,7 @@ public abstract class Provider extends Properties {
             remappingFunction) {
         if (!checkLegacy(key)) return null;
 
-        Service service = createServiceFromKey(key);
-        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+        if (!canRestrictedSecurityServiceBeRegistered(key)) {
             // We're in restricted security mode which does not allow this service,
             // return without merging anything.
             return null;
@@ -989,8 +944,7 @@ public abstract class Provider extends Properties {
 
         if (!checkLegacy(key)) return null;
 
-        Service service = createServiceFromKey(key);
-        if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+        if (!isRestrictedSecurityServiceAllowed(key)) {
             // We're in restricted security mode which does not allow this service,
             // return without computing anything.
             return null;
@@ -1012,8 +966,7 @@ public abstract class Provider extends Properties {
             ? extends Object> mappingFunction) {
         if (!checkLegacy(key)) return null;
 
-        Service service = createServiceFromKey(key);
-        if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+        if (!isRestrictedSecurityServiceAllowed(key)) {
             // We're in restricted security mode which does not allow this service,
             // return without computing anything.
             return null;
@@ -1031,8 +984,7 @@ public abstract class Provider extends Properties {
             ? super Object, ? extends Object> remappingFunction) {
         if (!checkLegacy(key)) return null;
 
-        Service service = createServiceFromKey(key);
-        if ((service != null) && !RestrictedSecurity.isServiceAllowed(service)) {
+        if (!isRestrictedSecurityServiceAllowed(key)) {
             // We're in restricted security mode which does not allow this service,
             // return without computing anything.
             return null;
@@ -1048,8 +1000,7 @@ public abstract class Provider extends Properties {
     private Object implPut(Object key, Object value) {
         if (!checkLegacy(key)) return null;
 
-        Service service = createServiceFromKey(key);
-        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+        if (!canRestrictedSecurityServiceBeRegistered(key)) {
             // We're in restricted security mode which does not allow this service,
             // return without putting.
             return null;
@@ -1065,8 +1016,7 @@ public abstract class Provider extends Properties {
     private Object implPutIfAbsent(Object key, Object value) {
         if (!checkLegacy(key)) return null;
 
-        Service service = createServiceFromKey(key);
-        if ((service != null) && !RestrictedSecurity.canServiceBeRegistered(service)) {
+        if (!canRestrictedSecurityServiceBeRegistered(key)) {
             // We're in restricted security mode which does not allow this service,
             // return without putting.
             return null;
@@ -1118,11 +1068,22 @@ public abstract class Provider extends Properties {
         return null;
     }
 
+    private boolean canRestrictedSecurityServiceBeRegistered(Object key) {
+        Service service = createServiceFromKey(key);
+        return ((service == null) || RestrictedSecurity.canServiceBeRegistered(service));
+    }
+
+    private boolean isRestrictedSecurityServiceAllowed(Object key) {
+        Service service = createServiceFromKey(key);
+        return ((service == null) || RestrictedSecurity.isServiceAllowed(service));
+    }
+
     /*
      * Checks if the provided key is one of the following:
      *  - one that cannot be used to create a service
      *  - pertains to information about the provider
      *  - corresponds to a service that is allowed
+     *    by the active RestrictedSecurity profile
      *
      * In any of this cases, the method returns true,
      * indicating that the key and associated value can

--- a/test/lib/jdk/test/lib/LegacyProvider.java
+++ b/test/lib/jdk/test/lib/LegacyProvider.java
@@ -46,6 +46,5 @@ public class LegacyProvider extends Provider {
         replace("Signature.Test3", "example.class.MyClass3", "example.class.MyClass3New");
 
         merge("Signature.Test5", "example.class.MyClass5", (a, b) -> b);
-
     }
 }

--- a/test/lib/jdk/test/lib/LegacyProvider.java
+++ b/test/lib/jdk/test/lib/LegacyProvider.java
@@ -22,14 +22,14 @@
  * ===========================================================================
  */
 
-/**
- * A provider created to test the restriction of legacy paths through
- * the RestrictedSecurity mode.
- */
 package jdk.test.lib;
 
 import java.security.Provider;
 
+/**
+ * A provider created to test the restriction of legacy paths through
+ * the RestrictedSecurity mode.
+ */
 public class LegacyProvider extends Provider {
     public LegacyProvider() {
         super("LegacyProvider", "1", "Test provider");

--- a/test/lib/jdk/test/lib/LegacyProvider.java
+++ b/test/lib/jdk/test/lib/LegacyProvider.java
@@ -1,0 +1,51 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+/**
+ * A provider created to test the restriction of legacy paths through
+ * the RestrictedSecurity mode.
+ */
+package jdk.test.lib;
+
+import java.security.Provider;
+
+public class LegacyProvider extends Provider {
+    public LegacyProvider() {
+        super("LegacyProvider", "1", "Test provider");
+        put("Signature.Test", "example.class.MyClass");
+        put("Signature.Test2", "example.class.MyClass2");
+        put("Signature.Test3", "example.class.MyClass3");
+
+        putIfAbsent("Signature.Test4", "example.class.MyClass4");
+
+        replace("Signature.Test2", "example.class.MyClass2New");
+        replace("Signature.Test2", "example.class.MyClass2New", "example.class.MyClass2");
+
+        replace("Signature.Test3", "example.class.MyClass3New");
+        replace("Signature.Test3", "example.class.MyClass3", "example.class.MyClass3New");
+
+        merge("Signature.Test5", "example.class.MyClass5", (a, b) -> b);
+
+    }
+}


### PR DESCRIPTION
Legacy security providers do not use the more modern getService() and putService() methods, but rather other more map based methods.

Further checks are added to restrict through RestrictedSecurity the registration and retrieval of services through legacy providers.

Tests are, also, added to verify these checks.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>