### PR TITLE
Fix IBM copyright placement

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java
@@ -1,28 +1,4 @@
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
- * ===========================================================================
- *
- * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
- *
- * IBM designates this particular file as subject to the "Classpath" exception
- * as provided by IBM in the LICENSE file that accompanied this code.
- *
- * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
- * accompanied this code).
- *
- * You should have received a copy of the GNU General Public License version
- * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
- *
- * ===========================================================================
- */
-
-/*
  * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,6 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  *
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
  */
 
  /*


### PR DESCRIPTION
Add IBM copyright after Oracle copyright instead at the start from this PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1254.
