### PR TITLE
Adjust EarlyLarvalNonPreviewTest error message matching for OpenJ9

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/EarlyLarvalNonPreviewTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library /test/lib
@@ -37,7 +43,7 @@ public class EarlyLarvalNonPreviewTest {
             var value = new EarlyLarvalNonPreviewApp(-1, -2);
             throw new RuntimeException("Expected ClassFormatError");
         } catch (ClassFormatError c) {
-            if (!c.getMessage().equals("StackMapTable format error: reserved frame type")) {
+            if (!c.getMessage().contains("StackMapTable format error: reserved frame type")) {
                 throw new RuntimeException("Unexpected ClassFormatError " + c.getMessage());
             }
             System.out.println("Test passed");


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/24666

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
