### PR TITLE
Fix checking for unrecognised JVM options

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
 # ===========================================================================
 
 m4_include([util_paths.m4])
@@ -333,7 +333,7 @@ AC_DEFUN([UTIL_ADD_JVM_ARG_IF_OK],
   $ECHO "Check if jvm arg is ok: $1" >&AS_MESSAGE_LOG_FD
   $ECHO "Command: $3 $1 -version" >&AS_MESSAGE_LOG_FD
   OUTPUT=`$3 $1 $USER_BOOT_JDK_OPTIONS -version 2>&1`
-  FOUND_WARN=`$ECHO "$OUTPUT" | $GREP -i "warn\|unrecognised"`
+  FOUND_WARN=`$ECHO "$OUTPUT" | $GREP -E -i "warn|unrecognised"`
   FOUND_VERSION=`$ECHO $OUTPUT | $GREP " version \""`
   if test "x$FOUND_VERSION" != x && test "x$FOUND_WARN" = x; then
     $2="[$]$2 $1"


### PR DESCRIPTION
On z/OS, `grep -E` must be used with a pattern containing `|`.

This is an improvement of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1113.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).