### PR TITLE
Fix StrongAlgorithm Tests When OpenJCEPlus Is Unavailable

### DIFF
--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -205,62 +205,70 @@ public class TestProperties {
     private static Stream<Arguments> patternMatches_strongAlgorithms() {
         Stream.Builder<Arguments> tests = Stream.builder();
 
-        // 1 - Test property - base profile with securerandom.strongAlgorithms loads successfully.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms",
-                System.getProperty("test.src") + "/property-java.security",
-                "(?s)(?=.*OpenJCEPlusFIPS)(?=.*SUN)(?=.*SunJSSE)",
-                0));
-        // 2 - Test property - securerandom.strongAlgorithms property with multiple algorithms.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-MultipleEntries",
-                System.getProperty("test.src") + "/property-java.security",
-                "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
-                0));
-        // 3 - Test property - securerandom.strongAlgorithms append algorithm in extended profile.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_1",
-                System.getProperty("test.src") + "/property-java.security",
-                "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
-                0));
-        // 4 - Test property - securerandom.strongAlgorithms remove algorithm in extended profile.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_2",
+        if (isProviderPresent("OpenJCEPlusFIPS")) {
+            // 1 - Test property - base profile with securerandom.strongAlgorithms loads successfully.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "(?s)(?=.*OpenJCEPlusFIPS)(?=.*SUN)(?=.*SunJSSE)",
+                    0));
+            // 2 - Test property - securerandom.strongAlgorithms property with multiple algorithms.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MultipleEntries",
+                   System.getProperty("test.src") + "/property-java.security",
+                   "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
+                    0));
+            // 3 - Test property - securerandom.strongAlgorithms append algorithm in extended profile.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_1",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
+                    0));
+            // 4 - Test property - securerandom.strongAlgorithms remove algorithm in extended profile.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_2",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "securerandom\\.strongAlgorithms: (NativePRNGBlocking:SUN|Windows-PRNG:SunMSCAPI),DRBG:SUN",
+                    0));
+            // 5 - Test property - securerandom.strongAlgorithms invalid algorithm.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidFormat",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: No strong SecureRandom impls available: .*",
+                    0));
+            // 6 - Test property - securerandom.strongAlgorithms missing algorithm.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingAlgo",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: No strong SecureRandom impls available: .*",
+                    0));
+            // 7 - Test property - securerandom.strongAlgorithms missing provider.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingProvider",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: missing provider",
+                    0));
+            // 8 - Test property - set invalid provider.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidProvider",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: No strong SecureRandom impls available: .*",
+                    0));
+            // 9 - Test property - securerandom.strongAlgorithms when only algorithm is present.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Specify-Algo-Only",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "securerandom\\.strongAlgorithms: SHA(256|512)DRBG$",
+                    0));
+            // 10 - Test property - invalid algorithm.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidAlgorithm",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: No strong SecureRandom impls available: .*",
+                    0));
+            // 11 - Test property - securerandom.strongAlgorithms misspelled property name.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MisspelledPropertyName",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "The property names: RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.strongAlgorithmsWrong "
+                            + "in profile RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName \\(or a base profile\\) are not recognized",
+                    1));
+        }
+
+        // 12 - Test property - default JDK value of securerandom.strongAlgorithms.
+        tests.add(Arguments.of("Test-Profile-strongAlgorithms-Default",
                 System.getProperty("test.src") + "/property-java.security",
                 "securerandom\\.strongAlgorithms: (NativePRNGBlocking:SUN|Windows-PRNG:SunMSCAPI),DRBG:SUN",
                 0));
-        // 5 - Test property - securerandom.strongAlgorithms invalid algorithm.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidFormat",
-                System.getProperty("test.src") + "/property-java.security",
-                "FAILED: No strong SecureRandom impls available: .*",
-                0));
-        // 6 - Test property - securerandom.strongAlgorithms missing algorithm.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingAlgo",
-                System.getProperty("test.src") + "/property-java.security",
-                "FAILED: No strong SecureRandom impls available: .*",
-                0));
-        // 7 - Test property - securerandom.strongAlgorithms missing provider.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingProvider",
-                System.getProperty("test.src") + "/property-java.security",
-                "FAILED: missing provider",
-                0));
-        // 8 - Test property - set invalid provider.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidProvider",
-                System.getProperty("test.src") + "/property-java.security",
-                "FAILED: No strong SecureRandom impls available: .*",
-                0));
-        // 9 - Test property - securerandom.strongAlgorithms when only algorithm is present.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-Specify-Algo-Only",
-                System.getProperty("test.src") + "/property-java.security",
-                "securerandom\\.strongAlgorithms: SHA(256|512)DRBG$",
-                0));
-        // 10 - Test property - invalid algorithm.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidAlgorithm",
-                System.getProperty("test.src") + "/property-java.security",
-                "FAILED: No strong SecureRandom impls available: .*",
-                0));
-        // 11 - Test property - securerandom.strongAlgorithms misspelled property name.
-        tests.add(Arguments.of("Test-Profile-strongAlgorithms-MisspelledPropertyName",
-                System.getProperty("test.src") + "/property-java.security",
-                "The property names: RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.strongAlgorithmsWrong "
-                        + "in profile RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName \\(or a base profile\\) are not recognized",
-                1));
 
         return tests.build();
     }

--- a/closed/test/jdk/openj9/internal/security/property-java.security
+++ b/closed/test/jdk/openj9/internal/security/property-java.security
@@ -649,3 +649,18 @@ RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.jce.prov
 RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.algorithm = SHA512DRBG
 RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.strongAlgorithmsWrong = SHA512DRBG:OpenJCEPlusFIPS
+
+#
+# Test-Profile-strongAlgorithms-Default
+# Test constraint - default JDK value of securerandom.strongAlgorithms
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.desc.name = Test-Profile-strongAlgorithms-Default
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.desc.hash = SHA256:26f0026f0806b09495eafcffa37140cc11e8a5c087bfdf546227cc2e4d2f393c
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.securerandom.provider = SUN
+RestrictedSecurity.Test-Profile-strongAlgorithms-Default.securerandom.algorithm = DRBG


### PR DESCRIPTION
Fix StrongAlgorithm test failures when tests run with a JDK that does not include the OpenJCEPlus module.

All StrongAlgorithm tests are now guarded with an
OpenJCEPlusFIPS availability check, since the FIPS SecureRandom strong algorithm is not available when OpenJCEPlus is absent.

Also added an additional test to verify the default SecureRandom value when OpenJCEPlus is not available. This also prevents the stream argument from being null.

Signed-off-by: Mohit Rajbhar [mohit.rajbhar@ibm.com](mailto:mohit.rajbhar@ibm.com)


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
