### PR TITLE
Disable GetCanonicalPath.mappedDrive()

### DIFF
--- a/test/jdk/java/io/File/GetCanonicalPath.java
+++ b/test/jdk/java/io/File/GetCanonicalPath.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 /* @test
  * @bug 4899022 8003887 8355342
  * @summary Look for erroneous representation of drive letter
@@ -38,6 +44,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -129,6 +136,7 @@ public class GetCanonicalPath {
     }
 
     @Test
+    @Disabled("Not supported by Semeru test infrastructure")
     @EnabledOnOs(OS.WINDOWS)
     void mappedDrive() throws IOException {
         // find the first unused drive letter


### PR DESCRIPTION
[Disable GetCanonicalPath.mappedDrive()](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/ee259fb8e9018bcee88e44b6832212d301cdfb60) 

This is a Window test using `net use` not supported by current infra.

Related to https://github.com/eclipse-openj9/openj9/issues/23351

Signed-off-by: Jason Feng <fengj@ca.ibm.com>


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
