### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/java.desktop/share/native/libfreetype/src/base/ftstroke.c
+++ b/src/java.desktop/share/native/libfreetype/src/base/ftstroke.c
@@ -656,12 +656,11 @@
     FT_UInt   num_contours = 0;
 
     FT_UInt     count      = border->num_points;
-    FT_Vector*  point      = border->points;
     FT_Byte*    tags       = border->tags;
     FT_Int      in_contour = 0;
 
 
-    for ( ; count > 0; count--, num_points++, point++, tags++ )
+    for ( ; count > 0; count--, num_points++, tags++ )
     {
       if ( tags[0] & FT_STROKE_TAG_BEGIN )
       {


### PR DESCRIPTION
Cherry-pick https://github.com/freetype/freetype/commit/a3c1a452dffd4c2579cca9e92188593fa678abd3

GCC 16 complains about the unused local variable.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).