### PR TITLE
Port Vahalla Fix GetStaticFieldID call ordering in InlineWithJni test

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/libValueWithJni.c
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/libValueWithJni.c
@@ -21,13 +21,19 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <jni.h>
 
 JNIEXPORT void JNICALL
 Java_runtime_valhalla_valuetypes_ValueWithJni_doJniMonitorEnter(JNIEnv *env, jobject obj) {
-    int ret = (*env)->MonitorEnter(env, obj);
     jclass class = (*env)->GetObjectClass(env, obj);
     jfieldID fieldId = (*env)->GetStaticFieldID(env, class, "returnValue", "I");
+    int ret = (*env)->MonitorEnter(env, obj);
     (*env)->SetStaticIntField(env, class, fieldId, ret);
 }
 


### PR DESCRIPTION
Port Vahalla Fix GetStaticFieldID call ordering in InlineWithJni test

* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/44

This is expected to be merged back to Vahalla extension repo to restore the change lost during recent merging.


Signed-off-by: Jason Feng <fengj@ca.ibm.com>




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
