### PR TITLE
Fix build failure with --disable-jfr

### DIFF
--- a/closed/custom/common/Modules-post.gmk
+++ b/closed/custom/common/Modules-post.gmk
@@ -44,13 +44,6 @@ else
 	#
 endif
 
-ifeq (false,$(OPENJ9_ENABLE_JFR))
-  MODULES_FILTER += \
-	jdk.jfr \
-	jdk.management.jfr \
-	#
-endif
-
 MODULES_FILTER += \
 	jdk.aot \
 	jdk.hotspot.agent \


### PR DESCRIPTION
Otherwise errors like these occur:
```
jdknext/test/lib/jdk/test/lib/jfr/CommonHelper.java:33: error: package jdk.jfr does not exist
import jdk.jfr.Recording;
              ^
jdknext/test/lib/jdk/test/lib/jfr/CommonHelper.java:34: error: package jdk.jfr does not exist
import jdk.jfr.RecordingState;
              ^
jdknext/test/lib/jdk/test/lib/jfr/CommonHelper.java:35: error: package jdk.jfr.consumer does not exist
import jdk.jfr.consumer.RecordedEvent;
                       ^
jdknext/test/lib/jdk/test/lib/jfr/CommonHelper.java:36: error: package jdk.jfr.consumer does not exist
import jdk.jfr.consumer.RecordingFile;
                       ^
jdknext/test/lib/jdk/test/lib/jfr/EventField.java:29: error: package jdk.jfr does not exist
import jdk.jfr.ValueDescriptor;
              ^
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).