### PR TITLE
Partially revert change to Thread::getStackTrace()

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -2255,7 +2255,7 @@ public class Thread implements Runnable {
             if (!isAlive()) {
                 return EMPTY_STACK_TRACE;
             }
-            StackTraceElement[] stackTrace = getStackTrace0();
+            StackTraceElement[] stackTrace = asyncGetStackTrace();
             if (stackTrace != null) {
                 return StackTraceElement.finishInit(stackTrace);
             }
@@ -2278,6 +2278,26 @@ public class Thread implements Runnable {
     }
 
     private native Throwable getStackTraceImpl();
+
+    /**
+     * Returns an array of stack trace elements representing the stack dump of
+     * this thread. Returns null if the stack trace cannot be obtained. In
+     * the default implementation, null is returned if the thread is a virtual
+     * thread that is not mounted or the thread is a platform thread that has
+     * terminated.
+     */
+    StackTraceElement[] asyncGetStackTrace() {
+        Object stackTrace = getStackTrace0();
+        if (stackTrace == null) {
+            return null;
+        }
+        StackTraceElement[] stes = (StackTraceElement[]) stackTrace;
+        if (stes.length == 0) {
+            return null;
+        } else {
+            return StackTraceElement.finishInit(stes);
+        }
+    }
 
     /**
      * Returns a map of stack traces for all live platform threads. The map

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
  * ===========================================================================
  */
 package java.lang;
@@ -156,6 +156,9 @@ final class VirtualThread extends BaseVirtualThread {
     private static final int TIMED_WAIT    = 18;    // waiting in timed-Object.wait
 
     private static final int TERMINATED = 99;  // final state
+
+    // can be suspended from scheduling when unmounted
+    private static final int SUSPENDED = 1 << 8;
 
     // parking permit made available by LockSupport.unpark
     private volatile boolean parkPermit;
@@ -941,19 +944,28 @@ final class VirtualThread extends BaseVirtualThread {
      */
     private void waitTimeoutExpired(byte seqNo) {
         assert !Thread.currentThread().isVirtual();
-
-        synchronized (timedWaitLock()) {
-            if (seqNo != timedWaitSeqNo) {
-                // this timeout task is for a past timed-wait
+        for (;;) {
+            boolean unblocked = false;
+            synchronized (timedWaitLock()) {
+                if (seqNo != timedWaitSeqNo) {
+                    // this timeout task is for a past timed-wait
+                    return;
+                }
+                int s = state();
+                if (s == TIMED_WAIT) {
+                    unblocked = compareAndSetState(TIMED_WAIT, UNBLOCKED);
+                } else if (s != (TIMED_WAIT | SUSPENDED)) {
+                    // notified or interrupted, no longer waiting
+                    return;
+                }
+            }
+            if (unblocked) {
+                lazySubmitRunContinuation();
                 return;
             }
-            if (!compareAndSetState(TIMED_WAIT, UNBLOCKED)) {
-                // already notified (or interrupted)
-                return;
-            }
+            // need to retry when thread is suspended in time-wait
+            Thread.yield();
         }
-
-        lazySubmitRunContinuation();
     }
 
     /**
@@ -1094,7 +1106,8 @@ final class VirtualThread extends BaseVirtualThread {
 
     @Override
     Thread.State threadState() {
-        switch (state()) {
+        int s = state();
+        switch (s & ~SUSPENDED) {
             case NEW:
                 return Thread.State.NEW;
             case STARTED:
@@ -1160,6 +1173,85 @@ final class VirtualThread extends BaseVirtualThread {
     @Override
     boolean isTerminated() {
         return (state == TERMINATED);
+    }
+
+    @Override
+    StackTraceElement[] asyncGetStackTrace() {
+        StackTraceElement[] stackTrace;
+        do {
+            stackTrace = (carrierThread != null)
+                    ? super.asyncGetStackTrace()  // mounted
+                    : tryGetStackTrace();         // unmounted
+            if (stackTrace == null) {
+                Thread.yield();
+            }
+        } while (stackTrace == null);
+        return stackTrace;
+    }
+
+    /**
+     * Returns the stack trace for this virtual thread if it is unmounted.
+     * Returns null if the thread is mounted or in transition.
+     */
+    private StackTraceElement[] tryGetStackTrace() {
+        int initialState = state() & ~SUSPENDED;
+        switch (initialState) {
+            case NEW, STARTED, TERMINATED -> {
+                return new StackTraceElement[0];  // unmounted, empty stack
+            }
+            case RUNNING, PINNED, TIMED_PINNED -> {
+                return null;   // mounted
+            }
+            case PARKED, TIMED_PARKED, BLOCKED, WAIT, TIMED_WAIT -> {
+                // unmounted, not runnable
+            }
+            case UNPARKED, UNBLOCKED, YIELDED -> {
+                // unmounted, runnable
+            }
+            case PARKING, TIMED_PARKING, BLOCKING, YIELDING, WAITING, TIMED_WAITING -> {
+                return null;  // in transition
+            }
+            default -> throw new InternalError("" + initialState);
+        }
+
+        // thread is unmounted, prevent it from continuing
+        int suspendedState = initialState | SUSPENDED;
+        if (!compareAndSetState(initialState, suspendedState)) {
+            return null;
+        }
+
+        // get stack trace and restore state
+        StackTraceElement[] stack;
+        try {
+            stack = cont.getStackTrace();
+        } finally {
+            assert state == suspendedState;
+            setState(initialState);
+        }
+        boolean resubmit = switch (initialState) {
+            case UNPARKED, UNBLOCKED, YIELDED -> {
+                // resubmit as task may have run while suspended
+                yield true;
+            }
+            case PARKED, TIMED_PARKED -> {
+                // resubmit if unparked while suspended
+                yield parkPermit && compareAndSetState(initialState, UNPARKED);
+            }
+            case BLOCKED -> {
+                // resubmit if unblocked while suspended
+                yield blockPermit && compareAndSetState(BLOCKED, UNBLOCKED);
+            }
+            case WAIT, TIMED_WAIT -> {
+                // resubmit if notified or interrupted while waiting (Object.wait)
+                // waitTimeoutExpired will retry if the timed expired when suspended
+                yield (notified || interrupted) && compareAndSetState(initialState, UNBLOCKED);
+            }
+            default -> throw new InternalError();
+        };
+        if (resubmit) {
+            submitRunContinuation();
+        }
+        return stack;
     }
 
     @Override


### PR DESCRIPTION
This partially reverts f4ecb5e571d276c23ccc4eb86aec3ed763654fd2
* 8376568: Change Thread::getStackTrace to use handshake op for all cases

Fixes: https://github.com/eclipse-openj9/openj9/issues/23759.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).