### PR TITLE
Add test property `vm.cds.nocoh.archive.available=false`

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -72,6 +72,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
         map.put("vm.asan", "false");
         map.put("vm.bits", this::vmBits);
         map.put("vm.cds", "false");
+        map.put("vm.cds.nocoh.archive.available", "false");
         map.put("vm.cds.write.archived.java.heap", "false");
         map.put("vm.compiler2.enabled", "false");
         map.put("vm.continuations", "true");


### PR DESCRIPTION
For consistency with upstream change:
* [8385437: Provide test property vm.cds.nocoh.archive.available and use it in CompressedCPUSpecificClassSpaceReservation](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/6160ce254a09ddb1bcd2653af8d2aafd54db5f8b)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).