### PR TITLE
Set jdk.tls.namedGroups property through RestrictedSecurity profiles

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -632,6 +632,17 @@ public final class RestrictedSecurity {
             // SSL property "javax.net.ssl.keyStore" set at the JVM level via system properties.
             System.setProperty("javax.net.ssl.keyStore", keyStore);
         }
+        String jdkTlsNamedGroups = restricts.jdkTlsNamedGroups;
+        if (!isNullOrBlank(jdkTlsNamedGroups)) {
+            String namedGroups = System.getProperty("jdk.tls.namedGroups");
+            if (namedGroups == null) {
+                // TLS property "jdk.tls.namedGroups" set at the JVM level via system properties.
+                System.setProperty("jdk.tls.namedGroups", jdkTlsNamedGroups);
+            } else {
+                printStackTraceAndExit("System property jdk.tls.namedGroups cannot be set"
+                        + " when defined in a RestrictedSecurity profile");
+            }
+        }
     }
 
     /**
@@ -777,6 +788,7 @@ public final class RestrictedSecurity {
         private final String jdkTlsDisabledAlgorithms;
         private final String jdkTlsEphemeralDHKeySize;
         private final String jdkTlsLegacyAlgorithms;
+        private final String jdkTlsNamedGroups;
         private final String jdkCertpathDisabledAlgorithms;
         private final String jdkSecurityLegacyAlgorithms;
         private final String keyStoreType;
@@ -812,6 +824,7 @@ public final class RestrictedSecurity {
             this.jdkTlsDisabledAlgorithms = parser.getProperty("jdkTlsDisabledAlgorithms");
             this.jdkTlsEphemeralDHKeySize = parser.getProperty("jdkTlsEphemeralDHKeySize");
             this.jdkTlsLegacyAlgorithms = parser.getProperty("jdkTlsLegacyAlgorithms");
+            this.jdkTlsNamedGroups = parser.getProperty("jdkTlsNamedGroups");
             this.jdkCertpathDisabledAlgorithms = parser.getProperty("jdkCertpathDisabledAlgorithms");
             this.jdkSecurityLegacyAlgorithms = parser.getProperty("jdkSecurityLegacyAlgorithms");
             this.keyStoreType = parser.getProperty("keyStoreType");
@@ -1107,6 +1120,7 @@ public final class RestrictedSecurity {
             printProperty(profileID + ".tls.disabledAlgorithms: ", jdkTlsDisabledAlgorithms);
             printProperty(profileID + ".tls.ephemeralDHKeySize: ", jdkTlsEphemeralDHKeySize);
             printProperty(profileID + ".tls.legacyAlgorithms: ", jdkTlsLegacyAlgorithms);
+            printProperty(profileID + ".tls.namedGroups: ", jdkTlsNamedGroups);
             printProperty(profileID + ".jce.certpath.disabledAlgorithms: ", jdkCertpathDisabledAlgorithms);
             printProperty(profileID + ".jce.legacyAlgorithms: ", jdkSecurityLegacyAlgorithms);
             System.out.println();
@@ -1562,6 +1576,8 @@ public final class RestrictedSecurity {
                     profileID + ".tls.ephemeralDHKeySize", allInfo);
             setProperty("jdkTlsLegacyAlgorithms",
                     profileID + ".tls.legacyAlgorithms", allInfo);
+            setProperty("jdkTlsNamedGroups",
+                    profileID + ".tls.namedGroups", allInfo);
             setProperty("jdkCertpathDisabledAlgorithms",
                     profileID + ".jce.certpath.disabledAlgorithms", allInfo);
             setProperty("jdkSecurityLegacyAlgorithms",

--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -265,6 +265,21 @@ public class TestProperties {
         return tests.build();
     }
 
+    private static Stream<Arguments> patternMatches_systemProperties() {
+        return Stream.of(
+                // 1 - Test property - base profile with javax.net.ssl.keyStore loads successfully.
+                Arguments.of("TestBase.Version",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "javax\\.net\\.ssl\\.keyStore: NONE",
+                        0),
+                // 2 - Test property - base profile with jdk.tls.namedGroups loads successfully.
+                Arguments.of("TestBase.Version",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "jdk\\.tls\\.namedGroups: secp256r1",
+                        0)
+        );
+    }
+
     @ParameterizedTest
     @MethodSource("patternMatches_expectedExitValue0")
     public void shouldContain_expectedExitValue0(String customprofile, String securityPropertyFile, String expected) throws Exception {
@@ -317,6 +332,19 @@ public class TestProperties {
         outputAnalyzer.shouldHaveExitValue(exitValue).shouldMatch(expected);
     }
 
+    @ParameterizedTest
+    @MethodSource("patternMatches_systemProperties")
+    public void shouldContain_systemProperties(String customprofile, String securityPropertyFile, String expected, int exitValue) throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.fips=true",
+                "-Dsemeru.customprofile=" + customprofile,
+                "-Djava.security.properties=" + securityPropertyFile,
+                "TestProperties"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(exitValue).shouldMatch(expected);
+    }
+
     private static boolean isProviderPresent(String providerName) {
         for (Provider provider : Security.getProviders()) {
             if (provider.getName().equalsIgnoreCase(providerName)) {
@@ -338,6 +366,20 @@ public class TestProperties {
         }
     }
 
+    private static void testSystemProperties() {
+        // Test javax.net.ssl.keyStore system property.
+        String keyStore = System.getProperty("javax.net.ssl.keyStore");
+        if (keyStore != null) {
+            System.out.println("javax.net.ssl.keyStore: " + keyStore);
+        }
+
+        // Test jdk.tls.namedGroups system property.
+        String namedGroups = System.getProperty("jdk.tls.namedGroups");
+        if (namedGroups != null) {
+            System.out.println("jdk.tls.namedGroups: " + namedGroups);
+        }
+    }
+
     public static void main(String[] args) {
         // Something to trigger "properties" debug output.
         try {
@@ -346,6 +388,7 @@ public class TestProperties {
                 System.out.println("Provider Version: " + provider.getVersionStr());
             }
             testStrongAlgorithms();
+            testSystemProperties();
         } catch (Exception e) {
             System.out.println(e);
         }

--- a/closed/test/jdk/openj9/internal/security/property-java.security
+++ b/closed/test/jdk/openj9/internal/security/property-java.security
@@ -21,13 +21,14 @@
 RestrictedSecurity.TestBase.Version.desc.name = Test Base Profile
 RestrictedSecurity.TestBase.Version.desc.default = false
 RestrictedSecurity.TestBase.Version.desc.fips = true
-RestrictedSecurity.TestBase.Version.desc.hash = SHA256:21cacdfdca721783808e74798d7fc8f17f5b5ae583fd8e175549db9bfceb9983
+RestrictedSecurity.TestBase.Version.desc.hash = SHA256:57416e31b0d2712800afb73841ee7dd0c8d98fc50d7ff60132ed8cb3a41be958
 RestrictedSecurity.TestBase.Version.fips.mode = 140-3
 
 RestrictedSecurity.TestBase.Version.tls.disabledNamedCurves =
 RestrictedSecurity.TestBase.Version.tls.disabledAlgorithms =
 RestrictedSecurity.TestBase.Version.tls.ephemeralDHKeySize =
 RestrictedSecurity.TestBase.Version.tls.legacyAlgorithms =
+RestrictedSecurity.TestBase.Version.tls.namedGroups = secp256r1
 
 RestrictedSecurity.TestBase.Version.jce.certpath.disabledAlgorithms =
 RestrictedSecurity.TestBase.Version.jce.legacyAlgorithms =


### PR DESCRIPTION
The `jdk.tls.namedGroups` system property can now be set through a RestrictedSecurity profile, instead of being specified explicitly through the command line.

The `TestProperties.java` test was updated to verify this new feature.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
