### PR TITLE
Reduce class loading depth to avoid stack overflow

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java
@@ -21,6 +21,11 @@
  * questions.
  *
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * @test
@@ -45,7 +50,8 @@ import org.junit.jupiter.api.Test;
 class ConcurrentClassLoadingTest {
     private static final boolean DEBUG = false;
     private static final int N_ITER = 125;
-    private static final int DEPTH = 100;
+    // Reduce depth to avoid StackOverflowError on platforms with smaller default native stack sizes.
+    private static final int DEPTH = 50;
 
     @Test
     void test() throws InterruptedException {


### PR DESCRIPTION
Reduce the default class generation depth in ConcurrentClassLoadingTest to 50. The previous depth can cause a StackOverflowError with the default OpenJ9 native stack size of -Xmso256k. Reducing the depth avoids the stack overflow
while still exercising concurrent class loading.

The problem can also be fixed by increasing the stack size to 512k but then -Xmso512k option needs to be appended while running, so keeping the run option default by changing the depth to 50 instead of 100.

Fixes: ConcurrentClassLoadingTest as stated in https://github.com/eclipse-openj9/openj9/issues/24005#issuecomment-5348668448
