### PR TITLE
Enable OpenJ9 JFR V2 testing in TestModularImage

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestModularImage.java
+++ b/test/jdk/jdk/jfr/jvm/TestModularImage.java
@@ -20,6 +20,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.jfr.jvm;
 
 import java.io.File;
@@ -89,7 +96,7 @@ public class TestModularImage {
     }
 
     private static void testCommandLineWithJFR(Path binPath) throws Exception {
-        var result = java(binPath, "-XX:StartFlightRecording", "--module", "hello.world/hello.Main");
+        var result = java(binPath, "-XX:+EnableOpenJ9ExperimentalFlightRecording", "-XX:StartFlightRecording", "--module", "hello.world/hello.Main");
         result.shouldNotContain(ERROR_LINE1);
         result.shouldNotContain(ERROR_LINE2);
         result.shouldContain(HELLO_WORLD);
@@ -98,7 +105,7 @@ public class TestModularImage {
     }
 
     private static void testJcmdWithJFR(Path binPath, String jcmd) throws Exception {
-        var result = java(binPath, "--module", "hello.world/hello.Main", jcmd);
+        var result = java(binPath, "-XX:+EnableOpenJ9ExperimentalFlightRecording", "--module", "hello.world/hello.Main", jcmd);
         result.shouldContain(HELLO_WORLD);
         result.shouldNotContain(ERROR_LINE1);
         result.shouldNotContain(ERROR_LINE2);
@@ -107,7 +114,7 @@ public class TestModularImage {
     }
 
     private static void testCommandLineWithoutJFR(Path binPath) throws Exception {
-        var result = java(binPath, "-XX:StartFlightRecording", "--module", "hello.world/hello.Main");
+        var result = java(binPath, "-XX:+EnableOpenJ9ExperimentalFlightRecording", "-XX:StartFlightRecording", "--module", "hello.world/hello.Main");
         result.shouldContain(ERROR_LINE1);
         result.shouldContain(ERROR_LINE2);
         result.shouldNotContain(HELLO_WORLD);
@@ -116,7 +123,7 @@ public class TestModularImage {
     }
 
     private static void testJcmdWithoutJFR(Path binPath, String jcmd) throws Exception {
-        OutputAnalyzer result = java(binPath, "--module", "hello.world/hello.Main", jcmd);
+        OutputAnalyzer result = java(binPath, "-XX:+EnableOpenJ9ExperimentalFlightRecording", "--module", "hello.world/hello.Main", jcmd);
         result.shouldContain(HELLO_WORLD);
         result.shouldContain("Module jdk.jfr not found.");
         result.shouldContain("Flight Recorder can not be enabled.");


### PR DESCRIPTION
TestModularImage spawns each jlinked runtime via ProcessBuilder. -`XX:+EnableOpenJ9ExperimentalFlightRecording` must be passed explicitly to each spawned java invocation for JFR V2 to actually be exercised.

Issue: https://github.com/eclipse-openj9/openj9/issues/23708
Required to test this PR: https://github.com/eclipse-openj9/openj9/pull/24714


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
