### PR TITLE
Exclude jdk.jcmd/share/conf/bash-completion/jcmd from the CPE check

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
+++ b/buildenv/jenkins/jobs/infrastructure/copyrightCheckDir.sh
@@ -56,6 +56,7 @@ print_excludes() {
   echo "src/jdk.internal.vm.compiler.management/share/classes/org.graalvm.compiler.hotspot.management/src/org/graalvm/compiler/hotspot/management/HotSpotGraalRuntimeMBean.java"
   echo "src/jdk.internal.vm.compiler.management/share/classes/org.graalvm.compiler.hotspot.management/src/org/graalvm/compiler/hotspot/management/JMXServiceProvider.java"
   echo "src/jdk.internal.vm.compiler.management/share/classes/org.graalvm.compiler.hotspot.management/src/org/graalvm/compiler/hotspot/management/package-info.java"
+  echo "src/jdk.jcmd/share/conf/bash-completion/jcmd"
   echo "test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/VerifierTroublev49.jasm"
   echo "test/jaxp/javax/xml/jaxp/unittest/common/dtd/DTDTestBase.java"
   echo "test/jaxp/javax/xml/jaxp/unittest/common/dtd/SchemaTest.java"


### PR DESCRIPTION
Fix the copyright check failure. This file is not linked, it seems the CPE doesn't apply.
https://openj9-jenkins.osuosl.org/job/CopyrightCheck-OpenJDK/1840/

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
