### PR TITLE
Update exclude list for OpenJCEPlusFIPS Profiles

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -825,6 +825,7 @@ sun/security/provider/PolicyFile/Alias.java https://github.com/eclipse-openj9/op
 sun/security/provider/PolicyFile/AliasExpansion.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/PolicyFile/TokenStore.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/PolicyFile/TrustedCert.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/provider/pqc/SeedOrExpanded.java https://github.com/eclipse-openj9/openj9/issues/24657 generic-all
 sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/SecureRandom/AutoReseed.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/SecureRandom/CommonSeeder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -975,6 +975,7 @@ sun/security/provider/PolicyFile/Alias.java https://github.com/eclipse-openj9/op
 sun/security/provider/PolicyFile/AliasExpansion.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/PolicyFile/TokenStore.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/PolicyFile/TrustedCert.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/provider/pqc/SeedOrExpanded.java https://github.com/eclipse-openj9/openj9/issues/24657 generic-all
 sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/SecureRandom/AutoReseed.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/SecureRandom/CommonSeeder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all


### PR DESCRIPTION
This change excludes the ML-KEM-768 test from the OpenJCEPlusFIPS profiles because the algorithm is currently not supported.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
