### PR TITLE
Work around Visual Studio internal compiler error

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/FieldAccessModify/libFieldAccessModify.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/FieldAccessModify/libFieldAccessModify.cpp
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -234,14 +240,15 @@ JNIEXPORT jint JNICALL
 Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
 {
     jvmtiError err;
-    jvmtiCapabilities caps = {};
-    jvmtiEventCallbacks callbacks = {};
+    jvmtiCapabilities caps;
+    jvmtiEventCallbacks callbacks;
     jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == nullptr) {
         reportError("GetEnv failed", res);
         return JNI_ERR;
     }
 
+    memset(&caps, 0, sizeof(caps));
     caps.can_generate_field_modification_events = 1;
     caps.can_generate_field_access_events = 1;
     caps.can_tag_objects = 1;
@@ -251,6 +258,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
         return JNI_ERR;
     }
 
+    memset(&callbacks, 0, sizeof(callbacks));
     callbacks.FieldModification = &onFieldModification;
     callbacks.FieldAccess = &onFieldAccess;
 


### PR DESCRIPTION
Acceptance builds are failing on Windows with an internal compiler error. See [build 1071](https://openj9-jenkins.osuosl.org/job/Build_JDKnext_x86-64_windows_OpenJDK/1071):
```
[2026-08-06T16:20:56.951Z] /cygdrive/f/Users/jenkins/workspace/Build_JDKnext_x86-64_windows_OpenJDK/make/scripts/fixpath.sh: line 448: 26304 Segmentation fault      "$command" "${collected_args[@]}"
[2026-08-06T16:20:56.951Z] f:\Users\jenkins\workspace\Build_JDKnext_x86-64_windows_OpenJDK\test\hotspot\jtreg\serviceability\jvmti\valhalla\FieldAccessModify\libFieldAccessModify.cpp(237): fatal error C1001: Internal compiler error.
```
No other file initializes a variable of type `jvmtiCapabilities` or `jvmtiEventCallbacks` with `= {};`. It would appear that is what the compiler is having trouble with.

Note: This targets the openj9-staging branch.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).