### PR TITLE
Propagate new configure option `--enable-objcopy-debuginfo-compression` to OMR

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -367,6 +367,11 @@ else # OPENJ9_ENABLE_CONTINUATION_ALLOCATION_PROFILING
   CMAKE_ARGS += -DJ9VM_PROF_CONTINUATION_ALLOCATION=OFF
 endif # OPENJ9_ENABLE_CONTINUATION_ALLOCATION_PROFILING
 
+# Propagate configure option '--objcopy-debuginfo-compression' to OMR.
+ifneq (,$(OBJCOPY_COMPRESS_FLAGS))
+  CMAKE_ARGS += -DOMR_OBJCOPY_COMPRESS_FLAGS=$(OBJCOPY_COMPRESS_FLAGS)
+endif
+
 # Propagate configure option '--disable-warnings-as-errors-omr' to OMR.
 ifeq (false,$(WARNINGS_AS_ERRORS_OMR))
   CMAKE_ARGS += -DOMR_WARNINGS_AS_ERRORS=OFF


### PR DESCRIPTION
OpenJDK added the configuration option `--enable-objcopy-debuginfo-compression`:
* [8383243: Make objcopy configurable to compress debug info](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/e77f7ecdbbcdf4fe8d5ed584cf423e97b1289ee8)

In a local build on x86-64 Linux, using that option (together with https://github.com/eclipse-omr/omr/pull/8247) shrinks `.debuginfo` files from a total of around 1.1GB to 457MB.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).