### PR TITLE
Work around an apparent JIT issue with ArraysSupport (take 2)

### DIFF
--- a/make/modules/jdk.jlink/Launcher.gmk
+++ b/make/modules/jdk.jlink/Launcher.gmk
@@ -23,13 +23,6 @@
 # questions.
 #
 
-# ===========================================================================
-# (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
-# ===========================================================================
-
-# Workaround an apparent JIT issue; see https://github.com/eclipse-openj9/openj9/issues/24523.
-JIT_CONTROL := -Xjit:exclude={jdk/internal/util/ArraysSupport.*}
-
 ################################################################################
 
 include LauncherCommon.gmk
@@ -49,7 +42,7 @@ $(eval $(call SetupBuildLauncher, jimage, \
 
 $(eval $(call SetupBuildLauncher, jlink, \
     MAIN_CLASS := jdk.tools.jlink.internal.Main, \
-    JAVA_ARGS := $(JIT_CONTROL) --add-modules ALL-DEFAULT, \
+    JAVA_ARGS := --add-modules ALL-DEFAULT, \
     ENABLE_ARG_FILES := true, \
     EXPAND_CLASSPATH_WILDCARDS := true, \
 ))
@@ -60,7 +53,6 @@ $(eval $(call SetupBuildLauncher, jlink, \
 
 $(eval $(call SetupBuildLauncher, jmod, \
     MAIN_CLASS := jdk.tools.jmod.Main, \
-    JAVA_ARGS := $(JIT_CONTROL), \
     ENABLE_ARG_FILES := true, \
     EXPAND_CLASSPATH_WILDCARDS := true, \
 ))

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util.zip;
 
 import java.nio.ByteBuffer;
@@ -299,7 +305,7 @@ class ZipCoder {
         byte compare(String str, byte[] b, int off, int len, boolean matchDirectory) {
             try {
                 byte[] encoded = JLA.uncheckedGetBytesOrThrow(str, UTF_8.INSTANCE);
-                int mismatch = Arrays.mismatch(encoded, 0, encoded.length, b, off, off+len);
+                int mismatch = simple_mismatch(encoded, 0, encoded.length, b, off, off+len);
                 if (mismatch == -1) {
                     return EXACT_MATCH;
                 } else if (matchDirectory && len == mismatch + 1 && hasTrailingSlash(b, off + len)) {
@@ -309,6 +315,24 @@ class ZipCoder {
                 }
             } catch (CharacterCodingException e) {
                 return NO_MATCH;
+            }
+        }
+
+        // A replacement for Arrays.mismatch() to work around an apparent JIT issue.
+        // See https://github.com/eclipse-openj9/openj9/issues/24523.
+        private static int simple_mismatch(byte[] a, int aFromIndex, int aToIndex,
+                                           byte[] b, int bFromIndex, int bToIndex) {
+            int aLength = aToIndex - aFromIndex;
+            int bLength = bToIndex - bFromIndex;
+            int length = Math.min(aLength, bLength);
+
+            for (int i = 0;; ++i) {
+                if (i >= length) {
+                    return (aLength == bLength) ? -1 : length;
+                }
+                if (a[aFromIndex + i] != a[aFromIndex + i]) {
+                    return i;
+                }
             }
         }
     }


### PR DESCRIPTION
This is a second attempt to work around an apparent JIT issue with recent changes to `ArraysSupport` (see https://github.com/eclipse-openj9/openj9/issues/24523).

This reverts https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1243 and applies the change to `ZipCoder.UTF8ZipCoder` mentioned in https://github.com/eclipse-openj9/openj9/issues/24523#issuecomment-5271958615.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).