### PR TITLE
Fix java/lang/IO/IO.java failure on OpenJ9

### DIFF
--- a/test/jdk/java/lang/IO/IO.java
+++ b/test/jdk/java/lang/IO/IO.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 import java.io.Writer;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
@@ -29,6 +35,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.stream.Stream;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import org.junit.jupiter.api.Assumptions;
@@ -149,7 +156,15 @@ public class IO {
                     }
                     """);
         }
-        var pb = ProcessTools.createTestJavaProcessBuilder("-Xlog:aot=off", "-Xlog:cds=off", file.toString());
+
+        ProcessBuilder pb;
+        if (Platform.isJ9()) {
+            /* The AOT/CDS -Xlog options are unsupported by OpenJ9 and are reported to stderr. */
+            pb = ProcessTools.createTestJavaProcessBuilder(file.toString());
+        } else {
+            pb = ProcessTools.createTestJavaProcessBuilder("-Xlog:aot=off", "-Xlog:cds=off", file.toString());
+        }
+
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
         assertEquals(0, output.getExitValue());
         assertTrue(output.getStderr().isEmpty());

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -23,7 +23,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -57,7 +57,7 @@ public class Platform {
     private static final String compiler    = System.getProperty("sun.management.compiler");
     private static final String testJdk     = System.getProperty("test.jdk");
 
-    private static boolean isJ9() {
+    public static boolean isJ9() {
         return vmName.contains("OpenJ9") || vmName.contains("IBM");
     }
 


### PR DESCRIPTION
Skip the RI-specific `AOT` and `CDS` logging options when running
`printlnNoParamsTest` on OpenJ9. OpenJ9 reports the unsupported
`-Xlog` options to `stderr`, causing the test's empty `stderr`
assertion to fail.

Related: https://github.com/eclipse-openj9/openj9/issues/23292

JDK27 backport: https://github.com/ibmruntimes/openj9-openjdk-jdk27/pull/25


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
