### PR TITLE
Update KeytoolOpensslInteropTest to skip PBMAC1 testing for FIPS

### DIFF
--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test id=GenerateOpensslPKCS12
  * @bug 8076190 8242151 8153005 8266182 8362894
  * @summary This is java keytool <-> openssl interop test. This test generates
@@ -68,6 +74,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
+import java.security.Security;
 import java.util.Base64;
 import java.util.Objects;
 
@@ -139,6 +146,9 @@ public class KeytoolOpensslInteropTest {
                 "AES-256-CBC", "-macalg", "SHA512")
                 .shouldHaveExitValue(0);
 
+        if (Security.getProperty("com.ibm.fips.mode") != null) {
+            return;
+        }
         ProcessTools.executeCommand(opensslPath, "pkcs12", "-export", "-in",
                         "kandc", "-out", "os6", "-name", "a", "-passout",
                         "pass:changeit", "-pbmac1_pbkdf2", "-macalg", "sha256")
@@ -173,7 +183,9 @@ public class KeytoolOpensslInteropTest {
         // no storepass no cert
         check("os5", "a", null, "changeit", true, false, true);
 
-        check("os6", "a", "changeit", "changeit", true, true, true);
+        if (Security.getProperty("com.ibm.fips.mode") == null) {
+            check("os6", "a", "changeit", "changeit", true, true, true);
+        }
 
         // keytool
 


### PR DESCRIPTION
For FIPS the minimum salt requirement for PBKDF2 is 128 bits. The private key os6 is using a salt length of 64 bits for PBMAC1 testing which uses PBKDF2. Hence, PBMAC1 testing should be skipped for FIPS.

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)