### PR TITLE
Add OpenJCEPlusSemeruDefaults as the first security provider

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -93,6 +93,7 @@
 #
 # List of providers and their preference orders (see above):
 #
+security.provider.tbd=com.ibm.crypto.plus.provider.OpenJCEPlusSemeruDefaults
 security.provider.tbd=SUN
 security.provider.tbd=SunRsaSign
 security.provider.tbd=SunEC


### PR DESCRIPTION
Introduce `com.ibm.crypto.plus.provider.OpenJCEPlusSemeruDefaults` as the first provider in the provider list.

The provider uses a runtime-generated name in the form `OpenJCEPlusSemeruDefaults-XXXXXX`. The generated suffix discourages applications from coding directly to the provider name while still allowing the provider to be inserted early in the provider list.

This provider supports a staged transition toward broader OpenJCEPlus enablement by default, while keeping the initial change limited in scope and easier to validate.