### PR TITLE
Update CheckSecurityProvider tests

### DIFF
--- a/test/jdk/java/lang/SecurityManager/CheckSecurityProvider.java
+++ b/test/jdk/java/lang/SecurityManager/CheckSecurityProvider.java
@@ -61,6 +61,8 @@ public class CheckSecurityProvider {
         List<String> expected = new ArrayList<>();
 
         // NOTE: the ordering must match what's defined inside java.security
+        layer.findModule("openjceplus")
+            .ifPresent(m -> expected.add("com.ibm.crypto.plus.provider.OpenJCEPlusSemeruDefaults"));
         expected.add("sun.security.provider.Sun");
         expected.add("sun.security.rsa.SunRsaSign");
         expected.add("sun.security.ec.SunEC");


### PR DESCRIPTION
Update `CheckSecurityProvider` test to account for the new `OpenJCEPlusSemeruDefaults` provider added to java.security.

- `CheckSecurityProvider.java`: add the expected class name "`com.ibm.crypto.plus.provider.OpenJCEPlusSemeruDefaults`" before SUN in the ordered provider list, matching the position defined in java.security.