### PR TITLE
Remove provider-specific condition from SecureRandom strong test

### DIFF
--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -205,64 +205,62 @@ public class TestProperties {
     private static Stream<Arguments> patternMatches_strongAlgorithms() {
         Stream.Builder<Arguments> tests = Stream.builder();
 
-        if (isProviderPresent("OpenJCEPlusFIPS")) {
-            // 1 - Test property - base profile with securerandom.strongAlgorithms loads successfully.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "(?s)(?=.*OpenJCEPlusFIPS)(?=.*SUN)(?=.*SunJSSE)",
-                    0));
-            // 2 - Test property - securerandom.strongAlgorithms property with multiple algorithms.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MultipleEntries",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
-                    0));
-            // 3 - Test property - securerandom.strongAlgorithms append algorithm in extended profile.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_1",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
-                    0));
-            // 4 - Test property - securerandom.strongAlgorithms remove algorithm in extended profile.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_2",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "securerandom\\.strongAlgorithms: (?=.*NativePRNGBlocking:SUN)(?=.*DRBG:SUN)",
-                    0));
-            // 5 - Test property - securerandom.strongAlgorithms invalid algorithm.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidFormat",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "FAILED: No strong SecureRandom impls available: .*",
-                    0));
-            // 6 - Test property - securerandom.strongAlgorithms missing algorithm.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingAlgo",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "FAILED: No strong SecureRandom impls available: .*",
-                    0));
-            // 7 - Test property - securerandom.strongAlgorithms missing provider.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingProvider",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "FAILED: missing provider",
-                    0));
-            // 8 - Test property - set invalid provider.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidProvider",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "FAILED: No strong SecureRandom impls available: .*",
-                    0));
-            // 9 - Test property - securerandom.strongAlgorithms when only algorithm is present.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Specify-Algo-Only",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "securerandom\\.strongAlgorithms: SHA(256|512)DRBG$",
-                    0));
-            // 10 - Test property - invalid algorithm.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidAlgorithm",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "FAILED: No strong SecureRandom impls available: .*",
-                    0));
-            // 11 - Test property - securerandom.strongAlgorithms misspelled property name.
-            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MisspelledPropertyName",
-                    System.getProperty("test.src") + "/property-java.security",
-                    "The property names: RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.strongAlgorithmsWrong "
-                            + "in profile RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName \\(or a base profile\\) are not recognized",
-                    1));
-        }
+        // 1 - Test property - base profile with securerandom.strongAlgorithms loads successfully.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms",
+                System.getProperty("test.src") + "/property-java.security",
+                "(?s)(?=.*OpenJCEPlusFIPS)(?=.*SUN)(?=.*SunJSSE)",
+                0));
+        // 2 - Test property - securerandom.strongAlgorithms property with multiple algorithms.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-MultipleEntries",
+                System.getProperty("test.src") + "/property-java.security",
+                "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
+                0));
+        // 3 - Test property - securerandom.strongAlgorithms append algorithm in extended profile.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_1",
+                System.getProperty("test.src") + "/property-java.security",
+                "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
+                0));
+        // 4 - Test property - securerandom.strongAlgorithms remove algorithm in extended profile.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_2",
+                System.getProperty("test.src") + "/property-java.security",
+                "securerandom\\.strongAlgorithms: (?=.*NativePRNGBlocking:SUN)(?=.*DRBG:SUN)",
+                0));
+        // 5 - Test property - securerandom.strongAlgorithms invalid algorithm.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidFormat",
+                System.getProperty("test.src") + "/property-java.security",
+                "FAILED: No strong SecureRandom impls available: .*",
+                0));
+        // 6 - Test property - securerandom.strongAlgorithms missing algorithm.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingAlgo",
+                System.getProperty("test.src") + "/property-java.security",
+                "FAILED: No strong SecureRandom impls available: .*",
+                0));
+        // 7 - Test property - securerandom.strongAlgorithms missing provider.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingProvider",
+                System.getProperty("test.src") + "/property-java.security",
+                "FAILED: missing provider",
+                0));
+        // 8 - Test property - set invalid provider.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidProvider",
+                System.getProperty("test.src") + "/property-java.security",
+                "FAILED: No strong SecureRandom impls available: .*",
+                0));
+        // 9 - Test property - securerandom.strongAlgorithms when only algorithm is present.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-Specify-Algo-Only",
+                System.getProperty("test.src") + "/property-java.security",
+                "securerandom\\.strongAlgorithms: SHA(256|512)DRBG$",
+                0));
+        // 10 - Test property - invalid algorithm.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidAlgorithm",
+                System.getProperty("test.src") + "/property-java.security",
+                "FAILED: No strong SecureRandom impls available: .*",
+                0));
+        // 11 - Test property - securerandom.strongAlgorithms misspelled property name.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-MisspelledPropertyName",
+                System.getProperty("test.src") + "/property-java.security",
+                "The property names: RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.strongAlgorithmsWrong "
+                        + "in profile RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName \\(or a base profile\\) are not recognized",
+                1));
 
         return tests.build();
     }
@@ -329,15 +327,13 @@ public class TestProperties {
     }
 
     private static void testStrongAlgorithms() {
-        if (isProviderPresent("OpenJCEPlusFIPS")) {
-            String strongAlgorithms = Security.getProperty("securerandom.strongAlgorithms");
-            if ((strongAlgorithms != null) && !strongAlgorithms.isEmpty()) {
-                try {
-                    java.security.SecureRandom.getInstanceStrong();
-                    System.out.println("securerandom.strongAlgorithms: " + strongAlgorithms);
-                } catch (java.security.NoSuchAlgorithmException | IllegalArgumentException e) {
-                    System.out.println("FAILED: " + e.getMessage());
-                }
+        String strongAlgorithms = Security.getProperty("securerandom.strongAlgorithms");
+        if ((strongAlgorithms != null) && !strongAlgorithms.isEmpty()) {
+            try {
+                java.security.SecureRandom.getInstanceStrong();
+                System.out.println("securerandom.strongAlgorithms: " + strongAlgorithms);
+            } catch (java.security.NoSuchAlgorithmException | IllegalArgumentException e) {
+                System.out.println("FAILED: " + e.getMessage());
             }
         }
     }


### PR DESCRIPTION
This change removes the provider-specific condition from the
SecureRandom strong algorithm test. The test should run with
any security provider to avoid failures when a different
provider is configured.

Signed-off-by: Mohit Rajbhar <mohit.rajbhar@ibm.com>