### PR TITLE
Handle Windows SecureRandom strongAlgorithms defaults in test

### DIFF
--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -223,7 +223,7 @@ public class TestProperties {
         // 4 - Test property - securerandom.strongAlgorithms remove algorithm in extended profile.
         tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_2",
                 System.getProperty("test.src") + "/property-java.security",
-                "securerandom\\.strongAlgorithms: (?=.*NativePRNGBlocking:SUN)(?=.*DRBG:SUN)",
+                "securerandom\\.strongAlgorithms: (NativePRNGBlocking:SUN|Windows-PRNG:SunMSCAPI),DRBG:SUN",
                 0));
         // 5 - Test property - securerandom.strongAlgorithms invalid algorithm.
         tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidFormat",


### PR DESCRIPTION
Update the test regular expression to match the Windows default
value of the `securerandom.strongAlgorithms` security property.

The default value on Windows differs from Linux and macOS, causing
the existing regular expression to fail even though the property is
correctly restored after all `RestrictedSecurity` settings are
removed.

Update the regular expression to match both the Windows and
non-Windows default values.

Signed-off-by: Mohit Rajbhar <mohit.rajbhar@ibm.com>